### PR TITLE
Add Go to sheet and favorites sorting

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
@@ -1,6 +1,7 @@
 package dev.narumi.kestrel.core.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -136,11 +137,21 @@ class KestrelPrefs(
         newName: String,
     ) {
         if (oldName == newName) return
-        mutateFavorites { current ->
-            if (current.any { it.name == newName }) {
-                current
-            } else {
-                current.map { if (it.name == oldName) it.copy(name = newName) else it }
+        store.edit { prefs ->
+            val current = prefs.decodeFavorites()
+            if (current.any { it.name == newName }) return@edit
+            prefs[Keys.FAVORITES] =
+                json.encodeToString(
+                    favoritesSerializer,
+                    current.map { if (it.name == oldName) it.copy(name = newName) else it },
+                )
+            val startup = prefs.toStartupPref(json)
+            if (startup.mode == StartupPreference.Mode.Favorite && startup.favoriteName == oldName) {
+                prefs[Keys.STARTUP_PREF] =
+                    json.encodeToString(
+                        StartupPreference.serializer(),
+                        startup.copy(favoriteName = newName),
+                    )
             }
         }
     }
@@ -221,14 +232,16 @@ class KestrelPrefs(
 
     private suspend fun mutateFavorites(transform: (List<Favorite>) -> List<Favorite>) {
         store.edit {
-            val current =
-                it[Keys.FAVORITES]?.let { raw ->
-                    runCatching {
-                        json.decodeFromString(favoritesSerializer, raw)
-                    }.getOrDefault(emptyList())
-                } ?: emptyList()
+            val current = it.decodeFavorites()
             it[Keys.FAVORITES] = json.encodeToString(favoritesSerializer, transform(current))
         }
+    }
+
+    private fun MutablePreferences.decodeFavorites(): List<Favorite> {
+        val raw = this[Keys.FAVORITES] ?: return emptyList()
+        return runCatching {
+            json.decodeFromString(favoritesSerializer, raw)
+        }.getOrDefault(emptyList())
     }
 
     private fun Preferences.toCamera(): CameraSnapshot? {

--- a/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
@@ -3,6 +3,7 @@ package dev.narumi.kestrel.feature.favorites
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,25 +11,37 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.outlined.StarBorder
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.narumi.kestrel.core.data.Favorite
+import dev.narumi.kestrel.core.data.FavoritesSortMode
 import dev.narumi.kestrel.core.data.KestrelPrefs
 import dev.narumi.kestrel.core.data.StartupPreference
 import kotlinx.coroutines.launch
@@ -40,8 +53,70 @@ fun FavoritesScreen(modifier: Modifier = Modifier) {
     val scope = rememberCoroutineScope()
 
     val favorites by prefs.favorites.collectAsStateWithLifecycle(emptyList())
+    val sortMode by prefs.favoritesSortMode.collectAsStateWithLifecycle(FavoritesSortMode())
     val startup by prefs.startupPreference.collectAsStateWithLifecycle(StartupPreference())
+    var selectedTab by remember { mutableStateOf(0) }
+    var editingFavorite by remember { mutableStateOf<Favorite?>(null) }
+    var renameText by remember { mutableStateOf("") }
+    val visibleFavorites =
+        favorites
+            .filter { if (selectedTab == 0) !it.isRoute else it.isRoute }
+            .sortedFor(sortMode.mode)
 
+    editingFavorite?.let { favorite ->
+        RenameFavoriteDialog(
+            name = renameText,
+            nameExists = favorites.any { it.name == renameText.trim() && it.name != favorite.name },
+            onNameChange = { renameText = it },
+            onConfirm = {
+                val newName = renameText.trim()
+                scope.launch { prefs.renameFavorite(favorite.name, newName) }
+                editingFavorite = null
+                renameText = ""
+            },
+            onDismiss = {
+                editingFavorite = null
+                renameText = ""
+            },
+        )
+    }
+
+    FavoritesContent(
+        modifier = modifier,
+        favorites = favorites,
+        visibleFavorites = visibleFavorites,
+        selectedTab = selectedTab,
+        sortMode = sortMode.mode,
+        onTabChange = { selectedTab = it },
+        onSortModeChange = { mode -> scope.launch { prefs.setFavoritesSortMode(mode) } },
+        onRename = { fav ->
+            editingFavorite = fav
+            renameText = fav.name
+        },
+        onDelete = { fav ->
+            scope.launch {
+                prefs.removeFavorite(fav.name)
+                if (startup.mode == StartupPreference.Mode.Favorite && startup.favoriteName == fav.name) {
+                    prefs.setStartupPreference(StartupPreference(StartupPreference.Mode.Last))
+                }
+            }
+        },
+    )
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun FavoritesContent(
+    modifier: Modifier,
+    favorites: List<Favorite>,
+    visibleFavorites: List<Favorite>,
+    selectedTab: Int,
+    sortMode: FavoritesSortMode.Mode,
+    onTabChange: (Int) -> Unit,
+    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+    onRename: (Favorite) -> Unit,
+    onDelete: (Favorite) -> Unit,
+) {
     Column(
         modifier =
             modifier
@@ -49,56 +124,122 @@ fun FavoritesScreen(modifier: Modifier = Modifier) {
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            text = "Favorites",
-            style = MaterialTheme.typography.titleMedium,
+        Text("Favorites", style = MaterialTheme.typography.titleMedium)
+        when {
+            favorites.isEmpty() ->
+                EmptyFavorites(
+                    title = "No favorites yet",
+                    message = "Long-press a spot on the map, or save a route from the map controls.",
+                )
+            else ->
+                FavoritesListContent(
+                    visibleFavorites = visibleFavorites,
+                    selectedTab = selectedTab,
+                    sortMode = sortMode,
+                    onTabChange = onTabChange,
+                    onSortModeChange = onSortModeChange,
+                    onRename = onRename,
+                    onDelete = onDelete,
+                )
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun FavoritesListContent(
+    visibleFavorites: List<Favorite>,
+    selectedTab: Int,
+    sortMode: FavoritesSortMode.Mode,
+    onTabChange: (Int) -> Unit,
+    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+    onRename: (Favorite) -> Unit,
+    onDelete: (Favorite) -> Unit,
+) {
+    PrimaryTabRow(selectedTabIndex = selectedTab) {
+        Tab(selected = selectedTab == 0, onClick = { onTabChange(0) }, text = { Text("Points") })
+        Tab(selected = selectedTab == 1, onClick = { onTabChange(1) }, text = { Text("Routes") })
+    }
+    SortModeMenu(sortMode = sortMode, onSortModeChange = onSortModeChange)
+    if (visibleFavorites.isEmpty()) {
+        EmptyFavorites(
+            title = if (selectedTab == 0) "No point favorites" else "No route favorites",
+            message =
+                if (selectedTab == 0) {
+                    "Long-press a map spot to save a point."
+                } else {
+                    "Generate or draw a route, then save it from the map controls."
+                },
         )
-        if (favorites.isEmpty()) {
-            Box(modifier = Modifier.fillMaxWidth().padding(top = 32.dp)) {
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.StarBorder,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.outline,
-                        modifier = Modifier.size(48.dp),
+    } else {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn {
+                items(visibleFavorites, key = { it.name }) { fav ->
+                    FavoriteRow(
+                        favorite = fav,
+                        onRename = { onRename(fav) },
+                        onDelete = { onDelete(fav) },
                     )
-                    Text(
-                        text = "No favorites yet",
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    Text(
-                        text = "Long-press a spot on the map, or save a route from the map controls.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    HorizontalDivider()
                 }
             }
-        } else {
-            Card(modifier = Modifier.fillMaxWidth()) {
-                LazyColumn {
-                    items(favorites, key = { it.name }) { fav ->
-                        FavoriteRow(
-                            favorite = fav,
-                            onDelete = {
-                                scope.launch {
-                                    prefs.removeFavorite(fav.name)
-                                    if (startup.mode == StartupPreference.Mode.Favorite &&
-                                        startup.favoriteName == fav.name
-                                    ) {
-                                        prefs.setStartupPreference(
-                                            StartupPreference(StartupPreference.Mode.Last),
-                                        )
-                                    }
-                                }
-                            },
-                        )
-                        HorizontalDivider()
-                    }
-                }
+        }
+    }
+}
+
+@Composable
+private fun EmptyFavorites(
+    title: String,
+    message: String,
+) {
+    Box(modifier = Modifier.fillMaxWidth().padding(top = 32.dp)) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.StarBorder,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.outline,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SortModeMenu(
+    sortMode: FavoritesSortMode.Mode,
+    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        TextButton(onClick = { expanded = true }) {
+            Text("Sort: ${sortMode.label()}")
+            Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            FavoritesSortMode.Mode.entries.forEach { mode ->
+                DropdownMenuItem(
+                    text = { Text(mode.label()) },
+                    onClick = {
+                        onSortModeChange(mode)
+                        expanded = false
+                    },
+                )
             }
         }
     }
@@ -107,22 +248,85 @@ fun FavoritesScreen(modifier: Modifier = Modifier) {
 @Composable
 private fun FavoriteRow(
     favorite: Favorite,
+    onRename: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    val supporting =
-        favorite.route?.let {
-            "Route · ${it.lats.size} waypoints · ${it.speedKmh.toInt()} km/h"
-        } ?: "%.5f, %.5f".format(favorite.lat, favorite.lng)
     ListItem(
         headlineContent = { Text(favorite.name) },
-        supportingContent = { Text(supporting) },
+        supportingContent = { Text(favorite.description()) },
         trailingContent = {
-            IconButton(onClick = onDelete) {
-                Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = "Delete ${favorite.name}",
-                )
+            Row {
+                IconButton(onClick = onRename) {
+                    Icon(
+                        imageVector = Icons.Filled.Edit,
+                        contentDescription = "Rename ${favorite.name}",
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = "Delete ${favorite.name}",
+                    )
+                }
             }
         },
     )
 }
+
+@Composable
+private fun RenameFavoriteDialog(
+    name: String,
+    nameExists: Boolean,
+    onNameChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val trimmed = name.trim()
+    val invalid = trimmed.isEmpty() || nameExists
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Rename favorite") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = onNameChange,
+                label = { Text("Name") },
+                supportingText = {
+                    if (nameExists) Text("A favorite with this name already exists.")
+                },
+                isError = nameExists,
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(
+                enabled = !invalid,
+                onClick = onConfirm,
+            ) { Text("Rename") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+private fun Favorite.description(): String {
+    val route = route
+    return if (route == null) {
+        "%.5f, %.5f".format(lat, lng)
+    } else {
+        "Route · ${route.lats.size} waypoints · ${route.speedKmh.toInt()} km/h · ${route.mode}"
+    }
+}
+
+private fun List<Favorite>.sortedFor(sortMode: FavoritesSortMode.Mode): List<Favorite> =
+    when (sortMode) {
+        FavoritesSortMode.Mode.Manual -> this
+        FavoritesSortMode.Mode.Recent -> sortedByDescending { it.lastUsedAt ?: Long.MIN_VALUE }
+        FavoritesSortMode.Mode.Alphabetical -> sortedBy { it.name.lowercase() }
+    }
+
+private fun FavoritesSortMode.Mode.label(): String =
+    when (this) {
+        FavoritesSortMode.Mode.Manual -> "Manual"
+        FavoritesSortMode.Mode.Recent -> "Recent"
+        FavoritesSortMode.Mode.Alphabetical -> "Alphabetical"
+    }

--- a/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Build
 import android.provider.Settings
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,12 +15,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -27,17 +34,24 @@ import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,6 +72,7 @@ import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import dev.narumi.kestrel.core.data.CameraSnapshot
 import dev.narumi.kestrel.core.data.Favorite
 import dev.narumi.kestrel.core.data.FavoriteRoute
+import dev.narumi.kestrel.core.data.FavoritesSortMode
 import dev.narumi.kestrel.core.data.KestrelPrefs
 import dev.narumi.kestrel.core.data.StartupPreference
 import dev.narumi.kestrel.core.location.LatLng
@@ -65,6 +80,7 @@ import dev.narumi.kestrel.core.location.LocationService
 import dev.narumi.kestrel.core.location.MockProviderManager
 import dev.narumi.kestrel.core.location.MovementEngine
 import dev.narumi.kestrel.core.location.RouteGenerator
+import dev.narumi.kestrel.core.location.parseCoordInput
 import dev.narumi.kestrel.core.location.rememberCurrentLocation
 import dev.narumi.kestrel.core.map.KestrelMap
 import kotlinx.coroutines.flow.first
@@ -112,6 +128,7 @@ fun MapScreen(modifier: Modifier = Modifier) {
     val scope = rememberCoroutineScope()
 
     val favorites by prefs.favorites.collectAsStateWithLifecycle(emptyList())
+    val sortMode by prefs.favoritesSortMode.collectAsStateWithLifecycle(FavoritesSortMode())
 
     var mockAllowed by remember { mutableStateOf(false) }
     var waypoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
@@ -124,6 +141,7 @@ fun MapScreen(modifier: Modifier = Modifier) {
     var awaitCurrentForStartup by remember { mutableStateOf(false) }
     var lastCameraCenter by remember { mutableStateOf<LatLng?>(null) }
     var showGenerateDialog by remember { mutableStateOf(false) }
+    var showGoToSheet by remember { mutableStateOf(false) }
     var startupResolved by remember { mutableStateOf(false) }
     var firstCameraIdleSeen by remember { mutableStateOf(false) }
 
@@ -177,6 +195,40 @@ fun MapScreen(modifier: Modifier = Modifier) {
             skipHiddenState = true,
         )
     val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
+    val goToSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    fun applyPoint(point: LatLng) {
+        if (runState != RunState.Idle) {
+            LocationService.stop(context)
+        }
+        waypoints = listOf(point)
+        cameraTarget = CameraSnapshot(point.lat, point.lng, 15.0)
+        runState = RunState.Idle
+        showGoToSheet = false
+    }
+
+    fun applyFavorite(favorite: Favorite) {
+        if (runState != RunState.Idle) {
+            LocationService.stop(context)
+        }
+        val route = favorite.route
+        if (route == null) {
+            val point = LatLng(favorite.lat, favorite.lng)
+            waypoints = listOf(point)
+            cameraTarget = CameraSnapshot(point.lat, point.lng, 15.0)
+        } else {
+            val routeWaypoints = route.toWaypoints()
+            waypoints = routeWaypoints
+            speedKmh = route.speedKmh
+            routeMode =
+                runCatching { MovementEngine.Mode.valueOf(route.mode) }
+                    .getOrDefault(MovementEngine.Mode.Once)
+            routeWaypoints.firstOrNull()?.let { cameraTarget = CameraSnapshot(it.lat, it.lng, 15.0) }
+        }
+        runState = RunState.Idle
+        showGoToSheet = false
+        scope.launch { prefs.touchFavorite(favorite.name) }
+    }
 
     if (showGenerateDialog) {
         GenerateRouteDialog(
@@ -194,6 +246,18 @@ fun MapScreen(modifier: Modifier = Modifier) {
                 showGenerateDialog = false
             },
             onDismiss = { showGenerateDialog = false },
+        )
+    }
+
+    if (showGoToSheet) {
+        GoToSheet(
+            sheetState = goToSheetState,
+            favorites = favorites,
+            sortMode = sortMode.mode,
+            onSortModeChange = { mode -> scope.launch { prefs.setFavoritesSortMode(mode) } },
+            onApplyPoint = ::applyPoint,
+            onApplyFavorite = ::applyFavorite,
+            onDismiss = { showGoToSheet = false },
         )
     }
 
@@ -314,6 +378,9 @@ fun MapScreen(modifier: Modifier = Modifier) {
                 SmallFloatingActionButton(onClick = { showGenerateDialog = true }) {
                     Icon(Icons.Filled.AutoAwesome, contentDescription = "Generate route")
                 }
+                SmallFloatingActionButton(onClick = { showGoToSheet = true }) {
+                    Icon(Icons.Filled.Search, contentDescription = "Go to")
+                }
                 SmallFloatingActionButton(
                     onClick = {
                         myLocation?.let { cameraTarget = CameraSnapshot(it.lat, it.lng, 15.0) }
@@ -345,6 +412,179 @@ private fun PendingFavorite.toFavorite(name: String): Favorite =
                     ),
             )
         }
+    }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun GoToSheet(
+    sheetState: SheetState,
+    favorites: List<Favorite>,
+    sortMode: FavoritesSortMode.Mode,
+    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+    onApplyPoint: (LatLng) -> Unit,
+    onApplyFavorite: (Favorite) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var input by remember { mutableStateOf("") }
+    var selectedTab by remember { mutableStateOf(0) }
+    val parsed = parseCoordInput(input)
+    val showInvalid = input.isNotBlank() && parsed == null
+    val filteredFavorites =
+        favorites
+            .filter { if (selectedTab == 0) !it.isRoute else it.isRoute }
+            .sortedFor(sortMode)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Go to", style = MaterialTheme.typography.titleLarge)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = input,
+                    onValueChange = { input = it },
+                    label = { Text("Paste coordinates or Maps URL") },
+                    supportingText = {
+                        if (showInvalid) Text("Enter a valid lat/lng in range.")
+                    },
+                    isError = showInvalid,
+                    singleLine = true,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = { parsed?.let(onApplyPoint) },
+                    enabled = parsed != null,
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                ) { Text("Go") }
+            }
+            PrimaryTabRow(selectedTabIndex = selectedTab) {
+                Tab(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    text = { Text("Points") },
+                )
+                Tab(
+                    selected = selectedTab == 1,
+                    onClick = { selectedTab = 1 },
+                    text = { Text("Routes") },
+                )
+            }
+            SortModeMenu(
+                sortMode = sortMode,
+                onSortModeChange = onSortModeChange,
+            )
+            if (filteredFavorites.isEmpty()) {
+                Text(
+                    text = if (selectedTab == 0) "No point favorites yet." else "No route favorites yet.",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            } else {
+                LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
+                    items(filteredFavorites, key = { it.name }) { favorite ->
+                        GoToFavoriteRow(
+                            favorite = favorite,
+                            onClick = { onApplyFavorite(favorite) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SortModeMenu(
+    sortMode: FavoritesSortMode.Mode,
+    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        TextButton(onClick = { expanded = true }) {
+            Text("Sort: ${sortMode.label()}")
+            Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            FavoritesSortMode.Mode.entries.forEach { mode ->
+                DropdownMenuItem(
+                    text = { Text(mode.label()) },
+                    onClick = {
+                        onSortModeChange(mode)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GoToFavoriteRow(
+    favorite: Favorite,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Filled.Star,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(favorite.name, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = favorite.description(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun Favorite.description(): String {
+    val route = route
+    return if (route == null) {
+        "%.5f, %.5f".format(lat, lng)
+    } else {
+        "Route · ${route.lats.size} waypoints · ${route.speedKmh.toInt()} km/h · ${route.mode}"
+    }
+}
+
+private fun FavoriteRoute.toWaypoints(): List<LatLng> {
+    val count = minOf(lats.size, lngs.size)
+    return List(count) { LatLng(lats[it], lngs[it]) }
+}
+
+private fun List<Favorite>.sortedFor(sortMode: FavoritesSortMode.Mode): List<Favorite> =
+    when (sortMode) {
+        FavoritesSortMode.Mode.Manual -> this
+        FavoritesSortMode.Mode.Recent -> sortedByDescending { it.lastUsedAt ?: Long.MIN_VALUE }
+        FavoritesSortMode.Mode.Alphabetical -> sortedBy { it.name.lowercase() }
+    }
+
+private fun FavoritesSortMode.Mode.label(): String =
+    when (this) {
+        FavoritesSortMode.Mode.Manual -> "Manual"
+        FavoritesSortMode.Mode.Recent -> "Recent"
+        FavoritesSortMode.Mode.Alphabetical -> "Alphabetical"
     }
 
 @Suppress("LongParameterList")

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,11 +2,40 @@
 
 依工程量排序的 backlog。打 `[x]` 表示已完成。
 
+## Phase：Go to 面板 + Favorites 整理（A + D）
+
+來源：`docs/plan/phase-quick-jump-and-favorites.md`。
+
+### 實作步驟
+
+- [x] **Schema + prefs 基礎**：加 `lastUsedAt`、`FavoritesSortMode`、相關 `KestrelPrefs` 方法。
+- [ ] **Prefs 單元測試**：覆蓋 sort mode、rename 衝突、startup favorite name 同步、reorder、touch。
+- [x] **座標解析器**：`parseCoordInput(String): LatLng?` + 單元測試（純座標、Google Maps URL、範圍邊界）。
+- [x] **Go to 面板 UI**：`ModalBottomSheet` + 座標欄 + Points / Routes tabs + favorites 列表（sort 套用）。
+- [x] **MapScreen 接線**：新 FAB、開啟面板、apply 動作、套用前先停 route / mock。
+- [ ] **Favorites 頁完整改版**：已完成 tabs / sort / rename / delete；尚缺 overflow menu、Edit coords、Edit route speed-mode、Apply now。
+- [ ] **Apply now / lastUsedAt 串起來**：Go to 面板已 touch；尚缺 Favorites 頁 Apply now 與 Startup 套用時 touch。
+- [ ] **Manual 拖曳重排 UI**：接 `reorderFavorite(name, toIndex)`，順序持久化。
+- [ ] **手動測試 + detekt baseline 更新**：實機驗證後更新。
+
+### 驗收條件
+
+- [x] 貼 `25.0330, 121.5654` / `25.0330 121.5654` / Google Maps URL 都能解析並跳轉。
+- [x] Go to 面板能套用單點 favorite，套完面板關閉、底部 sheet 顯示 Mock this point。
+- [x] Go to 面板能套用 route favorite，套完不自動播、speed / mode 已套上。
+- [x] route 跑步中按 Go to 套東西，會先停舊 mock / route 再套新。
+- [x] Favorites 頁 Points / Routes tabs 切換正常、空狀態文案合理。
+- [x] 三種排序模式皆可運作，設定持久化。
+- [ ] Manual 模式下能拖曳重排、順序持久化。
+- [ ] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作（Rename / Delete 已完成）。
+- [ ] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化（Go to 面板已完成；Favorites / Startup 尚缺）。
+- [x] `just check` / `just lint` 通過。
+
 ## Quick wins（30 分 – 1 小時）
 
 - [ ] **單元測試**：`MovementEngine`（Once/Loop/PingPong 邊界）、`RouteGenerator`（種子可重現、間距 ±誤差）、`Geo`（haversine、bearing、destinationPoint 球面繞回）。純 Kotlin，幾十行覆蓋。
 - [ ] **抖動 (jitter)**：`LocationService.pushSample` / `pushLocation` 加 lat/lng ±N m、speed ±5% 隨機擾動。讓 mock 軌跡不像鐵軌。預設可關。
-- [ ] **收藏 rename**：Favorites 列表加 edit icon，跳輸入框；`KestrelPrefs` 加 `renameFavorite(old, new)`，連帶處理 `StartupPreference.favoriteName`。
+- [x] **收藏 rename**：Favorites 列表加 edit icon，跳輸入框；`KestrelPrefs` 加 `renameFavorite(old, new)`，連帶處理 `StartupPreference.favoriteName`。
 - [ ] **通知文案微調 + channel description**：通知列現在 title/text 偏陽春，加 channel description（系統設定才看得到）與更明確的 mode 子標題。
 - [ ] **App icon**：目前還是 Android Studio 綠機器人。一個 vector + adaptive icon（前景 / 背景）就能換掉。
 


### PR DESCRIPTION
## Summary
- add a Go to bottom sheet for coordinate/Maps URL input and favorite selection
- apply point/route favorites to the map, stopping active mock sessions first
- add Favorites tabs, shared sort mode, rename support, and update TODO status

## Checks
- just check
- just build
- just lint