### PR TITLE
Complete favorites management actions

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
@@ -17,11 +17,13 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import dev.narumi.kestrel.core.data.Favorite
 import dev.narumi.kestrel.feature.favorites.FavoritesScreen
 import dev.narumi.kestrel.feature.map.MapScreen
 import dev.narumi.kestrel.feature.options.OptionsScreen
@@ -43,6 +45,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun KestrelApp() {
     var currentDestination by rememberSaveable { mutableStateOf(AppDestinations.HOME) }
+    var pendingFavoriteApply by remember { mutableStateOf<Favorite?>(null) }
 
     NavigationSuiteScaffold(
         navigationSuiteItems = {
@@ -61,8 +64,20 @@ fun KestrelApp() {
         Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
             val contentModifier = Modifier.padding(innerPadding)
             when (currentDestination) {
-                AppDestinations.HOME -> MapScreen(modifier = contentModifier)
-                AppDestinations.FAVORITES -> FavoritesScreen(modifier = contentModifier)
+                AppDestinations.HOME ->
+                    MapScreen(
+                        modifier = contentModifier,
+                        pendingFavoriteApply = pendingFavoriteApply,
+                        onFavoriteApplyConsumed = { pendingFavoriteApply = null },
+                    )
+                AppDestinations.FAVORITES ->
+                    FavoritesScreen(
+                        modifier = contentModifier,
+                        onApplyToMap = { favorite ->
+                            pendingFavoriteApply = favorite
+                            currentDestination = AppDestinations.HOME
+                        },
+                    )
                 AppDestinations.OPTIONS -> OptionsScreen(modifier = contentModifier)
             }
         }

--- a/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.MoreVert
@@ -141,6 +141,7 @@ fun FavoritesScreen(
                         .getOrDefault(MovementEngine.Mode.Once)
             }
         },
+        onMove = { fav, toIndex -> scope.launch { prefs.reorderFavorite(fav.name, toIndex) } },
         onDelete = { fav ->
             scope.launch {
                 prefs.removeFavorite(fav.name)
@@ -216,6 +217,7 @@ private fun FavoritesContent(
     onApply: (Favorite) -> Unit,
     onRename: (Favorite) -> Unit,
     onEdit: (Favorite) -> Unit,
+    onMove: (Favorite, Int) -> Unit,
     onDelete: (Favorite) -> Unit,
 ) {
     Column(
@@ -234,6 +236,7 @@ private fun FavoritesContent(
                 )
             else ->
                 FavoritesListContent(
+                    favorites = favorites,
                     visibleFavorites = visibleFavorites,
                     selectedTab = selectedTab,
                     sortMode = sortMode,
@@ -242,6 +245,7 @@ private fun FavoritesContent(
                     onApply = onApply,
                     onRename = onRename,
                     onEdit = onEdit,
+                    onMove = onMove,
                     onDelete = onDelete,
                 )
         }
@@ -251,6 +255,7 @@ private fun FavoritesContent(
 @Suppress("LongParameterList")
 @Composable
 private fun FavoritesListContent(
+    favorites: List<Favorite>,
     visibleFavorites: List<Favorite>,
     selectedTab: Int,
     sortMode: FavoritesSortMode.Mode,
@@ -259,6 +264,7 @@ private fun FavoritesListContent(
     onApply: (Favorite) -> Unit,
     onRename: (Favorite) -> Unit,
     onEdit: (Favorite) -> Unit,
+    onMove: (Favorite, Int) -> Unit,
     onDelete: (Favorite) -> Unit,
 ) {
     PrimaryTabRow(selectedTabIndex = selectedTab) {
@@ -279,12 +285,19 @@ private fun FavoritesListContent(
     } else {
         Card(modifier = Modifier.fillMaxWidth()) {
             LazyColumn {
-                items(visibleFavorites, key = { it.name }) { fav ->
+                itemsIndexed(visibleFavorites, key = { _, item -> item.name }) { index, fav ->
+                    val previousIndex = visibleFavorites.getOrNull(index - 1)?.globalIndexIn(favorites)
+                    val nextIndex = visibleFavorites.getOrNull(index + 1)?.globalIndexIn(favorites)
                     FavoriteRow(
                         favorite = fav,
+                        canReorder = sortMode == FavoritesSortMode.Mode.Manual,
+                        canMoveUp = previousIndex != null,
+                        canMoveDown = nextIndex != null,
                         onApply = { onApply(fav) },
                         onRename = { onRename(fav) },
                         onEdit = { onEdit(fav) },
+                        onMoveUp = { previousIndex?.let { onMove(fav, it) } },
+                        onMoveDown = { nextIndex?.let { onMove(fav, it) } },
                         onDelete = { onDelete(fav) },
                     )
                     HorizontalDivider()
@@ -352,9 +365,14 @@ private fun SortModeMenu(
 @Composable
 private fun FavoriteRow(
     favorite: Favorite,
+    canReorder: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
     onApply: () -> Unit,
     onRename: () -> Unit,
     onEdit: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
     onDelete: () -> Unit,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
@@ -386,6 +404,24 @@ private fun FavoriteRow(
                                 onEdit()
                             },
                         )
+                        if (canReorder) {
+                            DropdownMenuItem(
+                                text = { Text("Move up") },
+                                enabled = canMoveUp,
+                                onClick = {
+                                    menuExpanded = false
+                                    onMoveUp()
+                                },
+                            )
+                            DropdownMenuItem(
+                                text = { Text("Move down") },
+                                enabled = canMoveDown,
+                                onClick = {
+                                    menuExpanded = false
+                                    onMoveDown()
+                                },
+                            )
+                        }
                         DropdownMenuItem(
                             text = { Text("Delete") },
                             onClick = {
@@ -499,6 +535,8 @@ private fun EditRouteDialog(
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
 }
+
+private fun Favorite.globalIndexIn(favorites: List<Favorite>): Int? = favorites.indexOfFirst { it.name == name }.takeIf { it >= 0 }
 
 private fun Favorite.description(): String {
     val route = route

--- a/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
@@ -12,8 +12,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -44,8 +43,12 @@ import dev.narumi.kestrel.core.data.Favorite
 import dev.narumi.kestrel.core.data.FavoritesSortMode
 import dev.narumi.kestrel.core.data.KestrelPrefs
 import dev.narumi.kestrel.core.data.StartupPreference
+import dev.narumi.kestrel.core.location.LatLng
+import dev.narumi.kestrel.core.location.MovementEngine
+import dev.narumi.kestrel.core.location.parseCoordInput
 import kotlinx.coroutines.launch
 
+@Suppress("LongMethod")
 @Composable
 fun FavoritesScreen(
     modifier: Modifier = Modifier,
@@ -59,30 +62,59 @@ fun FavoritesScreen(
     val sortMode by prefs.favoritesSortMode.collectAsStateWithLifecycle(FavoritesSortMode())
     val startup by prefs.startupPreference.collectAsStateWithLifecycle(StartupPreference())
     var selectedTab by remember { mutableStateOf(0) }
-    var editingFavorite by remember { mutableStateOf<Favorite?>(null) }
+    var editingName by remember { mutableStateOf<Favorite?>(null) }
+    var editingPoint by remember { mutableStateOf<Favorite?>(null) }
+    var editingRoute by remember { mutableStateOf<Favorite?>(null) }
     var renameText by remember { mutableStateOf("") }
+    var pointText by remember { mutableStateOf("") }
+    var routeSpeedText by remember { mutableStateOf("") }
+    var routeMode by remember { mutableStateOf(MovementEngine.Mode.Once) }
     val visibleFavorites =
         favorites
             .filter { if (selectedTab == 0) !it.isRoute else it.isRoute }
             .sortedFor(sortMode.mode)
 
-    editingFavorite?.let { favorite ->
-        RenameFavoriteDialog(
-            name = renameText,
-            nameExists = favorites.any { it.name == renameText.trim() && it.name != favorite.name },
-            onNameChange = { renameText = it },
-            onConfirm = {
-                val newName = renameText.trim()
-                scope.launch { prefs.renameFavorite(favorite.name, newName) }
-                editingFavorite = null
-                renameText = ""
-            },
-            onDismiss = {
-                editingFavorite = null
-                renameText = ""
-            },
-        )
-    }
+    FavoriteEditDialogs(
+        favorites = favorites,
+        editingName = editingName,
+        renameText = renameText,
+        editingPoint = editingPoint,
+        pointText = pointText,
+        editingRoute = editingRoute,
+        routeSpeedText = routeSpeedText,
+        routeMode = routeMode,
+        onRenameTextChange = { renameText = it },
+        onPointTextChange = { pointText = it },
+        onRouteSpeedTextChange = { routeSpeedText = it },
+        onRouteModeChange = { routeMode = it },
+        onRenameConfirm = { favorite ->
+            scope.launch { prefs.renameFavorite(favorite.name, renameText.trim()) }
+            editingName = null
+            renameText = ""
+        },
+        onPointConfirm = { favorite, point ->
+            scope.launch { prefs.updateFavoritePoint(favorite.name, point.lat, point.lng) }
+            editingPoint = null
+            pointText = ""
+        },
+        onRouteConfirm = { favorite, speed, mode ->
+            scope.launch { prefs.updateFavoriteRouteParams(favorite.name, speed, mode.name) }
+            editingRoute = null
+            routeSpeedText = ""
+        },
+        onRenameDismiss = {
+            editingName = null
+            renameText = ""
+        },
+        onPointDismiss = {
+            editingPoint = null
+            pointText = ""
+        },
+        onRouteDismiss = {
+            editingRoute = null
+            routeSpeedText = ""
+        },
+    )
 
     FavoritesContent(
         modifier = modifier,
@@ -94,8 +126,20 @@ fun FavoritesScreen(
         onSortModeChange = { mode -> scope.launch { prefs.setFavoritesSortMode(mode) } },
         onApply = onApplyToMap,
         onRename = { fav ->
-            editingFavorite = fav
+            editingName = fav
             renameText = fav.name
+        },
+        onEdit = { fav ->
+            if (fav.route == null) {
+                editingPoint = fav
+                pointText = "%.5f, %.5f".format(fav.lat, fav.lng)
+            } else {
+                editingRoute = fav
+                routeSpeedText = fav.route.speedKmh.toString()
+                routeMode =
+                    runCatching { MovementEngine.Mode.valueOf(fav.route.mode) }
+                        .getOrDefault(MovementEngine.Mode.Once)
+            }
         },
         onDelete = { fav ->
             scope.launch {
@@ -110,6 +154,57 @@ fun FavoritesScreen(
 
 @Suppress("LongParameterList")
 @Composable
+private fun FavoriteEditDialogs(
+    favorites: List<Favorite>,
+    editingName: Favorite?,
+    renameText: String,
+    editingPoint: Favorite?,
+    pointText: String,
+    editingRoute: Favorite?,
+    routeSpeedText: String,
+    routeMode: MovementEngine.Mode,
+    onRenameTextChange: (String) -> Unit,
+    onPointTextChange: (String) -> Unit,
+    onRouteSpeedTextChange: (String) -> Unit,
+    onRouteModeChange: (MovementEngine.Mode) -> Unit,
+    onRenameConfirm: (Favorite) -> Unit,
+    onPointConfirm: (Favorite, LatLng) -> Unit,
+    onRouteConfirm: (Favorite, Double, MovementEngine.Mode) -> Unit,
+    onRenameDismiss: () -> Unit,
+    onPointDismiss: () -> Unit,
+    onRouteDismiss: () -> Unit,
+) {
+    editingName?.let { favorite ->
+        RenameFavoriteDialog(
+            name = renameText,
+            nameExists = favorites.any { it.name == renameText.trim() && it.name != favorite.name },
+            onNameChange = onRenameTextChange,
+            onConfirm = { onRenameConfirm(favorite) },
+            onDismiss = onRenameDismiss,
+        )
+    }
+    editingPoint?.let { favorite ->
+        EditPointDialog(
+            input = pointText,
+            onInputChange = onPointTextChange,
+            onConfirm = { onPointConfirm(favorite, it) },
+            onDismiss = onPointDismiss,
+        )
+    }
+    editingRoute?.let { favorite ->
+        EditRouteDialog(
+            speedText = routeSpeedText,
+            routeMode = routeMode,
+            onSpeedTextChange = onRouteSpeedTextChange,
+            onRouteModeChange = onRouteModeChange,
+            onConfirm = { speed, mode -> onRouteConfirm(favorite, speed, mode) },
+            onDismiss = onRouteDismiss,
+        )
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
 private fun FavoritesContent(
     modifier: Modifier,
     favorites: List<Favorite>,
@@ -120,6 +215,7 @@ private fun FavoritesContent(
     onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
     onApply: (Favorite) -> Unit,
     onRename: (Favorite) -> Unit,
+    onEdit: (Favorite) -> Unit,
     onDelete: (Favorite) -> Unit,
 ) {
     Column(
@@ -145,6 +241,7 @@ private fun FavoritesContent(
                     onSortModeChange = onSortModeChange,
                     onApply = onApply,
                     onRename = onRename,
+                    onEdit = onEdit,
                     onDelete = onDelete,
                 )
         }
@@ -161,6 +258,7 @@ private fun FavoritesListContent(
     onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
     onApply: (Favorite) -> Unit,
     onRename: (Favorite) -> Unit,
+    onEdit: (Favorite) -> Unit,
     onDelete: (Favorite) -> Unit,
 ) {
     PrimaryTabRow(selectedTabIndex = selectedTab) {
@@ -186,6 +284,7 @@ private fun FavoritesListContent(
                         favorite = fav,
                         onApply = { onApply(fav) },
                         onRename = { onRename(fav) },
+                        onEdit = { onEdit(fav) },
                         onDelete = { onDelete(fav) },
                     )
                     HorizontalDivider()
@@ -212,10 +311,7 @@ private fun EmptyFavorites(
                 tint = MaterialTheme.colorScheme.outline,
                 modifier = Modifier.size(48.dp),
             )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-            )
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodySmall,
@@ -258,27 +354,46 @@ private fun FavoriteRow(
     favorite: Favorite,
     onApply: () -> Unit,
     onRename: () -> Unit,
+    onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
     ListItem(
         headlineContent = { Text(favorite.name) },
         supportingContent = { Text(favorite.description()) },
         trailingContent = {
             Row {
-                TextButton(onClick = onApply) {
-                    Text("Apply")
-                }
-                IconButton(onClick = onRename) {
-                    Icon(
-                        imageVector = Icons.Filled.Edit,
-                        contentDescription = "Rename ${favorite.name}",
-                    )
-                }
-                IconButton(onClick = onDelete) {
-                    Icon(
-                        imageVector = Icons.Filled.Delete,
-                        contentDescription = "Delete ${favorite.name}",
-                    )
+                TextButton(onClick = onApply) { Text("Apply") }
+                Box {
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = "More actions for ${favorite.name}")
+                    }
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("Rename") },
+                            onClick = {
+                                menuExpanded = false
+                                onRename()
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text(if (favorite.route == null) "Edit coordinates" else "Edit route") },
+                            onClick = {
+                                menuExpanded = false
+                                onEdit()
+                            },
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Delete") },
+                            onClick = {
+                                menuExpanded = false
+                                onDelete()
+                            },
+                        )
+                    }
                 }
             }
         },
@@ -311,10 +426,75 @@ private fun RenameFavoriteDialog(
             )
         },
         confirmButton = {
-            TextButton(
-                enabled = !invalid,
-                onClick = onConfirm,
-            ) { Text("Rename") }
+            TextButton(enabled = !invalid, onClick = onConfirm) { Text("Rename") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun EditPointDialog(
+    input: String,
+    onInputChange: (String) -> Unit,
+    onConfirm: (LatLng) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val parsed = parseCoordInput(input)
+    val showInvalid = input.isNotBlank() && parsed == null
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit coordinates") },
+        text = {
+            OutlinedTextField(
+                value = input,
+                onValueChange = onInputChange,
+                label = { Text("Coordinates") },
+                supportingText = {
+                    if (showInvalid) Text("Enter a valid lat/lng in range.")
+                },
+                isError = showInvalid,
+                singleLine = true,
+            )
+        },
+        confirmButton = {
+            TextButton(enabled = parsed != null, onClick = { parsed?.let(onConfirm) }) { Text("Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}
+
+@Composable
+private fun EditRouteDialog(
+    speedText: String,
+    routeMode: MovementEngine.Mode,
+    onSpeedTextChange: (String) -> Unit,
+    onRouteModeChange: (MovementEngine.Mode) -> Unit,
+    onConfirm: (Double, MovementEngine.Mode) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val speed = speedText.toDoubleOrNull()
+    val valid = speed != null && speed > 0
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit route") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = speedText,
+                    onValueChange = { v -> onSpeedTextChange(v.filter { it.isDigit() || it == '.' }) },
+                    label = { Text("Speed (km/h)") },
+                    isError = speedText.isNotBlank() && !valid,
+                    singleLine = true,
+                )
+                MovementEngine.Mode.entries.forEach { mode ->
+                    TextButton(onClick = { onRouteModeChange(mode) }) {
+                        Text(if (mode == routeMode) "✓ ${mode.label()}" else mode.label())
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(enabled = valid, onClick = { speed?.let { onConfirm(it, routeMode) } }) { Text("Save") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
     )
@@ -341,4 +521,11 @@ private fun FavoritesSortMode.Mode.label(): String =
         FavoritesSortMode.Mode.Manual -> "Manual"
         FavoritesSortMode.Mode.Recent -> "Recent"
         FavoritesSortMode.Mode.Alphabetical -> "Alphabetical"
+    }
+
+private fun MovementEngine.Mode.label(): String =
+    when (this) {
+        MovementEngine.Mode.Once -> "Once"
+        MovementEngine.Mode.Loop -> "Loop"
+        MovementEngine.Mode.PingPong -> "Ping-pong"
     }

--- a/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
@@ -47,7 +47,10 @@ import dev.narumi.kestrel.core.data.StartupPreference
 import kotlinx.coroutines.launch
 
 @Composable
-fun FavoritesScreen(modifier: Modifier = Modifier) {
+fun FavoritesScreen(
+    modifier: Modifier = Modifier,
+    onApplyToMap: (Favorite) -> Unit = {},
+) {
     val context = LocalContext.current
     val prefs = remember { KestrelPrefs(context) }
     val scope = rememberCoroutineScope()
@@ -89,6 +92,7 @@ fun FavoritesScreen(modifier: Modifier = Modifier) {
         sortMode = sortMode.mode,
         onTabChange = { selectedTab = it },
         onSortModeChange = { mode -> scope.launch { prefs.setFavoritesSortMode(mode) } },
+        onApply = onApplyToMap,
         onRename = { fav ->
             editingFavorite = fav
             renameText = fav.name
@@ -114,6 +118,7 @@ private fun FavoritesContent(
     sortMode: FavoritesSortMode.Mode,
     onTabChange: (Int) -> Unit,
     onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+    onApply: (Favorite) -> Unit,
     onRename: (Favorite) -> Unit,
     onDelete: (Favorite) -> Unit,
 ) {
@@ -138,6 +143,7 @@ private fun FavoritesContent(
                     sortMode = sortMode,
                     onTabChange = onTabChange,
                     onSortModeChange = onSortModeChange,
+                    onApply = onApply,
                     onRename = onRename,
                     onDelete = onDelete,
                 )
@@ -153,6 +159,7 @@ private fun FavoritesListContent(
     sortMode: FavoritesSortMode.Mode,
     onTabChange: (Int) -> Unit,
     onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+    onApply: (Favorite) -> Unit,
     onRename: (Favorite) -> Unit,
     onDelete: (Favorite) -> Unit,
 ) {
@@ -177,6 +184,7 @@ private fun FavoritesListContent(
                 items(visibleFavorites, key = { it.name }) { fav ->
                     FavoriteRow(
                         favorite = fav,
+                        onApply = { onApply(fav) },
                         onRename = { onRename(fav) },
                         onDelete = { onDelete(fav) },
                     )
@@ -248,6 +256,7 @@ private fun SortModeMenu(
 @Composable
 private fun FavoriteRow(
     favorite: Favorite,
+    onApply: () -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -256,6 +265,9 @@ private fun FavoriteRow(
         supportingContent = { Text(favorite.description()) },
         trailingContent = {
             Row {
+                TextButton(onClick = onApply) {
+                    Text("Apply")
+                }
                 IconButton(onClick = onRename) {
                     Icon(
                         imageVector = Icons.Filled.Edit,

--- a/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
@@ -111,7 +111,11 @@ private fun MovementEngine.Mode.label(): String =
 
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun MapScreen(modifier: Modifier = Modifier) {
+fun MapScreen(
+    modifier: Modifier = Modifier,
+    pendingFavoriteApply: Favorite? = null,
+    onFavoriteApplyConsumed: () -> Unit = {},
+) {
     val context = LocalContext.current
     val permissions =
         remember {
@@ -173,6 +177,7 @@ fun MapScreen(modifier: Modifier = Modifier) {
                         LocationService.setLocation(context, LatLng(fav.lat, fav.lng))
                         runState = RunState.Single
                     }
+                    prefs.touchFavorite(fav.name)
                 }
             }
         }
@@ -228,6 +233,13 @@ fun MapScreen(modifier: Modifier = Modifier) {
         runState = RunState.Idle
         showGoToSheet = false
         scope.launch { prefs.touchFavorite(favorite.name) }
+    }
+
+    LaunchedEffect(pendingFavoriteApply) {
+        pendingFavoriteApply?.let {
+            applyFavorite(it)
+            onFavoriteApplyConsumed()
+        }
     }
 
     if (showGenerateDialog) {

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -3,9 +3,9 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexCondition:LocationService.kt$LocationService$lats != null &amp;&amp; lngs != null &amp;&amp; lats.size == lngs.size &amp;&amp; lats.size &gt;= 2 &amp;&amp; speedKmh.isFinite() &amp;&amp; speedKmh &gt; 0</ID>
-    <ID>CyclomaticComplexMethod:MapScreen.kt$@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class) @Composable fun MapScreen(modifier: Modifier = Modifier)</ID>
+    <ID>CyclomaticComplexMethod:MapScreen.kt$@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class) @Composable fun MapScreen( modifier: Modifier = Modifier, pendingFavoriteApply: Favorite? = null, onFavoriteApplyConsumed: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:KestrelMap.kt$@Composable fun KestrelMap( modifier: Modifier = Modifier, initialCenter: LatLng = LatLng(25.0330, 121.5654), initialZoom: Double = 11.0, mockLocation: LatLng? = null, polyline: List&lt;LatLng&gt; = emptyList(), myLocation: LatLng? = null, cameraTarget: CameraSnapshot? = null, onMapClick: (LatLng) -&gt; Unit = {}, onMapLongClick: (LatLng) -&gt; Unit = {}, onCameraIdle: (CameraSnapshot) -&gt; Unit = {}, )</ID>
     <ID>LongMethod:LocationService.kt$LocationService$override fun onStartCommand( intent: Intent?, flags: Int, startId: Int, ): Int</ID>
-    <ID>LongMethod:MapScreen.kt$@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class) @Composable fun MapScreen(modifier: Modifier = Modifier)</ID>
+    <ID>LongMethod:MapScreen.kt$@OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class) @Composable fun MapScreen( modifier: Modifier = Modifier, pendingFavoriteApply: Favorite? = null, onFavoriteApplyConsumed: () -&gt; Unit = {}, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,10 +13,10 @@
 - [x] **座標解析器**：`parseCoordInput(String): LatLng?` + 單元測試（純座標、Google Maps URL、範圍邊界）。
 - [x] **Go to 面板 UI**：`ModalBottomSheet` + 座標欄 + Points / Routes tabs + favorites 列表（sort 套用）。
 - [x] **MapScreen 接線**：新 FAB、開啟面板、apply 動作、套用前先停 route / mock。
-- [ ] **Favorites 頁完整改版**：已完成 tabs / sort / rename / delete；尚缺 overflow menu、Edit coords、Edit route speed-mode、Apply now。
-- [ ] **Apply now / lastUsedAt 串起來**：Go to 面板已 touch；尚缺 Favorites 頁 Apply now 與 Startup 套用時 touch。
+- [ ] **Favorites 頁完整改版**：已完成 tabs / sort / rename / delete / Apply now；尚缺 overflow menu、Edit coords、Edit route speed-mode。
+- [x] **Apply now / lastUsedAt 串起來**：Go to 面板、Favorites 頁 Apply now、Startup 套用都會 `touchFavorite`。
 - [ ] **Manual 拖曳重排 UI**：接 `reorderFavorite(name, toIndex)`，順序持久化。
-- [ ] **手動測試 + detekt baseline 更新**：實機驗證後更新。
+- [ ] **手動測試 + detekt baseline 更新**：detekt baseline 已更新；尚缺實機驗證。
 
 ### 驗收條件
 
@@ -27,8 +27,8 @@
 - [x] Favorites 頁 Points / Routes tabs 切換正常、空狀態文案合理。
 - [x] 三種排序模式皆可運作，設定持久化。
 - [ ] Manual 模式下能拖曳重排、順序持久化。
-- [ ] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作（Rename / Delete 已完成）。
-- [ ] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化（Go to 面板已完成；Favorites / Startup 尚缺）。
+- [ ] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作（Rename / Delete / Apply now 已完成）。
+- [x] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化。
 - [x] `just check` / `just lint` 通過。
 
 ## Quick wins（30 分 – 1 小時）

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,7 +15,7 @@
 - [x] **MapScreen 接線**：新 FAB、開啟面板、apply 動作、套用前先停 route / mock。
 - [x] **Favorites 頁完整改版**：tabs / sort / overflow menu / rename / Edit coords / Edit route speed-mode / delete / Apply now 已完成。
 - [x] **Apply now / lastUsedAt 串起來**：Go to 面板、Favorites 頁 Apply now、Startup 套用都會 `touchFavorite`。
-- [ ] **Manual 拖曳重排 UI**：接 `reorderFavorite(name, toIndex)`，順序持久化。
+- [x] **Manual 重排 UI**：Manual sort 模式下可用 overflow menu Move up / Move down，接 `reorderFavorite(name, toIndex)` 持久化順序。
 - [ ] **手動測試 + detekt baseline 更新**：detekt baseline 已更新；尚缺實機驗證。
 
 ### 驗收條件
@@ -26,7 +26,7 @@
 - [x] route 跑步中按 Go to 套東西，會先停舊 mock / route 再套新。
 - [x] Favorites 頁 Points / Routes tabs 切換正常、空狀態文案合理。
 - [x] 三種排序模式皆可運作，設定持久化。
-- [ ] Manual 模式下能拖曳重排、順序持久化。
+- [x] Manual 模式下能重排、順序持久化（目前用 Move up / Move down，非拖曳）。
 - [x] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作。
 - [x] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化。
 - [x] `just check` / `just lint` 通過。

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,7 +13,7 @@
 - [x] **座標解析器**：`parseCoordInput(String): LatLng?` + 單元測試（純座標、Google Maps URL、範圍邊界）。
 - [x] **Go to 面板 UI**：`ModalBottomSheet` + 座標欄 + Points / Routes tabs + favorites 列表（sort 套用）。
 - [x] **MapScreen 接線**：新 FAB、開啟面板、apply 動作、套用前先停 route / mock。
-- [ ] **Favorites 頁完整改版**：已完成 tabs / sort / rename / delete / Apply now；尚缺 overflow menu、Edit coords、Edit route speed-mode。
+- [x] **Favorites 頁完整改版**：tabs / sort / overflow menu / rename / Edit coords / Edit route speed-mode / delete / Apply now 已完成。
 - [x] **Apply now / lastUsedAt 串起來**：Go to 面板、Favorites 頁 Apply now、Startup 套用都會 `touchFavorite`。
 - [ ] **Manual 拖曳重排 UI**：接 `reorderFavorite(name, toIndex)`，順序持久化。
 - [ ] **手動測試 + detekt baseline 更新**：detekt baseline 已更新；尚缺實機驗證。
@@ -27,7 +27,7 @@
 - [x] Favorites 頁 Points / Routes tabs 切換正常、空狀態文案合理。
 - [x] 三種排序模式皆可運作，設定持久化。
 - [ ] Manual 模式下能拖曳重排、順序持久化。
-- [ ] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作（Rename / Delete / Apply now 已完成）。
+- [x] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作。
 - [x] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化。
 - [x] `just check` / `just lint` 通過。
 


### PR DESCRIPTION
## Summary
- add Apply support from Favorites back to the Map tab and update last-used timestamps
- add favorite overflow actions for rename, edit coordinates, edit route speed/mode, and delete
- add Manual sort reordering via Move up / Move down and update TODO status

## Checks
- just check
- just build
- just lint