### PR TITLE
feat(routes): remember random route settings

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
@@ -47,8 +47,10 @@ data class FavoriteRoute(
 ) {
     override fun equals(other: Any?): Boolean =
         other is FavoriteRoute &&
-            lats.contentEquals(other.lats) && lngs.contentEquals(other.lngs) &&
-            speedKmh == other.speedKmh && mode == other.mode
+            lats.contentEquals(other.lats) &&
+            lngs.contentEquals(other.lngs) &&
+            speedKmh == other.speedKmh &&
+            mode == other.mode
 
     override fun hashCode(): Int {
         var result = lats.contentHashCode()
@@ -90,6 +92,27 @@ data class StartupPreference(
     enum class Mode { Last, Current, Favorite }
 }
 
+@Serializable
+data class RandomRoutePreference(
+    val defaultPointCount: Int = RECOMMENDED_POINT_COUNT,
+    val defaultSpacingMeters: Double = RECOMMENDED_SPACING_METERS,
+    val lastPointCount: Int? = null,
+    val lastSpacingMeters: Double? = null,
+) {
+    companion object {
+        const val MIN_POINT_COUNT = 2
+        const val MAX_POINT_COUNT = 1000
+        const val MIN_SPACING_METERS = 1.0
+        const val MAX_SPACING_METERS = 10000.0
+        const val RECOMMENDED_POINT_COUNT = 100
+        const val RECOMMENDED_SPACING_METERS = 500.0
+    }
+
+    val effectivePointCount: Int get() = lastPointCount ?: defaultPointCount
+    val effectiveSpacingMeters: Double get() = lastSpacingMeters ?: defaultSpacingMeters
+    val usesLastSettings: Boolean get() = lastPointCount != null && lastSpacingMeters != null
+}
+
 private val Context.prefStore by preferencesDataStore("kestrel_prefs")
 
 private object Keys {
@@ -100,8 +123,10 @@ private object Keys {
     val FAVORITES_SORT_MODE = stringPreferencesKey("favorites_sort_mode_json")
     val MOCK_STATE = stringPreferencesKey("mock_state_json")
     val STARTUP_PREF = stringPreferencesKey("startup_pref_json")
+    val RANDOM_ROUTE_PREF = stringPreferencesKey("random_route_pref_json")
 }
 
+@Suppress("TooManyFunctions")
 class KestrelPrefs(
     context: Context,
 ) {
@@ -113,6 +138,8 @@ class KestrelPrefs(
     val favoritesSortMode: Flow<FavoritesSortMode> = store.data.map { it.toFavoritesSortMode(json) }
     val mockState: Flow<MockState?> = store.data.map { it.toMockState(json) }
     val startupPreference: Flow<StartupPreference> = store.data.map { it.toStartupPref(json) }
+    val randomRoutePreference: Flow<RandomRoutePreference> =
+        store.data.map { it.toRandomRoutePref(json) }
 
     suspend fun setLastCamera(snap: CameraSnapshot) {
         store.edit {
@@ -218,6 +245,44 @@ class KestrelPrefs(
         }
     }
 
+    suspend fun setRandomRouteDefaults(
+        pointCount: Int,
+        spacingMeters: Double,
+    ) {
+        store.edit { prefs ->
+            val current = prefs.toRandomRoutePref(json)
+            prefs[Keys.RANDOM_ROUTE_PREF] =
+                json.encodeToString(
+                    RandomRoutePreference.serializer(),
+                    current.copy(
+                        defaultPointCount = pointCount,
+                        defaultSpacingMeters = spacingMeters,
+                    ),
+                )
+        }
+    }
+
+    suspend fun setLastRandomRouteSettings(
+        pointCount: Int,
+        spacingMeters: Double,
+    ) {
+        store.edit { prefs ->
+            val current = prefs.toRandomRoutePref(json)
+            prefs[Keys.RANDOM_ROUTE_PREF] =
+                json.encodeToString(
+                    RandomRoutePreference.serializer(),
+                    current.copy(
+                        lastPointCount = pointCount,
+                        lastSpacingMeters = spacingMeters,
+                    ),
+                )
+        }
+    }
+
+    suspend fun resetRandomRoutePreference() {
+        store.edit { it.remove(Keys.RANDOM_ROUTE_PREF) }
+    }
+
     suspend fun setMockState(state: MockState?) {
         store.edit {
             if (state == null) {
@@ -277,5 +342,12 @@ class KestrelPrefs(
         return runCatching {
             json.decodeFromString(StartupPreference.serializer(), raw)
         }.getOrDefault(StartupPreference())
+    }
+
+    private fun Preferences.toRandomRoutePref(json: Json): RandomRoutePreference {
+        val raw = this[Keys.RANDOM_ROUTE_PREF] ?: return RandomRoutePreference()
+        return runCatching {
+            json.decodeFromString(RandomRoutePreference.serializer(), raw)
+        }.getOrDefault(RandomRoutePreference())
     }
 }

--- a/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
@@ -74,6 +74,7 @@ import dev.narumi.kestrel.core.data.Favorite
 import dev.narumi.kestrel.core.data.FavoriteRoute
 import dev.narumi.kestrel.core.data.FavoritesSortMode
 import dev.narumi.kestrel.core.data.KestrelPrefs
+import dev.narumi.kestrel.core.data.RandomRoutePreference
 import dev.narumi.kestrel.core.data.StartupPreference
 import dev.narumi.kestrel.core.location.LatLng
 import dev.narumi.kestrel.core.location.LocationService
@@ -101,6 +102,29 @@ private sealed interface PendingFavorite {
 }
 
 private val SPEED_PRESETS = listOf(5.0, 10.0, 15.0, 20.0)
+
+private fun isValidPointCount(value: Int?): Boolean =
+    value != null &&
+        value in RandomRoutePreference.MIN_POINT_COUNT..RandomRoutePreference.MAX_POINT_COUNT
+
+private fun isValidSpacing(value: Double?): Boolean =
+    value != null &&
+        value >= RandomRoutePreference.MIN_SPACING_METERS &&
+        value <= RandomRoutePreference.MAX_SPACING_METERS
+
+private fun isValidRandomRoute(
+    pointCount: Int?,
+    spacingMeters: Double?,
+): Boolean = isValidPointCount(pointCount) && isValidSpacing(spacingMeters)
+
+private fun formatMeters(value: Double): String = if (value % 1.0 == 0.0) value.toInt().toString() else value.toString()
+
+private fun formatDistance(meters: Double): String =
+    if (meters >= 1000.0) {
+        "%.1f km".format(meters / 1000.0)
+    } else {
+        "${formatMeters(meters)} m"
+    }
 
 private fun MovementEngine.Mode.label(): String =
     when (this) {
@@ -133,6 +157,8 @@ fun MapScreen(
 
     val favorites by prefs.favorites.collectAsStateWithLifecycle(emptyList())
     val sortMode by prefs.favoritesSortMode.collectAsStateWithLifecycle(FavoritesSortMode())
+    val randomRoutePref by
+        prefs.randomRoutePreference.collectAsStateWithLifecycle(RandomRoutePreference())
 
     var mockAllowed by remember { mutableStateOf(false) }
     var waypoints by remember { mutableStateOf<List<LatLng>>(emptyList()) }
@@ -244,6 +270,9 @@ fun MapScreen(
 
     if (showGenerateDialog) {
         GenerateRouteDialog(
+            initialPointCount = randomRoutePref.effectivePointCount,
+            initialSpacingMeters = randomRoutePref.effectiveSpacingMeters,
+            usingLastSettings = randomRoutePref.usesLastSettings,
             onConfirm = { count, meters ->
                 val origin =
                     lastCameraCenter
@@ -251,6 +280,7 @@ fun MapScreen(
                         ?: cameraTarget?.let { LatLng(it.lat, it.lng) }
                         ?: LatLng(25.0330, 121.5654)
                 waypoints = RouteGenerator.generate(origin, count, meters)
+                scope.launch { prefs.setLastRandomRouteSettings(count, meters) }
                 if (runState == RunState.Single) {
                     LocationService.stop(context)
                     runState = RunState.Idle
@@ -928,38 +958,30 @@ private fun StatusBanner(
 
 @Composable
 private fun GenerateRouteDialog(
-    initialPointCount: Int = 10,
-    initialSpacingMeters: Int = 50,
+    initialPointCount: Int,
+    initialSpacingMeters: Double,
+    usingLastSettings: Boolean,
     onConfirm: (count: Int, meters: Double) -> Unit,
     onDismiss: () -> Unit,
 ) {
     var count by remember { mutableStateOf(initialPointCount.toString()) }
-    var meters by remember { mutableStateOf(initialSpacingMeters.toString()) }
+    var meters by remember { mutableStateOf(formatMeters(initialSpacingMeters)) }
     val parsedCount = count.toIntOrNull()
     val parsedMeters = meters.toDoubleOrNull()
-    val valid = parsedCount != null && parsedCount >= 2 && parsedMeters != null && parsedMeters > 0
+    val valid = isValidRandomRoute(parsedCount, parsedMeters)
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Generate random route") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(
-                    text = "Smooth random walk from the current map center.",
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                OutlinedTextField(
-                    value = count,
-                    onValueChange = { v -> count = v.filter(Char::isDigit).take(4) },
-                    label = { Text("Point count (≥ 2)") },
-                    singleLine = true,
-                )
-                OutlinedTextField(
-                    value = meters,
-                    onValueChange = { v -> meters = v.filter { it.isDigit() || it == '.' }.take(7) },
-                    label = { Text("Spacing (meters)") },
-                    singleLine = true,
-                )
-            }
+            GenerateRouteDialogContent(
+                count = count,
+                meters = meters,
+                parsedCount = parsedCount,
+                parsedMeters = parsedMeters,
+                usingLastSettings = usingLastSettings,
+                onCountChange = { count = it },
+                onMetersChange = { meters = it },
+            )
         },
         confirmButton = {
             TextButton(
@@ -972,6 +994,81 @@ private fun GenerateRouteDialog(
         },
     )
 }
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun GenerateRouteDialogContent(
+    count: String,
+    meters: String,
+    parsedCount: Int?,
+    parsedMeters: Double?,
+    usingLastSettings: Boolean,
+    onCountChange: (String) -> Unit,
+    onMetersChange: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "Smooth random walk from the current map center.",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = if (usingLastSettings) "Using last used settings" else "Using default settings",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SectionLabel("Point count")
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            listOf(20, 50, 100, 200).forEach { preset ->
+                ChipChoice(
+                    label = preset.toString(),
+                    selected = parsedCount == preset,
+                    enabled = true,
+                    onClick = { onCountChange(preset.toString()) },
+                )
+            }
+        }
+        OutlinedTextField(
+            value = count,
+            onValueChange = { onCountChange(it.filter(Char::isDigit).take(4)) },
+            label = { Text("Point count (2–1000)") },
+            isError = count.isNotBlank() && !isValidPointCount(parsedCount),
+            singleLine = true,
+        )
+        SectionLabel("Spacing")
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            listOf(50.0, 100.0, 500.0, 1000.0).forEach { preset ->
+                ChipChoice(
+                    label = formatDistance(preset),
+                    selected = parsedMeters == preset,
+                    enabled = true,
+                    onClick = { onMetersChange(formatMeters(preset)) },
+                )
+            }
+        }
+        OutlinedTextField(
+            value = meters,
+            onValueChange = { onMetersChange(it.filter { ch -> ch.isDigit() || ch == '.' }.take(7)) },
+            label = { Text("Spacing meters (1–10000)") },
+            isError = meters.isNotBlank() && !isValidSpacing(parsedMeters),
+            singleLine = true,
+        )
+        Text(
+            text = "Estimated distance: ${estimatedRouteDistance(parsedCount, parsedMeters)}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun estimatedRouteDistance(
+    pointCount: Int?,
+    spacingMeters: Double?,
+): String =
+    if (pointCount != null && spacingMeters != null) {
+        formatDistance((pointCount - 1).coerceAtLeast(0) * spacingMeters)
+    } else {
+        "—"
+    }
 
 @Composable
 private fun SaveFavoriteDialog(

--- a/app/src/main/java/dev/narumi/kestrel/feature/options/OptionsScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/options/OptionsScreen.kt
@@ -2,25 +2,36 @@ package dev.narumi.kestrel.feature.options
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.narumi.kestrel.core.data.Favorite
 import dev.narumi.kestrel.core.data.KestrelPrefs
+import dev.narumi.kestrel.core.data.RandomRoutePreference
 import dev.narumi.kestrel.core.data.StartupPreference
 import kotlinx.coroutines.launch
 
@@ -32,6 +43,14 @@ fun OptionsScreen(modifier: Modifier = Modifier) {
 
     val favorites by prefs.favorites.collectAsStateWithLifecycle(emptyList())
     val startup by prefs.startupPreference.collectAsStateWithLifecycle(StartupPreference())
+    val randomRoute by prefs.randomRoutePreference.collectAsStateWithLifecycle(RandomRoutePreference())
+    var defaultPointCount by remember { mutableStateOf("") }
+    var defaultSpacingMeters by remember { mutableStateOf("") }
+
+    LaunchedEffect(randomRoute.defaultPointCount, randomRoute.defaultSpacingMeters) {
+        defaultPointCount = randomRoute.defaultPointCount.toString()
+        defaultSpacingMeters = formatMeters(randomRoute.defaultSpacingMeters)
+    }
 
     fun update(pref: StartupPreference) {
         scope.launch { prefs.setStartupPreference(pref) }
@@ -41,75 +60,208 @@ fun OptionsScreen(modifier: Modifier = Modifier) {
         modifier =
             modifier
                 .fillMaxSize()
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            text = "When opening the app",
-            style = MaterialTheme.typography.titleMedium,
+        StartupPreferenceCard(
+            favorites = favorites,
+            startup = startup,
+            onUpdate = ::update,
         )
-        Card(modifier = Modifier.fillMaxWidth()) {
-            StartupRadioRow(
-                label = "Last position",
-                selected = startup.mode == StartupPreference.Mode.Last,
-                onSelect = { update(StartupPreference(StartupPreference.Mode.Last)) },
-            )
-            HorizontalDivider()
-            StartupRadioRow(
-                label = "Current location",
-                selected = startup.mode == StartupPreference.Mode.Current,
-                onSelect = { update(StartupPreference(StartupPreference.Mode.Current)) },
-            )
-            HorizontalDivider()
-            StartupRadioRow(
-                label =
-                    if (favorites.isEmpty()) {
-                        "A favorite (none yet — long-press the map)"
-                    } else {
-                        "A favorite"
-                    },
-                selected = startup.mode == StartupPreference.Mode.Favorite,
-                enabled = favorites.isNotEmpty(),
-                onSelect = {
-                    val target =
-                        favorites.firstOrNull { it.name == startup.favoriteName }
-                            ?: favorites.firstOrNull()
-                            ?: return@StartupRadioRow
-                    update(StartupPreference(StartupPreference.Mode.Favorite, target.name))
-                },
-            )
-        }
 
-        if (startup.mode == StartupPreference.Mode.Favorite && favorites.isNotEmpty()) {
-            Text(
-                text = "Pick a favorite",
-                style = MaterialTheme.typography.titleSmall,
-            )
-            Card(modifier = Modifier.fillMaxWidth()) {
-                favorites.forEachIndexed { index, fav ->
-                    if (index > 0) HorizontalDivider()
-                    val supporting =
-                        fav.route?.let {
-                            "Route · ${it.lats.size} waypoints · ${it.speedKmh.toInt()} km/h"
-                        } ?: "%.5f, %.5f".format(fav.lat, fav.lng)
-                    StartupRadioRow(
-                        label = fav.name,
-                        supporting = supporting,
-                        selected = startup.favoriteName == fav.name,
-                        onSelect = {
-                            update(
-                                StartupPreference(
-                                    mode = StartupPreference.Mode.Favorite,
-                                    favoriteName = fav.name,
-                                ),
-                            )
-                        },
+        RandomRouteDefaultsCard(
+            pointCount = defaultPointCount,
+            spacingMeters = defaultSpacingMeters,
+            hasLastUsed = randomRoute.usesLastSettings,
+            onPointCountChange = { defaultPointCount = it.filter(Char::isDigit).take(4) },
+            onSpacingMetersChange = {
+                defaultSpacingMeters = it.filter { ch -> ch.isDigit() || ch == '.' }.take(7)
+            },
+            onSave = {
+                scope.launch {
+                    prefs.setRandomRouteDefaults(
+                        defaultPointCount.toIntOrNull() ?: return@launch,
+                        defaultSpacingMeters.toDoubleOrNull() ?: return@launch,
                     )
                 }
+            },
+            onReset = { scope.launch { prefs.resetRandomRoutePreference() } },
+        )
+
+        FavoriteStartupPicker(
+            favorites = favorites,
+            startup = startup,
+            onSelect = { update(StartupPreference(StartupPreference.Mode.Favorite, it.name)) },
+        )
+    }
+}
+
+@Composable
+private fun StartupPreferenceCard(
+    favorites: List<Favorite>,
+    startup: StartupPreference,
+    onUpdate: (StartupPreference) -> Unit,
+) {
+    Text(
+        text = "When opening the app",
+        style = MaterialTheme.typography.titleMedium,
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        StartupRadioRow(
+            label = "Last position",
+            selected = startup.mode == StartupPreference.Mode.Last,
+            onSelect = { onUpdate(StartupPreference(StartupPreference.Mode.Last)) },
+        )
+        HorizontalDivider()
+        StartupRadioRow(
+            label = "Current location",
+            selected = startup.mode == StartupPreference.Mode.Current,
+            onSelect = { onUpdate(StartupPreference(StartupPreference.Mode.Current)) },
+        )
+        HorizontalDivider()
+        StartupRadioRow(
+            label =
+                if (favorites.isEmpty()) {
+                    "A favorite (none yet — long-press the map)"
+                } else {
+                    "A favorite"
+                },
+            selected = startup.mode == StartupPreference.Mode.Favorite,
+            enabled = favorites.isNotEmpty(),
+            onSelect = {
+                val target =
+                    favorites.firstOrNull { it.name == startup.favoriteName }
+                        ?: favorites.firstOrNull()
+                        ?: return@StartupRadioRow
+                onUpdate(StartupPreference(StartupPreference.Mode.Favorite, target.name))
+            },
+        )
+    }
+}
+
+@Composable
+private fun FavoriteStartupPicker(
+    favorites: List<Favorite>,
+    startup: StartupPreference,
+    onSelect: (Favorite) -> Unit,
+) {
+    if (startup.mode != StartupPreference.Mode.Favorite || favorites.isEmpty()) return
+    Text(
+        text = "Pick a favorite",
+        style = MaterialTheme.typography.titleSmall,
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        favorites.forEachIndexed { index, fav ->
+            if (index > 0) HorizontalDivider()
+            val supporting =
+                fav.route?.let {
+                    "Route · ${it.lats.size} waypoints · ${it.speedKmh.toInt()} km/h"
+                } ?: "%.5f, %.5f".format(fav.lat, fav.lng)
+            StartupRadioRow(
+                label = fav.name,
+                supporting = supporting,
+                selected = startup.favoriteName == fav.name,
+                onSelect = { onSelect(fav) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun RandomRouteDefaultsCard(
+    pointCount: String,
+    spacingMeters: String,
+    hasLastUsed: Boolean,
+    onPointCountChange: (String) -> Unit,
+    onSpacingMetersChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onReset: () -> Unit,
+) {
+    val parsedPointCount = pointCount.toIntOrNull()
+    val parsedSpacing = spacingMeters.toDoubleOrNull()
+    val valid = isValidRandomRoute(parsedPointCount, parsedSpacing)
+    Text(
+        text = "Random route defaults",
+        style = MaterialTheme.typography.titleMedium,
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Used when no previous random route settings exist.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (hasLastUsed) {
+                Text(
+                    text = "Generate random route is currently using last used settings.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            OutlinedTextField(
+                value = pointCount,
+                onValueChange = onPointCountChange,
+                label = { Text("Point count (2–1000)") },
+                isError = pointCount.isNotBlank() && !isValidPointCount(parsedPointCount),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = spacingMeters,
+                onValueChange = onSpacingMetersChange,
+                label = { Text("Spacing meters (1–10000)") },
+                isError = spacingMeters.isNotBlank() && !isValidSpacing(parsedSpacing),
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                text =
+                    "Estimated distance: " +
+                        if (parsedPointCount != null && parsedSpacing != null) {
+                            formatDistance((parsedPointCount - 1).coerceAtLeast(0) * parsedSpacing)
+                        } else {
+                            "—"
+                        },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(
+                    onClick = onSave,
+                    enabled = valid,
+                ) { Text("Save") }
+                OutlinedButton(onClick = onReset) { Text("Reset to recommended") }
             }
         }
     }
 }
+
+private fun isValidPointCount(value: Int?): Boolean =
+    value != null &&
+        value in RandomRoutePreference.MIN_POINT_COUNT..RandomRoutePreference.MAX_POINT_COUNT
+
+private fun isValidSpacing(value: Double?): Boolean =
+    value != null &&
+        value >= RandomRoutePreference.MIN_SPACING_METERS &&
+        value <= RandomRoutePreference.MAX_SPACING_METERS
+
+private fun isValidRandomRoute(
+    pointCount: Int?,
+    spacingMeters: Double?,
+): Boolean = isValidPointCount(pointCount) && isValidSpacing(spacingMeters)
+
+private fun formatMeters(value: Double): String = if (value % 1.0 == 0.0) value.toInt().toString() else value.toString()
+
+private fun formatDistance(meters: Double): String =
+    if (meters >= 1000.0) {
+        "%.1f km".format(meters / 1000.0)
+    } else {
+        "${formatMeters(meters)} m"
+    }
 
 @Composable
 private fun StartupRadioRow(


### PR DESCRIPTION
## Summary
- add persisted random route defaults and last-used settings
- update generate dialog with chips, source hint, validation, and estimated distance
- add Options controls for route defaults and reset to recommended values

## Verification
- just format
- just lint
- just check
- just build