### PR TITLE
feat(web): add cloud console

### DIFF
--- a/.agents/docs/todos/location-route-sync-platform-todo.md
+++ b/.agents/docs/todos/location-route-sync-platform-todo.md
@@ -68,17 +68,17 @@
 
 ## Phase 4：Next.js Web console
 
-- [ ] 建立 Next.js app。
-- [ ] 實作 username/password + TOTP login UI。
-- [ ] 實作 session refresh / logout。
-- [ ] 建立 authenticated shell layout。
-- [ ] 建立 Place list / detail / edit。
-- [ ] 建立 Route list / detail。
-- [ ] 整合 MapLibre GL JS。
-- [ ] 實作 route waypoint 新增 / 刪除 / 拖曳排序。
-- [ ] 實作 route default speed / mode 設定。
-- [ ] 儲存 route 時呼叫 API 並建立新 revision。
-- [ ] 顯示 route latest revision number。
+- [x] 建立 Next.js app。
+- [x] 實作 username/password + TOTP login UI。
+- [x] 實作 session refresh / logout。
+- [x] 建立 authenticated shell layout。
+- [x] 建立 Place list / detail / edit。
+- [x] 建立 Route list / detail。
+- [x] 整合 MapLibre GL JS。
+- [ ] 實作 route waypoint 新增 / 刪除 / 拖曳排序。（目前支援點地圖新增、刪除、按鈕重排、拖曳 marker 改座標；尚未做 list drag-and-drop 排序。）
+- [x] 實作 route default speed / mode 設定。
+- [x] 儲存 route 時呼叫 API 並建立新 revision。
+- [x] 顯示 route latest revision number。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A **foreground service** (type `location`) keeps the mock alive while the UI is 
 
 ```
 backend/                     # NestJS + Prisma cloud platform backend
+web/                         # Next.js cloud console
 app/src/main/java/dev/narumi/kestrel/
 ├── core/
 │   ├── data/        # DataStore Preferences, @Serializable schema
@@ -96,6 +97,18 @@ npm run db:up
 npm run prisma:migrate:dev
 npm run start:dev
 ```
+
+### Web console
+
+The Next.js cloud console lives in `web/` and proxies `/api/backend/*` to the NestJS API.
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+Open `http://localhost:3001`. Set `KESTREL_API_BASE_URL` if the API is not on `http://localhost:3000`.
 
 ---
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+# Next.js rewrites /api/backend/* to this NestJS API origin.
+KESTREL_API_BASE_URL=http://localhost:3000

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+.next/
+out/
+node_modules/
+.env*.local

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,38 @@
+# Kestrel Web Console
+
+Next.js web console for the Kestrel cloud backend.
+
+## Local development
+
+Start the NestJS API first, then run:
+
+```bash
+npm install
+npm run dev
+```
+
+The console runs on `http://localhost:3001` and rewrites `/api/backend/*` to `http://localhost:3000` by default.
+
+Set a custom API origin with:
+
+```bash
+KESTREL_API_BASE_URL=http://localhost:3000 npm run dev
+```
+
+## Current scope
+
+- Register + TOTP setup.
+- Username/password + TOTP or recovery-code login.
+- LocalStorage-backed access/refresh session with one retry after refresh.
+- Authenticated dashboard shell and logout.
+- Place list/create/edit/delete.
+- Route list/create/edit/delete.
+- MapLibre route editor: click map to add waypoints, drag markers to adjust coordinates, delete/reorder waypoint rows.
+- Route default speed/mode/public flag and latest revision display.
+
+## Validation
+
+```bash
+npm run typecheck
+npm run build
+```

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,0 +1,475 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { useAuth } from '@/components/AuthProvider';
+import { ApiError, type Place, type PlaceInput, type Route, type RouteInput, type RouteMode, type RouteWaypoint } from '@/lib/api';
+
+const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
+  ssr: false,
+});
+
+export default function DashboardPage() {
+  const auth = useAuth();
+  const router = useRouter();
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [routes, setRoutes] = useState<Route[]>([]);
+  const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+  const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const selectedPlace = useMemo(
+    () => places.find((place) => place.id === selectedPlaceId) ?? null,
+    [places, selectedPlaceId],
+  );
+  const selectedRoute = useMemo(
+    () => routes.find((route) => route.id === selectedRouteId) ?? null,
+    [routes, selectedRouteId],
+  );
+
+  const loadLibrary = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const [nextPlaces, nextRoutes] = await Promise.all([
+        auth.apiRequest<Place[]>('/places'),
+        auth.apiRequest<Route[]>('/routes'),
+      ]);
+      setPlaces(nextPlaces);
+      setRoutes(nextRoutes);
+      setSelectedPlaceId((current) => current ?? nextPlaces[0]?.id ?? null);
+      setSelectedRouteId((current) => current ?? nextRoutes[0]?.id ?? null);
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [auth]);
+
+  useEffect(() => {
+    if (!auth.isHydrated) {
+      return;
+    }
+
+    if (!auth.isAuthenticated) {
+      router.replace('/login');
+      return;
+    }
+
+    void loadLibrary();
+  }, [auth.isAuthenticated, auth.isHydrated, loadLibrary, router]);
+
+  async function savePlace(input: PlaceInput) {
+    const savedPlace = selectedPlace == null
+      ? await auth.apiRequest<Place>('/places', {
+          body: JSON.stringify(input),
+          method: 'POST',
+        })
+      : await auth.apiRequest<Place>(`/places/${selectedPlace.id}`, {
+          body: JSON.stringify(input),
+          method: 'PATCH',
+        });
+
+    await loadLibrary();
+    setSelectedPlaceId(savedPlace.id);
+  }
+
+  async function deletePlace(placeId: string) {
+    await auth.apiRequest(`/places/${placeId}`, { method: 'DELETE' });
+    await loadLibrary();
+    setSelectedPlaceId(null);
+  }
+
+  async function saveRoute(input: RouteInput) {
+    const savedRoute = selectedRoute == null
+      ? await auth.apiRequest<Route>('/routes', {
+          body: JSON.stringify(input),
+          method: 'POST',
+        })
+      : await auth.apiRequest<Route>(`/routes/${selectedRoute.id}`, {
+          body: JSON.stringify(input),
+          method: 'PATCH',
+        });
+
+    await loadLibrary();
+    setSelectedRouteId(savedRoute.id);
+  }
+
+  async function deleteRoute(routeId: string) {
+    await auth.apiRequest(`/routes/${routeId}`, { method: 'DELETE' });
+    await loadLibrary();
+    setSelectedRouteId(null);
+  }
+
+  return (
+    <main className="shell">
+      <header className="topbar">
+        <div className="brand">
+          <strong>Kestrel Cloud</strong>
+          <span className="muted">Signed in as {auth.session?.user.username}</span>
+        </div>
+        <div className="row">
+          <button className="secondary" type="button" onClick={() => void loadLibrary()}>
+            Refresh
+          </button>
+          <button className="secondary" type="button" onClick={auth.logout}>
+            Logout
+          </button>
+        </div>
+      </header>
+
+      {error == null ? null : <div className="error" style={{ marginBottom: '1rem' }}>{error}</div>}
+
+      <section className="dashboard-grid">
+        <aside className="grid">
+          <div className="card stack">
+            <div className="row" style={{ justifyContent: 'space-between' }}>
+              <h2>Places</h2>
+              <button className="secondary" type="button" onClick={() => setSelectedPlaceId(null)}>
+                New
+              </button>
+            </div>
+            {isLoading ? <p className="muted">Loading…</p> : null}
+            <div className="list">
+              {places.map((place) => (
+                <button
+                  className={`list-item ${selectedPlaceId === place.id ? 'active' : ''}`}
+                  key={place.id}
+                  type="button"
+                  onClick={() => setSelectedPlaceId(place.id)}
+                >
+                  <strong>{place.name}</strong>
+                  <span className="muted">{formatCoord(place.latitude)}, {formatCoord(place.longitude)}</span>
+                  <TagRow tags={place.tags} />
+                </button>
+              ))}
+              {places.length === 0 && !isLoading ? <p className="muted">No places yet.</p> : null}
+            </div>
+          </div>
+
+          <div className="card stack">
+            <div className="row" style={{ justifyContent: 'space-between' }}>
+              <h2>Routes</h2>
+              <button className="secondary" type="button" onClick={() => setSelectedRouteId(null)}>
+                New
+              </button>
+            </div>
+            <div className="list">
+              {routes.map((route) => (
+                <button
+                  className={`list-item ${selectedRouteId === route.id ? 'active' : ''}`}
+                  key={route.id}
+                  type="button"
+                  onClick={() => setSelectedRouteId(route.id)}
+                >
+                  <strong>{route.name}</strong>
+                  <span className="muted">
+                    {route.currentRevision?.waypoints.length ?? 0} waypoints · {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
+                  </span>
+                  <span className="chip-row">
+                    <span className="chip">rev {route.currentRevision?.revisionNumber ?? '—'}</span>
+                    {route.isPublic ? <span className="chip">public</span> : null}
+                  </span>
+                </button>
+              ))}
+              {routes.length === 0 && !isLoading ? <p className="muted">No routes yet.</p> : null}
+            </div>
+          </div>
+        </aside>
+
+        <section className="grid">
+          <PlaceEditor
+            key={selectedPlace?.id ?? 'new-place'}
+            onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
+            onSave={(input) => void savePlace(input)}
+            place={selectedPlace}
+          />
+          <RouteEditor
+            key={selectedRoute?.id ?? 'new-route'}
+            onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
+            onSave={(input) => void saveRoute(input)}
+            route={selectedRoute}
+          />
+        </section>
+      </section>
+    </main>
+  );
+}
+
+function PlaceEditor({
+  onDelete,
+  onSave,
+  place,
+}: {
+  onDelete?: () => void;
+  onSave: (input: PlaceInput) => void;
+  place: Place | null;
+}) {
+  const [name, setName] = useState(place?.name ?? '');
+  const [latitude, setLatitude] = useState(place?.latitude.toString() ?? '25.033');
+  const [longitude, setLongitude] = useState(place?.longitude.toString() ?? '121.5654');
+  const [description, setDescription] = useState(place?.description ?? '');
+  const [tags, setTags] = useState(place?.tags.join(', ') ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSaving(true);
+
+    try {
+      await onSave({
+        description: normalizeNullable(description),
+        latitude: parseNumber(latitude, 'latitude'),
+        longitude: parseNumber(longitude, 'longitude'),
+        name,
+        tags: tags.split(',').map((tag) => tag.trim()).filter(Boolean),
+      });
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <form className="panel stack" onSubmit={submit}>
+      <h2>{place == null ? 'New place' : 'Edit place'}</h2>
+      {error == null ? null : <div className="error">{error}</div>}
+      <label>
+        Name
+        <input required value={name} onChange={(event) => setName(event.target.value)} />
+      </label>
+      <div className="split">
+        <label>
+          Latitude
+          <input required inputMode="decimal" value={latitude} onChange={(event) => setLatitude(event.target.value)} />
+        </label>
+        <label>
+          Longitude
+          <input required inputMode="decimal" value={longitude} onChange={(event) => setLongitude(event.target.value)} />
+        </label>
+      </div>
+      <label>
+        Tags (comma separated)
+        <input value={tags} onChange={(event) => setTags(event.target.value)} />
+      </label>
+      <label>
+        Description
+        <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
+      </label>
+      <div className="row">
+        <button disabled={isSaving} type="submit">{isSaving ? 'Saving…' : 'Save place'}</button>
+        {onDelete == null ? null : (
+          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>Delete</button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function RouteEditor({
+  onDelete,
+  onSave,
+  route,
+}: {
+  onDelete?: () => void;
+  onSave: (input: RouteInput) => void;
+  route: Route | null;
+}) {
+  const [name, setName] = useState(route?.name ?? '');
+  const [description, setDescription] = useState(route?.description ?? '');
+  const [defaultSpeedKmh, setDefaultSpeedKmh] = useState(route?.defaultSpeedKmh.toString() ?? '5');
+  const [mode, setMode] = useState<RouteMode>(route?.mode ?? 'ONCE');
+  const [isPublic, setIsPublic] = useState(route?.isPublic ?? false);
+  const [waypoints, setWaypoints] = useState<RouteWaypoint[]>(
+    route?.currentRevision?.waypoints.map((waypoint) => ({
+      latitude: waypoint.latitude,
+      longitude: waypoint.longitude,
+    })) ?? [
+      { latitude: 25.033, longitude: 121.5654 },
+      { latitude: 25.0375, longitude: 121.5637 },
+    ],
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSaving(true);
+
+    try {
+      await onSave({
+        defaultSpeedKmh: parseNumber(defaultSpeedKmh, 'default speed'),
+        description: normalizeNullable(description),
+        isPublic,
+        mode,
+        name,
+        waypoints: waypoints.map((waypoint) => ({
+          latitude: waypoint.latitude,
+          longitude: waypoint.longitude,
+        })),
+      });
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <form className="panel stack" onSubmit={submit}>
+      <div className="row" style={{ justifyContent: 'space-between' }}>
+        <h2>{route == null ? 'New route' : 'Route editor'}</h2>
+        {route?.currentRevision == null ? null : <span className="chip">latest revision {route.currentRevision.revisionNumber}</span>}
+      </div>
+      {error == null ? null : <div className="error">{error}</div>}
+      <RouteMapEditor waypoints={waypoints} onChange={setWaypoints} />
+      <label>
+        Name
+        <input required value={name} onChange={(event) => setName(event.target.value)} />
+      </label>
+      <div className="split">
+        <label>
+          Default speed (km/h)
+          <input required inputMode="decimal" value={defaultSpeedKmh} onChange={(event) => setDefaultSpeedKmh(event.target.value)} />
+        </label>
+        <label>
+          Playback mode
+          <select value={mode} onChange={(event) => setMode(event.target.value as RouteMode)}>
+            <option value="ONCE">Once</option>
+            <option value="LOOP">Loop</option>
+            <option value="PING_PONG">PingPong</option>
+          </select>
+        </label>
+      </div>
+      <label className="row">
+        <input checked={isPublic} style={{ width: 'auto' }} type="checkbox" onChange={(event) => setIsPublic(event.target.checked)} />
+        Public route
+      </label>
+      <label>
+        Description
+        <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
+      </label>
+
+      <div className="stack">
+        <h3>Waypoints</h3>
+        {waypoints.map((waypoint, index) => (
+          <div className="waypoint-row" key={`${index}-${waypoint.latitude}-${waypoint.longitude}`}>
+            <span className="chip">#{index + 1}</span>
+            <input
+              inputMode="decimal"
+              value={waypoint.latitude}
+              onChange={(event) => updateWaypoint(waypoints, setWaypoints, index, 'latitude', event.target.value)}
+            />
+            <input
+              inputMode="decimal"
+              value={waypoint.longitude}
+              onChange={(event) => updateWaypoint(waypoints, setWaypoints, index, 'longitude', event.target.value)}
+            />
+            <div className="row">
+              <button className="secondary" disabled={index === 0} type="button" onClick={() => moveWaypoint(waypoints, setWaypoints, index, index - 1)}>↑</button>
+              <button className="secondary" disabled={index === waypoints.length - 1} type="button" onClick={() => moveWaypoint(waypoints, setWaypoints, index, index + 1)}>↓</button>
+              <button className="danger" disabled={waypoints.length <= 2} type="button" onClick={() => setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index))}>×</button>
+            </div>
+          </div>
+        ))}
+        <button
+          className="secondary"
+          type="button"
+          onClick={() => setWaypoints([...waypoints, waypoints.at(-1) ?? { latitude: 25.033, longitude: 121.5654 }])}
+        >
+          Add waypoint
+        </button>
+      </div>
+
+      <div className="row">
+        <button disabled={isSaving || waypoints.length < 2} type="submit">{isSaving ? 'Saving…' : 'Save route'}</button>
+        {onDelete == null ? null : (
+          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>Delete</button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function TagRow({ tags }: { tags: string[] }) {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className="chip-row">
+      {tags.map((tag) => <span className="chip" key={tag}>{tag}</span>)}
+    </span>
+  );
+}
+
+function updateWaypoint(
+  waypoints: RouteWaypoint[],
+  setWaypoints: (waypoints: RouteWaypoint[]) => void,
+  index: number,
+  field: 'latitude' | 'longitude',
+  value: string,
+) {
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue)) {
+    return;
+  }
+
+  setWaypoints(
+    waypoints.map((waypoint, currentIndex) =>
+      currentIndex === index ? { ...waypoint, [field]: parsedValue } : waypoint,
+    ),
+  );
+}
+
+function moveWaypoint(
+  waypoints: RouteWaypoint[],
+  setWaypoints: (waypoints: RouteWaypoint[]) => void,
+  fromIndex: number,
+  toIndex: number,
+) {
+  const nextWaypoints = [...waypoints];
+  const [waypoint] = nextWaypoints.splice(fromIndex, 1);
+  nextWaypoints.splice(toIndex, 0, waypoint);
+  setWaypoints(nextWaypoints);
+}
+
+function parseNumber(value: string, label: string): number {
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+
+  return parsedValue;
+}
+
+function normalizeNullable(value: string): string | null {
+  const trimmed = value.trim();
+
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function formatCoord(value: number): string {
+  return value.toFixed(6);
+}
+
+function formatMode(mode: RouteMode): string {
+  return mode === 'PING_PONG' ? 'PingPong' : mode[0] + mode.slice(1).toLowerCase();
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof ApiError || error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unexpected error';
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,297 @@
+:root {
+  --background: #08111f;
+  --card: #0f1b2d;
+  --card-strong: #14243a;
+  --text: #edf5ff;
+  --muted: #9fb1c8;
+  --line: #263a56;
+  --accent: #55d0ff;
+  --accent-strong: #26b7ee;
+  --danger: #ff6b7a;
+  --success: #70e3a4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background:
+    radial-gradient(circle at 20% 10%, rgb(33 91 130 / 45%), transparent 32rem),
+    radial-gradient(circle at 80% 0%, rgb(19 87 85 / 30%), transparent 28rem),
+    var(--background);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  background: var(--accent);
+  border: 0;
+  border-radius: 999px;
+  color: #041421;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.7rem 1rem;
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--text);
+}
+
+button.danger {
+  background: transparent;
+  border: 1px solid rgb(255 107 122 / 60%);
+  color: var(--danger);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+input,
+select,
+textarea {
+  background: #081321;
+  border: 1px solid var(--line);
+  border-radius: 0.8rem;
+  color: var(--text);
+  padding: 0.72rem 0.85rem;
+  width: 100%;
+}
+
+textarea {
+  min-height: 5rem;
+  resize: vertical;
+}
+
+label {
+  color: var(--muted);
+  display: grid;
+  font-size: 0.88rem;
+  gap: 0.4rem;
+}
+
+.shell {
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 2rem;
+}
+
+.topbar,
+.card,
+.panel {
+  background: rgb(15 27 45 / 82%);
+  border: 1px solid rgb(255 255 255 / 9%);
+  box-shadow: 0 24px 80px rgb(0 0 0 / 24%);
+}
+
+.topbar {
+  align-items: center;
+  border-radius: 1.4rem;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.3rem;
+  padding: 1rem 1.2rem;
+}
+
+.brand {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.brand strong {
+  font-size: 1.1rem;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard-grid {
+  align-items: start;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(18rem, 0.9fr) minmax(24rem, 1.4fr);
+}
+
+.card,
+.panel {
+  border-radius: 1.2rem;
+  padding: 1rem;
+}
+
+.card h2,
+.card h3,
+.panel h2,
+.panel h3 {
+  margin: 0 0 0.8rem;
+}
+
+.stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.row {
+  align-items: center;
+  display: flex;
+  gap: 0.7rem;
+}
+
+.row > * {
+  min-width: 0;
+}
+
+.split {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr 1fr;
+}
+
+.list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.list-item {
+  background: rgb(255 255 255 / 4%);
+  border: 1px solid rgb(255 255 255 / 8%);
+  border-radius: 0.9rem;
+  cursor: pointer;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.8rem;
+  text-align: left;
+}
+
+.list-item.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgb(85 208 255 / 30%);
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.chip {
+  background: rgb(85 208 255 / 10%);
+  border: 1px solid rgb(85 208 255 / 22%);
+  border-radius: 999px;
+  color: #cdefff;
+  font-size: 0.78rem;
+  padding: 0.2rem 0.55rem;
+}
+
+.error {
+  background: rgb(255 107 122 / 12%);
+  border: 1px solid rgb(255 107 122 / 35%);
+  border-radius: 0.8rem;
+  color: #ffd9de;
+  padding: 0.75rem;
+}
+
+.success {
+  background: rgb(112 227 164 / 12%);
+  border: 1px solid rgb(112 227 164 / 30%);
+  border-radius: 0.8rem;
+  color: #ddffeb;
+  padding: 0.75rem;
+}
+
+.auth-page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.auth-card {
+  max-width: 34rem;
+  width: 100%;
+}
+
+.tabs {
+  background: rgb(255 255 255 / 4%);
+  border-radius: 999px;
+  display: grid;
+  gap: 0.25rem;
+  grid-template-columns: 1fr 1fr;
+  padding: 0.25rem;
+}
+
+.tabs button {
+  background: transparent;
+  color: var(--muted);
+}
+
+.tabs button.active {
+  background: var(--accent);
+  color: #041421;
+}
+
+.qr {
+  background: white;
+  border-radius: 0.8rem;
+  max-width: 14rem;
+  padding: 0.4rem;
+  width: 100%;
+}
+
+.map {
+  border-radius: 1rem;
+  height: 24rem;
+  overflow: hidden;
+}
+
+.map-mini {
+  border-radius: 0.8rem;
+  height: 13rem;
+  overflow: hidden;
+}
+
+.waypoint-row {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto 1fr 1fr auto;
+}
+
+@media (max-width: 860px) {
+  .dashboard-grid,
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .shell {
+    padding: 1rem;
+  }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,19 @@
+import 'maplibre-gl/dist/maplibre-gl.css';
+import './globals.css';
+import type { Metadata } from 'next';
+import { AuthProvider } from '@/components/AuthProvider';
+
+export const metadata: Metadata = {
+  description: 'Web console for editing Kestrel cloud places and routes.',
+  title: 'Kestrel Cloud',
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthProvider>{children}</AuthProvider>
+      </body>
+    </html>
+  );
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useEffect, useState } from 'react';
+import { useAuth } from '@/components/AuthProvider';
+import { ApiError, login, register, setupTotp, verifyTotp } from '@/lib/api';
+
+type AuthTab = 'login' | 'register';
+type TotpSetup = {
+  qrCodeDataUrl: string;
+  secret: string;
+};
+
+export default function LoginPage() {
+  const auth = useAuth();
+  const router = useRouter();
+  const [tab, setTab] = useState<AuthTab>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [oneTimeCode, setOneTimeCode] = useState('');
+  const [isRecoveryCode, setIsRecoveryCode] = useState(false);
+  const [totpSetup, setTotpSetup] = useState<TotpSetup | null>(null);
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (auth.isHydrated && auth.isAuthenticated) {
+      router.replace('/dashboard');
+    }
+  }, [auth.isAuthenticated, auth.isHydrated, router]);
+
+  async function submitLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const session = await login({
+        password,
+        username,
+        ...(isRecoveryCode
+          ? { recoveryCode: oneTimeCode }
+          : { totpCode: oneTimeCode }),
+      });
+      auth.saveSession(session);
+      router.replace('/dashboard');
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function submitRegister(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      if (totpSetup == null) {
+        await register({ password, username });
+        const setup = await setupTotp({ password, username });
+        setTotpSetup({
+          qrCodeDataUrl: setup.qrCodeDataUrl,
+          secret: setup.secret,
+        });
+      } else {
+        const result = await verifyTotp({
+          code: oneTimeCode,
+          password,
+          username,
+        });
+        setRecoveryCodes(result.recoveryCodes);
+      }
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="auth-page">
+      <section className="card auth-card stack">
+        <div className="brand">
+          <strong>🦅 Kestrel Cloud</strong>
+          <span className="muted">Edit places and routes for Android sync.</span>
+        </div>
+
+        <div className="tabs">
+          <button
+            className={tab === 'login' ? 'active' : ''}
+            type="button"
+            onClick={() => setTab('login')}
+          >
+            Login
+          </button>
+          <button
+            className={tab === 'register' ? 'active' : ''}
+            type="button"
+            onClick={() => setTab('register')}
+          >
+            Register
+          </button>
+        </div>
+
+        {error == null ? null : <div className="error">{error}</div>}
+
+        {tab === 'login' ? (
+          <form className="stack" onSubmit={submitLogin}>
+            <CredentialsFields
+              password={password}
+              setPassword={setPassword}
+              setUsername={setUsername}
+              username={username}
+            />
+            <label>
+              {isRecoveryCode ? 'Recovery code' : 'TOTP code'}
+              <input
+                autoComplete="one-time-code"
+                inputMode="numeric"
+                required
+                value={oneTimeCode}
+                onChange={(event) => setOneTimeCode(event.target.value)}
+              />
+            </label>
+            <label className="row">
+              <input
+                checked={isRecoveryCode}
+                style={{ width: 'auto' }}
+                type="checkbox"
+                onChange={(event) => setIsRecoveryCode(event.target.checked)}
+              />
+              Use a recovery code instead
+            </label>
+            <button disabled={isSubmitting} type="submit">
+              {isSubmitting ? 'Signing in…' : 'Sign in'}
+            </button>
+          </form>
+        ) : (
+          <form className="stack" onSubmit={submitRegister}>
+            <CredentialsFields
+              password={password}
+              setPassword={setPassword}
+              setUsername={setUsername}
+              username={username}
+            />
+
+            {totpSetup == null ? (
+              <p className="muted">
+                Passwords must be at least 12 characters. Registration starts TOTP setup immediately.
+              </p>
+            ) : (
+              <div className="stack">
+                <div className="success">Scan this QR code, then enter the current authenticator code.</div>
+                <img alt="TOTP QR code" className="qr" src={totpSetup.qrCodeDataUrl} />
+                <label>
+                  Secret
+                  <input readOnly value={totpSetup.secret} />
+                </label>
+                <label>
+                  TOTP code
+                  <input
+                    autoComplete="one-time-code"
+                    inputMode="numeric"
+                    required
+                    value={oneTimeCode}
+                    onChange={(event) => setOneTimeCode(event.target.value)}
+                  />
+                </label>
+              </div>
+            )}
+
+            {recoveryCodes == null ? null : (
+              <div className="success stack">
+                <strong>Save these recovery codes now. They will not be shown again.</strong>
+                <div className="chip-row">
+                  {recoveryCodes.map((code) => (
+                    <code className="chip" key={code}>{code}</code>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <button disabled={isSubmitting || recoveryCodes != null} type="submit">
+              {totpSetup == null ? 'Create account' : 'Verify TOTP'}
+            </button>
+            {recoveryCodes == null ? null : (
+              <button
+                className="secondary"
+                type="button"
+                onClick={() => {
+                  setTab('login');
+                  setOneTimeCode('');
+                  setRecoveryCodes(null);
+                  setTotpSetup(null);
+                }}
+              >
+                Continue to login
+              </button>
+            )}
+          </form>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function CredentialsFields({
+  password,
+  setPassword,
+  setUsername,
+  username,
+}: {
+  password: string;
+  setPassword: (value: string) => void;
+  setUsername: (value: string) => void;
+  username: string;
+}) {
+  return (
+    <>
+      <label>
+        Username
+        <input
+          autoComplete="username"
+          required
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+        />
+      </label>
+      <label>
+        Password
+        <input
+          autoComplete="current-password"
+          minLength={12}
+          required
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+        />
+      </label>
+    </>
+  );
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof ApiError || error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unexpected error';
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/dashboard');
+}

--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { ApiError, apiFetch, refreshSession, type AuthSession } from '@/lib/api';
+
+type AuthContextValue = {
+  apiRequest: <T>(path: string, options?: RequestInit) => Promise<T>;
+  isAuthenticated: boolean;
+  isHydrated: boolean;
+  logout: () => void;
+  saveSession: (session: AuthSession) => void;
+  session: AuthSession | null;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+const STORAGE_KEY = 'kestrel.web.session';
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const storedSession = window.localStorage.getItem(STORAGE_KEY);
+
+    if (storedSession != null) {
+      try {
+        setSession(JSON.parse(storedSession) as AuthSession);
+      } catch {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+
+    setIsHydrated(true);
+  }, []);
+
+  const saveSession = useCallback((nextSession: AuthSession) => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextSession));
+    setSession(nextSession);
+  }, []);
+
+  const logout = useCallback(() => {
+    window.localStorage.removeItem(STORAGE_KEY);
+    setSession(null);
+  }, []);
+
+  const apiRequest = useCallback(
+    async <T,>(path: string, options: RequestInit = {}): Promise<T> => {
+      if (session == null) {
+        throw new ApiError('Not authenticated', 401);
+      }
+
+      try {
+        return await apiFetch<T>(path, {
+          ...options,
+          accessToken: session.accessToken,
+        });
+      } catch (error) {
+        if (!(error instanceof ApiError) || error.status !== 401) {
+          throw error;
+        }
+
+        const refreshedSession = await refreshSession(session.refreshToken);
+        saveSession(refreshedSession);
+
+        return apiFetch<T>(path, {
+          ...options,
+          accessToken: refreshedSession.accessToken,
+        });
+      }
+    },
+    [saveSession, session],
+  );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      apiRequest,
+      isAuthenticated: session != null,
+      isHydrated,
+      logout,
+      saveSession,
+      session,
+    }),
+    [apiRequest, isHydrated, logout, saveSession, session],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context == null) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+
+  return context;
+}

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import maplibregl, { type GeoJSONSource, type Map, type Marker } from 'maplibre-gl';
+import { useEffect, useRef } from 'react';
+import type { RouteWaypoint } from '@/lib/api';
+
+type Props = {
+  className?: string;
+  onChange: (waypoints: RouteWaypoint[]) => void;
+  waypoints: RouteWaypoint[];
+};
+
+const LINE_SOURCE_ID = 'route-line';
+const LINE_LAYER_ID = 'route-line';
+
+export default function RouteMapEditor({ className = 'map', onChange, waypoints }: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<Map | null>(null);
+  const markersRef = useRef<Marker[]>([]);
+  const onChangeRef = useRef(onChange);
+  const waypointsRef = useRef(waypoints);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+    waypointsRef.current = waypoints;
+  }, [onChange, waypoints]);
+
+  useEffect(() => {
+    if (containerRef.current == null || mapRef.current != null) {
+      return;
+    }
+
+    const firstWaypoint = waypointsRef.current[0];
+    const map = new maplibregl.Map({
+      center: firstWaypoint == null ? [121.5654, 25.033] : [firstWaypoint.longitude, firstWaypoint.latitude],
+      container: containerRef.current,
+      style: {
+        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+        layers: [
+          {
+            id: 'osm',
+            source: 'osm',
+            type: 'raster',
+          },
+        ],
+        sources: {
+          osm: {
+            attribution: '© OpenStreetMap contributors',
+            tileSize: 256,
+            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+            type: 'raster',
+          },
+        },
+        version: 8,
+      },
+      zoom: firstWaypoint == null ? 11 : 14,
+    });
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
+    map.on('load', () => {
+      map.addSource(LINE_SOURCE_ID, {
+        data: toLineFeature(waypointsRef.current),
+        type: 'geojson',
+      });
+      map.addLayer({
+        id: LINE_LAYER_ID,
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
+        paint: {
+          'line-color': '#26b7ee',
+          'line-width': 4,
+        },
+        source: LINE_SOURCE_ID,
+        type: 'line',
+      });
+      syncMarkers(map, markersRef.current, waypointsRef.current, onChangeRef.current);
+      fitWaypoints(map, waypointsRef.current);
+    });
+    map.on('click', (event) => {
+      onChangeRef.current([
+        ...waypointsRef.current,
+        {
+          latitude: roundCoord(event.lngLat.lat),
+          longitude: roundCoord(event.lngLat.lng),
+        },
+      ]);
+    });
+
+    mapRef.current = map;
+
+    return () => {
+      markersRef.current.forEach((marker) => marker.remove());
+      markersRef.current = [];
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    if (map.isStyleLoaded()) {
+      updateLine(map, waypoints);
+      syncMarkers(map, markersRef.current, waypoints, onChange);
+      fitWaypoints(map, waypoints);
+    } else {
+      map.once('load', () => {
+        updateLine(map, waypoints);
+        syncMarkers(map, markersRef.current, waypoints, onChange);
+        fitWaypoints(map, waypoints);
+      });
+    }
+  }, [onChange, waypoints]);
+
+  return <div className={className} ref={containerRef} />;
+}
+
+function syncMarkers(
+  map: Map,
+  existingMarkers: Marker[],
+  waypoints: RouteWaypoint[],
+  onChange: (waypoints: RouteWaypoint[]) => void,
+) {
+  existingMarkers.forEach((marker) => marker.remove());
+  existingMarkers.length = 0;
+
+  waypoints.forEach((waypoint, index) => {
+    const marker = new maplibregl.Marker({
+      color: index === 0 ? '#70e3a4' : '#55d0ff',
+      draggable: true,
+    })
+      .setLngLat([waypoint.longitude, waypoint.latitude])
+      .addTo(map);
+
+    marker.on('dragend', () => {
+      const lngLat = marker.getLngLat();
+      onChange(
+        waypoints.map((currentWaypoint, currentIndex) =>
+          currentIndex === index
+            ? {
+                ...currentWaypoint,
+                latitude: roundCoord(lngLat.lat),
+                longitude: roundCoord(lngLat.lng),
+              }
+            : currentWaypoint,
+        ),
+      );
+    });
+
+    existingMarkers.push(marker);
+  });
+}
+
+function fitWaypoints(map: Map, waypoints: RouteWaypoint[]) {
+  if (waypoints.length === 0) {
+    return;
+  }
+
+  if (waypoints.length === 1) {
+    map.easeTo({
+      center: [waypoints[0].longitude, waypoints[0].latitude],
+      duration: 350,
+      zoom: Math.max(map.getZoom(), 13),
+    });
+    return;
+  }
+
+  const bounds = waypoints.reduce(
+    (currentBounds, waypoint) => currentBounds.extend([waypoint.longitude, waypoint.latitude]),
+    new maplibregl.LngLatBounds(
+      [waypoints[0].longitude, waypoints[0].latitude],
+      [waypoints[0].longitude, waypoints[0].latitude],
+    ),
+  );
+
+  map.fitBounds(bounds, {
+    duration: 350,
+    maxZoom: 15,
+    padding: 56,
+  });
+}
+
+function updateLine(map: Map, waypoints: RouteWaypoint[]) {
+  const source = map.getSource(LINE_SOURCE_ID) as GeoJSONSource | undefined;
+
+  source?.setData(toLineFeature(waypoints));
+}
+
+function toLineFeature(waypoints: RouteWaypoint[]): GeoJSON.Feature<GeoJSON.LineString> {
+  return {
+    geometry: {
+      coordinates: waypoints.map((waypoint) => [waypoint.longitude, waypoint.latitude]),
+      type: 'LineString',
+    },
+    properties: {},
+    type: 'Feature',
+  };
+}
+
+function roundCoord(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,196 @@
+export type AuthSession = {
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    username: string;
+  };
+};
+
+export type LoginInput = {
+  password: string;
+  recoveryCode?: string;
+  totpCode?: string;
+  username: string;
+};
+
+export type Place = {
+  createdAt: string;
+  deletedAt: string | null;
+  description: string | null;
+  id: string;
+  latitude: number;
+  libraryItem: LibraryItem | null;
+  longitude: number;
+  name: string;
+  tags: string[];
+  updatedAt: string;
+};
+
+export type RouteMode = 'ONCE' | 'LOOP' | 'PING_PONG';
+
+export type RouteWaypoint = {
+  latitude: number;
+  longitude: number;
+  pauseSeconds?: number | null;
+  sequence?: number;
+  speedKmh?: number | null;
+};
+
+export type Route = {
+  createdAt: string;
+  currentRevision: {
+    createdAt: string;
+    createdBy: string;
+    defaultSpeedKmh: number;
+    id: string;
+    mode: RouteMode;
+    revisionNumber: number;
+    waypoints: RouteWaypoint[];
+  } | null;
+  defaultSpeedKmh: number;
+  deletedAt: string | null;
+  description: string | null;
+  id: string;
+  isPublic: boolean;
+  libraryItem: LibraryItem | null;
+  mode: RouteMode;
+  name: string;
+  updatedAt: string;
+};
+
+export type LibraryItem = {
+  createdAt: string;
+  deletedAt: string | null;
+  id: string;
+  kind: 'PLACE' | 'ROUTE';
+  lastUsedAt: string | null;
+  pinned: boolean;
+  placeId: string | null;
+  routeId: string | null;
+  sortOrder: number;
+  updatedAt: string;
+};
+
+export type PlaceInput = {
+  description: string | null;
+  latitude: number;
+  longitude: number;
+  name: string;
+  tags: string[];
+};
+
+export type RouteInput = {
+  defaultSpeedKmh: number;
+  description: string | null;
+  isPublic: boolean;
+  mode: RouteMode;
+  name: string;
+  waypoints: Array<{
+    latitude: number;
+    longitude: number;
+  }>;
+};
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+const API_BASE_URL = '/api/backend';
+
+export async function apiFetch<T>(
+  path: string,
+  options: RequestInit & { accessToken?: string } = {},
+): Promise<T> {
+  const { accessToken, headers, ...requestOptions } = options;
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...requestOptions,
+    headers: {
+      'content-type': 'application/json',
+      ...(accessToken == null ? {} : { authorization: `Bearer ${accessToken}` }),
+      ...headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new ApiError(await readErrorMessage(response), response.status);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+export function login(input: LoginInput) {
+  return apiFetch<AuthSession>('/auth/login', {
+    body: JSON.stringify(input),
+    method: 'POST',
+  });
+}
+
+export function refreshSession(refreshToken: string) {
+  return apiFetch<AuthSession>('/auth/refresh', {
+    body: JSON.stringify({ refreshToken }),
+    method: 'POST',
+  });
+}
+
+export function register(input: { password: string; username: string }) {
+  return apiFetch<{ nextStep: 'totp_setup'; user: { id: string; username: string } }>(
+    '/auth/register',
+    {
+      body: JSON.stringify(input),
+      method: 'POST',
+    },
+  );
+}
+
+export function setupTotp(input: { password: string; username: string }) {
+  return apiFetch<{
+    otpauthUrl: string;
+    qrCodeDataUrl: string;
+    secret: string;
+    user: { id: string; username: string };
+  }>('/auth/totp/setup', {
+    body: JSON.stringify(input),
+    method: 'POST',
+  });
+}
+
+export function verifyTotp(input: { code: string; password: string; username: string }) {
+  return apiFetch<{
+    nextStep: 'login';
+    recoveryCodes: string[];
+    user: { id: string; username: string };
+  }>('/auth/totp/verify', {
+    body: JSON.stringify(input),
+    method: 'POST',
+  });
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { message?: unknown };
+    const message = body.message;
+
+    if (Array.isArray(message)) {
+      return message.join('\n');
+    }
+
+    if (typeof message === 'string') {
+      return message;
+    }
+  } catch {
+    // Fall through to status text.
+  }
+
+  return response.statusText || `HTTP ${response.status}`;
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,0 +1,16 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  async rewrites() {
+    const apiBaseUrl = process.env.KESTREL_API_BASE_URL ?? 'http://localhost:3000';
+
+    return [
+      {
+        source: '/api/backend/:path*',
+        destination: `${apiBaseUrl}/:path*`,
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1223 @@
+{
+  "name": "kestrel-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kestrel-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "maplibre-gl": "^5.14.0",
+        "next": "^16.0.7",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.5",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
+      "integrity": "sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
+      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.6",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kestrel-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start --port 3001",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "maplibre-gl": "^5.14.0",
+    "next": "^16.0.7",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Next.js web console workspace under `web/`
- implement auth UI for register, TOTP setup, login, refresh-backed sessions, and logout
- add dashboard CRUD flows for places and routes with a MapLibre waypoint editor
- update README and Phase 4 TODO status

## Validation
- `cd web && npm run typecheck`
- `cd web && npm run build`