### PR TITLE
chore(web): add biome just recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ app/src/main/java/dev/narumi/kestrel/
 |---|---|
 | Build debug APK | `just build` |
 | Build → install → launch | `just` (or `just br`) |
-| Auto-format (Spotless + ktlint) | `just format` |
-| Verify formatting (no writes) | `just check` |
-| Detekt static analysis | `just lint` |
+| Auto-format (Spotless + ktlint + Biome) | `just format` |
+| Verify formatting / web checks (no writes) | `just check` |
+| Detekt + web static analysis | `just lint` |
 | Regenerate Detekt baseline | `just lint-baseline` |
 | Install git hooks (prek) | `just hooks` |
 | Reset app data | `just reset` |

--- a/justfile
+++ b/justfile
@@ -17,17 +17,32 @@ build:
 clean:
     JAVA_HOME="{{java_home}}" PATH="{{java_home}}/bin:$PATH" ./gradlew clean
 
-# auto-format Kotlin / xml / misc with spotless + ktlint
+# auto-format Android + web code
 format:
     JAVA_HOME="{{java_home}}" PATH="{{java_home}}/bin:$PATH" ./gradlew spotlessApply
+    just web-format
 
-# verify formatting without changing files
+# verify Android + web formatting/lint without changing files
 check:
     JAVA_HOME="{{java_home}}" PATH="{{java_home}}/bin:$PATH" ./gradlew spotlessCheck
+    just web-check
 
-# run detekt static analysis
+# run Android detekt + web linter
 lint:
     JAVA_HOME="{{java_home}}" PATH="{{java_home}}/bin:$PATH" ./gradlew detekt
+    just web-lint
+
+# auto-format web code with Biome, including safe fixes and import sorting
+web-format:
+    cd web && npm exec -- biome check --write .
+
+# verify web formatting/lint/import sorting without changing files
+web-check:
+    cd web && npm exec -- biome ci .
+
+# run web linter only
+web-lint:
+    cd web && npm exec -- biome lint .
 
 # run JVM unit tests (debug variant)
 test:

--- a/web/README.md
+++ b/web/README.md
@@ -33,6 +33,9 @@ KESTREL_API_BASE_URL=http://localhost:3000 npm run dev
 ## Validation
 
 ```bash
+just web-format
+just web-check
+just web-lint
 npm run typecheck
 npm run build
 ```

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -2,9 +2,17 @@
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '@/components/AuthProvider';
-import { ApiError, type Place, type PlaceInput, type Route, type RouteInput, type RouteMode, type RouteWaypoint } from '@/lib/api';
+import {
+  ApiError,
+  type Place,
+  type PlaceInput,
+  type Route,
+  type RouteInput,
+  type RouteMode,
+  type RouteWaypoint,
+} from '@/lib/api';
 
 const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
   ssr: false,
@@ -63,15 +71,16 @@ export default function DashboardPage() {
   }, [auth.isAuthenticated, auth.isHydrated, loadLibrary, router]);
 
   async function savePlace(input: PlaceInput) {
-    const savedPlace = selectedPlace == null
-      ? await auth.apiRequest<Place>('/places', {
-          body: JSON.stringify(input),
-          method: 'POST',
-        })
-      : await auth.apiRequest<Place>(`/places/${selectedPlace.id}`, {
-          body: JSON.stringify(input),
-          method: 'PATCH',
-        });
+    const savedPlace =
+      selectedPlace == null
+        ? await auth.apiRequest<Place>('/places', {
+            body: JSON.stringify(input),
+            method: 'POST',
+          })
+        : await auth.apiRequest<Place>(`/places/${selectedPlace.id}`, {
+            body: JSON.stringify(input),
+            method: 'PATCH',
+          });
 
     await loadLibrary();
     setSelectedPlaceId(savedPlace.id);
@@ -84,15 +93,16 @@ export default function DashboardPage() {
   }
 
   async function saveRoute(input: RouteInput) {
-    const savedRoute = selectedRoute == null
-      ? await auth.apiRequest<Route>('/routes', {
-          body: JSON.stringify(input),
-          method: 'POST',
-        })
-      : await auth.apiRequest<Route>(`/routes/${selectedRoute.id}`, {
-          body: JSON.stringify(input),
-          method: 'PATCH',
-        });
+    const savedRoute =
+      selectedRoute == null
+        ? await auth.apiRequest<Route>('/routes', {
+            body: JSON.stringify(input),
+            method: 'POST',
+          })
+        : await auth.apiRequest<Route>(`/routes/${selectedRoute.id}`, {
+            body: JSON.stringify(input),
+            method: 'PATCH',
+          });
 
     await loadLibrary();
     setSelectedRouteId(savedRoute.id);
@@ -121,7 +131,11 @@ export default function DashboardPage() {
         </div>
       </header>
 
-      {error == null ? null : <div className="error" style={{ marginBottom: '1rem' }}>{error}</div>}
+      {error == null ? null : (
+        <div className="error" style={{ marginBottom: '1rem' }}>
+          {error}
+        </div>
+      )}
 
       <section className="dashboard-grid">
         <aside className="grid">
@@ -142,7 +156,9 @@ export default function DashboardPage() {
                   onClick={() => setSelectedPlaceId(place.id)}
                 >
                   <strong>{place.name}</strong>
-                  <span className="muted">{formatCoord(place.latitude)}, {formatCoord(place.longitude)}</span>
+                  <span className="muted">
+                    {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
+                  </span>
                   <TagRow tags={place.tags} />
                 </button>
               ))}
@@ -167,7 +183,8 @@ export default function DashboardPage() {
                 >
                   <strong>{route.name}</strong>
                   <span className="muted">
-                    {route.currentRevision?.waypoints.length ?? 0} waypoints · {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
+                    {route.currentRevision?.waypoints.length ?? 0} waypoints ·{' '}
+                    {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
                   </span>
                   <span className="chip-row">
                     <span className="chip">rev {route.currentRevision?.revisionNumber ?? '—'}</span>
@@ -227,7 +244,10 @@ function PlaceEditor({
         latitude: parseNumber(latitude, 'latitude'),
         longitude: parseNumber(longitude, 'longitude'),
         name,
-        tags: tags.split(',').map((tag) => tag.trim()).filter(Boolean),
+        tags: tags
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean),
       });
     } catch (nextError) {
       setError(formatError(nextError));
@@ -247,11 +267,21 @@ function PlaceEditor({
       <div className="split">
         <label>
           Latitude
-          <input required inputMode="decimal" value={latitude} onChange={(event) => setLatitude(event.target.value)} />
+          <input
+            required
+            inputMode="decimal"
+            value={latitude}
+            onChange={(event) => setLatitude(event.target.value)}
+          />
         </label>
         <label>
           Longitude
-          <input required inputMode="decimal" value={longitude} onChange={(event) => setLongitude(event.target.value)} />
+          <input
+            required
+            inputMode="decimal"
+            value={longitude}
+            onChange={(event) => setLongitude(event.target.value)}
+          />
         </label>
       </div>
       <label>
@@ -263,9 +293,13 @@ function PlaceEditor({
         <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
       </label>
       <div className="row">
-        <button disabled={isSaving} type="submit">{isSaving ? 'Saving…' : 'Save place'}</button>
+        <button disabled={isSaving} type="submit">
+          {isSaving ? 'Saving…' : 'Save place'}
+        </button>
         {onDelete == null ? null : (
-          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>Delete</button>
+          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>
+            Delete
+          </button>
         )}
       </div>
     </form>
@@ -326,7 +360,9 @@ function RouteEditor({
     <form className="panel stack" onSubmit={submit}>
       <div className="row" style={{ justifyContent: 'space-between' }}>
         <h2>{route == null ? 'New route' : 'Route editor'}</h2>
-        {route?.currentRevision == null ? null : <span className="chip">latest revision {route.currentRevision.revisionNumber}</span>}
+        {route?.currentRevision == null ? null : (
+          <span className="chip">latest revision {route.currentRevision.revisionNumber}</span>
+        )}
       </div>
       {error == null ? null : <div className="error">{error}</div>}
       <RouteMapEditor waypoints={waypoints} onChange={setWaypoints} />
@@ -337,7 +373,12 @@ function RouteEditor({
       <div className="split">
         <label>
           Default speed (km/h)
-          <input required inputMode="decimal" value={defaultSpeedKmh} onChange={(event) => setDefaultSpeedKmh(event.target.value)} />
+          <input
+            required
+            inputMode="decimal"
+            value={defaultSpeedKmh}
+            onChange={(event) => setDefaultSpeedKmh(event.target.value)}
+          />
         </label>
         <label>
           Playback mode
@@ -349,7 +390,12 @@ function RouteEditor({
         </label>
       </div>
       <label className="row">
-        <input checked={isPublic} style={{ width: 'auto' }} type="checkbox" onChange={(event) => setIsPublic(event.target.checked)} />
+        <input
+          checked={isPublic}
+          style={{ width: 'auto' }}
+          type="checkbox"
+          onChange={(event) => setIsPublic(event.target.checked)}
+        />
         Public route
       </label>
       <label>
@@ -360,38 +406,75 @@ function RouteEditor({
       <div className="stack">
         <h3>Waypoints</h3>
         {waypoints.map((waypoint, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: waypoint rows are edited by position until drag-and-drop adds stable row ids.
           <div className="waypoint-row" key={`${index}-${waypoint.latitude}-${waypoint.longitude}`}>
             <span className="chip">#{index + 1}</span>
             <input
               inputMode="decimal"
               value={waypoint.latitude}
-              onChange={(event) => updateWaypoint(waypoints, setWaypoints, index, 'latitude', event.target.value)}
+              onChange={(event) =>
+                updateWaypoint(waypoints, setWaypoints, index, 'latitude', event.target.value)
+              }
             />
             <input
               inputMode="decimal"
               value={waypoint.longitude}
-              onChange={(event) => updateWaypoint(waypoints, setWaypoints, index, 'longitude', event.target.value)}
+              onChange={(event) =>
+                updateWaypoint(waypoints, setWaypoints, index, 'longitude', event.target.value)
+              }
             />
             <div className="row">
-              <button className="secondary" disabled={index === 0} type="button" onClick={() => moveWaypoint(waypoints, setWaypoints, index, index - 1)}>↑</button>
-              <button className="secondary" disabled={index === waypoints.length - 1} type="button" onClick={() => moveWaypoint(waypoints, setWaypoints, index, index + 1)}>↓</button>
-              <button className="danger" disabled={waypoints.length <= 2} type="button" onClick={() => setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index))}>×</button>
+              <button
+                className="secondary"
+                disabled={index === 0}
+                type="button"
+                onClick={() => moveWaypoint(waypoints, setWaypoints, index, index - 1)}
+              >
+                ↑
+              </button>
+              <button
+                className="secondary"
+                disabled={index === waypoints.length - 1}
+                type="button"
+                onClick={() => moveWaypoint(waypoints, setWaypoints, index, index + 1)}
+              >
+                ↓
+              </button>
+              <button
+                className="danger"
+                disabled={waypoints.length <= 2}
+                type="button"
+                onClick={() =>
+                  setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index))
+                }
+              >
+                ×
+              </button>
             </div>
           </div>
         ))}
         <button
           className="secondary"
           type="button"
-          onClick={() => setWaypoints([...waypoints, waypoints.at(-1) ?? { latitude: 25.033, longitude: 121.5654 }])}
+          onClick={() =>
+            setWaypoints([
+              ...waypoints,
+              waypoints.at(-1) ?? { latitude: 25.033, longitude: 121.5654 },
+            ])
+          }
         >
           Add waypoint
         </button>
       </div>
 
       <div className="row">
-        <button disabled={isSaving || waypoints.length < 2} type="submit">{isSaving ? 'Saving…' : 'Save route'}</button>
+        <button disabled={isSaving || waypoints.length < 2} type="submit">
+          {isSaving ? 'Saving…' : 'Save route'}
+        </button>
         {onDelete == null ? null : (
-          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>Delete</button>
+          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>
+            Delete
+          </button>
         )}
       </div>
     </form>
@@ -405,7 +488,11 @@ function TagRow({ tags }: { tags: string[] }) {
 
   return (
     <span className="chip-row">
-      {tags.map((tag) => <span className="chip" key={tag}>{tag}</span>)}
+      {tags.map((tag) => (
+        <span className="chip" key={tag}>
+          {tag}
+        </span>
+      ))}
     </span>
   );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -24,8 +24,7 @@ body {
 body {
   background:
     radial-gradient(circle at 20% 10%, rgb(33 91 130 / 45%), transparent 32rem),
-    radial-gradient(circle at 80% 0%, rgb(19 87 85 / 30%), transparent 28rem),
-    var(--background);
+    radial-gradient(circle at 80% 0%, rgb(19 87 85 / 30%), transparent 28rem), var(--background);
   color: var(--text);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { FormEvent, useEffect, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import { ApiError, login, register, setupTotp, verifyTotp } from '@/lib/api';
 
@@ -39,9 +40,7 @@ export default function LoginPage() {
       const session = await login({
         password,
         username,
-        ...(isRecoveryCode
-          ? { recoveryCode: oneTimeCode }
-          : { totpCode: oneTimeCode }),
+        ...(isRecoveryCode ? { recoveryCode: oneTimeCode } : { totpCode: oneTimeCode }),
       });
       auth.saveSession(session);
       router.replace('/dashboard');
@@ -149,12 +148,22 @@ export default function LoginPage() {
 
             {totpSetup == null ? (
               <p className="muted">
-                Passwords must be at least 12 characters. Registration starts TOTP setup immediately.
+                Passwords must be at least 12 characters. Registration starts TOTP setup
+                immediately.
               </p>
             ) : (
               <div className="stack">
-                <div className="success">Scan this QR code, then enter the current authenticator code.</div>
-                <img alt="TOTP QR code" className="qr" src={totpSetup.qrCodeDataUrl} />
+                <div className="success">
+                  Scan this QR code, then enter the current authenticator code.
+                </div>
+                <Image
+                  alt="TOTP QR code"
+                  className="qr"
+                  height={224}
+                  src={totpSetup.qrCodeDataUrl}
+                  unoptimized
+                  width={224}
+                />
                 <label>
                   Secret
                   <input readOnly value={totpSetup.secret} />
@@ -177,7 +186,9 @@ export default function LoginPage() {
                 <strong>Save these recovery codes now. They will not be shown again.</strong>
                 <div className="chip-row">
                   {recoveryCodes.map((code) => (
-                    <code className="chip" key={code}>{code}</code>
+                    <code className="chip" key={code}>
+                      {code}
+                    </code>
                   ))}
                 </div>
               </div>

--- a/web/biome.json
+++ b/web/biome.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "files": {
+    "includes": ["**", "!next-env.d.ts"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "vcs": {
+    "clientKind": "git",
+    "enabled": true,
+    "useIgnoreFile": true
+  }
+}

--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -2,14 +2,14 @@
 
 import {
   createContext,
+  type ReactNode,
   useCallback,
   useContext,
   useEffect,
   useMemo,
   useState,
-  type ReactNode,
 } from 'react';
-import { ApiError, apiFetch, refreshSession, type AuthSession } from '@/lib/api';
+import { ApiError, type AuthSession, apiFetch, refreshSession } from '@/lib/api';
 
 type AuthContextValue = {
   apiRequest: <T>(path: string, options?: RequestInit) => Promise<T>;

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import maplibregl, { type GeoJSONSource, type Map, type Marker } from 'maplibre-gl';
+import maplibregl, { type GeoJSONSource, type Map as MapLibreMap, type Marker } from 'maplibre-gl';
 import { useEffect, useRef } from 'react';
 import type { RouteWaypoint } from '@/lib/api';
 
@@ -15,7 +15,7 @@ const LINE_LAYER_ID = 'route-line';
 
 export default function RouteMapEditor({ className = 'map', onChange, waypoints }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<Map | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
   const onChangeRef = useRef(onChange);
   const waypointsRef = useRef(waypoints);
@@ -32,7 +32,10 @@ export default function RouteMapEditor({ className = 'map', onChange, waypoints 
 
     const firstWaypoint = waypointsRef.current[0];
     const map = new maplibregl.Map({
-      center: firstWaypoint == null ? [121.5654, 25.033] : [firstWaypoint.longitude, firstWaypoint.latitude],
+      center:
+        firstWaypoint == null
+          ? [121.5654, 25.033]
+          : [firstWaypoint.longitude, firstWaypoint.latitude],
       container: containerRef.current,
       style: {
         glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
@@ -91,7 +94,9 @@ export default function RouteMapEditor({ className = 'map', onChange, waypoints 
     mapRef.current = map;
 
     return () => {
-      markersRef.current.forEach((marker) => marker.remove());
+      markersRef.current.forEach((marker) => {
+        marker.remove();
+      });
       markersRef.current = [];
       map.remove();
       mapRef.current = null;
@@ -122,12 +127,14 @@ export default function RouteMapEditor({ className = 'map', onChange, waypoints 
 }
 
 function syncMarkers(
-  map: Map,
+  map: MapLibreMap,
   existingMarkers: Marker[],
   waypoints: RouteWaypoint[],
   onChange: (waypoints: RouteWaypoint[]) => void,
 ) {
-  existingMarkers.forEach((marker) => marker.remove());
+  existingMarkers.forEach((marker) => {
+    marker.remove();
+  });
   existingMarkers.length = 0;
 
   waypoints.forEach((waypoint, index) => {
@@ -157,7 +164,7 @@ function syncMarkers(
   });
 }
 
-function fitWaypoints(map: Map, waypoints: RouteWaypoint[]) {
+function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
   if (waypoints.length === 0) {
     return;
   }
@@ -186,7 +193,7 @@ function fitWaypoints(map: Map, waypoints: RouteWaypoint[]) {
   });
 }
 
-function updateLine(map: Map, waypoints: RouteWaypoint[]) {
+function updateLine(map: MapLibreMap, waypoints: RouteWaypoint[]) {
   const source = map.getSource(LINE_SOURCE_ID) as GeoJSONSource | undefined;
 
   source?.setData(toLineFeature(waypoints));

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,10 +14,174 @@
         "react-dom": "^19.2.1"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.15",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.15.tgz",
+      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.15",
+        "@biomejs/cli-darwin-x64": "2.4.15",
+        "@biomejs/cli-linux-arm64": "2.4.15",
+        "@biomejs/cli-linux-arm64-musl": "2.4.15",
+        "@biomejs/cli-linux-x64": "2.4.15",
+        "@biomejs/cli-linux-x64-musl": "2.4.15",
+        "@biomejs/cli-win32-arm64": "2.4.15",
+        "@biomejs/cli-win32-x64": "2.4.15"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.15.tgz",
+      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.15.tgz",
+      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.15.tgz",
+      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.15.tgz",
+      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.15.tgz",
+      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.15.tgz",
+      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.15.tgz",
+      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.15.tgz",
+      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^19.2.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.15",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add Biome config and dependency for the Next.js web workspace
- add `just web-format`, `just web-check`, and `just web-lint`
- wire root `just format`, `just check`, and `just lint` to run the web Biome tasks too
- apply the required web code/style fixes so Biome, typecheck, and build all pass

## Validation
- `just web-format`
- `just web-check`
- `just web-lint`
- `cd web && npm run typecheck`
- `cd web && npm run build`

## Note
- In this Linux environment, root Android recipes still point at the macOS Android Studio `JAVA_HOME`, so `just format`, `just check`, and `just lint` cannot be fully executed end-to-end here.
