### PR TITLE
feat(android-cloud): add auth foundation

### DIFF
--- a/.agents/docs/plan/phase-android-cloud-sync.md
+++ b/.agents/docs/plan/phase-android-cloud-sync.md
@@ -1,0 +1,239 @@
+# Phase：Android cloud sync
+
+> 此 phase 把 Android 從「只有本機 cloud-shaped library」推進到「能登入 cloud、拉下遠端 library、保存 session、顯示 sync 狀態」。
+> 本 phase 先做資料同步與登入，不做 local-only item upload、衝突解決 UI、realtime remote control。
+>
+> 長期產品藍圖見 `.agents/docs/plan/location-route-sync-platform.md`。
+
+---
+
+## 1. 動機
+
+前一個 phase 已把 Android library 形狀改成 `Place / Route / RouteRevision / LibraryItem`，但目前仍完全是 local-only：
+
+1. Web 已可編輯 place / route，但 Android 還看不到遠端資料。
+2. backend 已有 auth、library API、sync API，但 Android 尚未接線。
+3. 使用者需要在手機上登入同一帳號後，直接套用 Web 建好的 cloud route。
+4. `SyncStateEntity`、`remoteId`、`syncStatus` 已預留，現在應開始真的使用它們。
+
+---
+
+## 2. 範圍
+
+| 項目 | 是否含於本 phase |
+|---|---|
+| Android auth session storage（Keystore / encrypted storage） | ✅ |
+| username/password + TOTP / recovery code login UI | ✅ |
+| API client（auth + sync） | ✅ |
+| bootstrap 全量同步 | ✅ |
+| changes 增量同步 | ✅ |
+| sync cursor 保存 | ✅ |
+| foreground / manual refresh | ✅ |
+| deletions / cursor expired handling | ✅ |
+| UI 顯示 last synced at / sync error | ✅ |
+| Map / Favorites / Go to 使用 current revision snapshot | ✅ |
+| local-only item upload to cloud | ❌ Phase 7 |
+| conflict resolution UI | ❌ Phase 7 |
+| device state reporting | ❌ Phase 7 |
+| realtime command / remote control | ❌ Phase 8 |
+
+---
+
+## 3. 設計原則
+
+1. **Cloud 是 canonical，Android 只做 cache**
+   Room 是本機快取與 execution source，不是最終真相。
+
+2. **登入與 sync 分層**
+   auth/session、HTTP client、sync orchestration、Room upsert 分開，避免都塞進 Composable。
+
+3. **current revision snapshot 即 execution source**
+   route playback 一律讀 `Route.currentRevisionId` 對應的 waypoint snapshot；不保存歷史 revision UI。
+
+4. **local-only item 不在本 phase 自動上傳**
+   未登入或既有 local-only items 先保留在 Room；cloud sync 只拉 remote → local cache。
+
+5. **安全優先於方便**
+   refresh token 不存明文；至少要用 Keystore 保護的加密儲存。
+
+---
+
+## 4. Android package 規劃
+
+建議新增：
+
+```text
+app/src/main/java/dev/narumi/kestrel/core/cloud/
+  CloudModels.kt             -- auth / sync DTOs
+  CloudSessionStore.kt       -- Keystore-backed encrypted storage
+  CloudApiClient.kt          -- HTTP + JSON client
+  CloudAuthRepository.kt     -- login / refresh / logout facade
+  CloudSyncRepository.kt     -- bootstrap / changes orchestration
+```
+
+既有模組會擴充：
+
+```text
+core/data/Preferences.kt     -- cloud API base URL 等輕量設定
+core/library/db/LibraryDao.kt -- remoteId lookup, upsert, sync_state helpers
+feature/options/OptionsScreen.kt -- login / logout / sync status / manual refresh UI
+feature/map/MapScreen.kt / FavoritesScreen.kt -- 顯示 synced cache（大多可沿用）
+```
+
+---
+
+## 5. 資料與狀態模型
+
+### 5.1 Session storage
+
+```kotlin
+data class CloudSession(
+    val accessToken: String,
+    val accessTokenExpiresAt: Long,
+    val refreshToken: String,
+    val sessionId: String,
+    val userId: String,
+    val username: String,
+)
+```
+
+保存策略：
+
+- `refreshToken` 與 `accessToken` 一起保存，但整個 payload 先 JSON serialize 再用 Android Keystore AES-GCM 加密。
+- 儲存介質可用 SharedPreferences / DataStore 任一；本 phase 重點是 **Keystore-backed encryption**。
+- 登出時清除本機 session；remote revoke 失敗不阻止 local clear。
+
+### 5.2 Sync state
+
+`sync_state` 至少保存：
+
+```text
+cloud_sync_cursor
+cloud_last_synced_at
+cloud_last_error
+cloud_user_id
+```
+
+用途：
+
+- `cloud_sync_cursor`：下次 changes polling 起點。
+- `cloud_last_synced_at`：UI 顯示。
+- `cloud_last_error`：UI 顯示最近錯誤。
+- `cloud_user_id`：若登入帳號改變，可先清空 synced cache 再 bootstrap。
+
+---
+
+## 6. API client 行為
+
+### 6.1 auth
+
+- `POST /auth/login`
+  - username/password + `totpCode`
+  - 或 username/password + `recoveryCode`
+- `POST /auth/refresh`
+- `POST /auth/session/revoke`
+
+### 6.2 sync
+
+- `GET /sync/bootstrap`
+- `GET /sync/changes?since=<cursor>`
+
+### 6.3 refresh 策略
+
+- access token 401 → 嘗試 refresh 一次 → 成功後重試原 request。
+- refresh 失敗 → 清掉 session，UI 回到 signed-out state。
+
+---
+
+## 7. Room upsert 規則
+
+### 7.1 remote → local identity 對應
+
+所有 remote entity 用 `remoteId` 對應到本機 row：
+
+- `Place.remoteId`
+- `Route.remoteId`
+- `RouteRevision.remoteId`
+- `LibraryItem.remoteId`
+
+若找不到既有 `remoteId`：建立新的 local UUID。
+
+### 7.2 bootstrap
+
+bootstrap 是 full snapshot，因此：
+
+1. 依 `remoteId` upsert places / routes / current revisions / libraryItems。
+2. route 的 current revision waypoint 以 snapshot 為準，覆蓋本機該 revision 的 waypoint rows。
+3. 若發現 `cloud_user_id` 與本次登入 user 不同，先清空所有 `syncStatus == Synced` 的 rows，再做 bootstrap。
+4. local-only rows 保留，不自動上傳。
+
+### 7.3 changes
+
+- `UPSERT`：重新拉 payload 對應 rows 並 upsert。
+- `DELETE`：依 `entityType + remoteId` 刪除本機 synced row。
+- `SYNC_CURSOR_EXPIRED`：清掉 cursor，重新 bootstrap。
+
+---
+
+## 8. UI 規劃
+
+## 8.1 Options 頁新增 Cloud 區塊
+
+至少包含：
+
+- API base URL
+- signed out 時：username / password / TOTP or recovery code login form
+- signed in 時：username、session 狀態、last synced at、last error
+- 按鈕：Login / Logout / Sync now
+
+> MVP 先把 cloud 管理放在 Options，避免先做整頁 navigation / account center。
+
+### 8.2 foreground / manual refresh
+
+- app 啟動後若有 session 且 cursor 為空 → bootstrap
+- app 回 foreground 且已有 session → 觸發 changes sync
+- 使用者可在 Options 手動按 `Sync now`
+
+---
+
+## 9. 實作步驟（建議 PR 切法）
+
+1. **auth 基礎**
+   - `CloudSessionStore`
+   - `CloudApiClient` auth endpoints
+   - Options login/logout UI
+2. **sync bootstrap**
+   - sync DTOs
+   - Room remoteId lookup / upsert helpers
+   - bootstrap → Room + cursor / status 保存
+3. **changes sync + 狀態 UI**
+   - changes endpoint
+   - deletions / cursor expired handling
+   - foreground/manual refresh + last synced / error UI
+4. **execution 驗收**
+   - 確認 Map / Favorites / Go to 對 cloud route 讀 current revision snapshot
+
+---
+
+## 10. 風險 / 待決
+
+| 項目 | 風險 | 應對 |
+|---|---|---|
+| Android 本機沒有 HTTP client | 要選擇依賴或手寫 client | MVP 可先用 `HttpURLConnection` + kotlinx.serialization；之後再換 OkHttp/Ktor |
+| session storage 設計太重 | 引入大套加密依賴會拖慢 | 先用 Android Keystore + AES-GCM 自行封裝 |
+| synced row 與 local-only row 共存 | UI 可能出現重複概念 item | 本 phase 接受；upload / merge 留到 Phase 7 |
+| logout 後 cache 策略 | 要不要清空 synced data | 預設保留 cache 但不可 refresh；若切換 user，bootstrap 前清掉舊 synced cache |
+| route revision 多次 upsert | waypoint snapshot 與 currentRevisionId 易不一致 | transaction 內先 upsert revision / waypoints，再更新 route.currentRevisionId |
+
+---
+
+## 11. 驗收條件
+
+- [ ] 使用者可在 Android 以 username/password + TOTP 登入。
+- [ ] refresh token 以 Keystore-backed encrypted storage 保存。
+- [ ] `Sync now` 可成功 bootstrap cloud places / routes 到 Room。
+- [ ] Favorites / Go to 可看到 Web 建立的 cloud library。
+- [ ] route 會使用 cloud current revision snapshot 執行。
+- [ ] changes sync 可抓到 Web 新增 / 修改 / 刪除。
+- [ ] cursor 過期時會自動 fallback 到 bootstrap。
+- [ ] Options 頁可看到 last synced at / 最近 sync error。

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudApiClient.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudApiClient.kt
@@ -1,0 +1,188 @@
+package dev.narumi.kestrel.core.cloud
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+class CloudApiClient(
+    private val baseUrlProvider: suspend () -> String,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun loginWithTotp(
+        username: String,
+        password: String,
+        totpCode: String,
+    ): CloudSession =
+        postJson<LoginWithTotpRequest, AuthSessionResponse>(
+            path = "/auth/login",
+            body = LoginWithTotpRequest(username = username, password = password, totpCode = totpCode),
+        ).toSession()
+
+    suspend fun loginWithRecoveryCode(
+        username: String,
+        password: String,
+        recoveryCode: String,
+    ): CloudSession =
+        postJson<LoginWithRecoveryCodeRequest, AuthSessionResponse>(
+            path = "/auth/login",
+            body =
+                LoginWithRecoveryCodeRequest(
+                    username = username,
+                    password = password,
+                    recoveryCode = recoveryCode,
+                ),
+        ).toSession()
+
+    suspend fun refresh(refreshToken: String): CloudSession =
+        postJson<RefreshSessionRequest, AuthSessionResponse>(
+            path = "/auth/refresh",
+            body = RefreshSessionRequest(refreshToken = refreshToken),
+        ).toSession()
+
+    suspend fun revokeSession(accessToken: String) {
+        postWithoutBody<RevokeSessionResponse>(
+            path = "/auth/session/revoke",
+            accessToken = accessToken,
+        )
+    }
+
+    private suspend inline fun <reified Request : Any, reified Response : Any> postJson(
+        path: String,
+        body: Request,
+        accessToken: String? = null,
+    ): Response {
+        val requestBody = json.encodeToString<Request>(body)
+        return request(
+            method = "POST",
+            path = path,
+            body = requestBody,
+            accessToken = accessToken,
+        )
+    }
+
+    private suspend inline fun <reified Response : Any> postWithoutBody(
+        path: String,
+        accessToken: String? = null,
+    ): Response =
+        request(
+            method = "POST",
+            path = path,
+            body = "{}",
+            accessToken = accessToken,
+        )
+
+    private suspend inline fun <reified Response : Any> request(
+        method: String,
+        path: String,
+        body: String? = null,
+        accessToken: String? = null,
+    ): Response {
+        val url = URL(normalizedBaseUrl() + path)
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            requestMethod = method
+            connectTimeout = CONNECT_TIMEOUT_MILLIS
+            readTimeout = READ_TIMEOUT_MILLIS
+            setRequestProperty("Accept", "application/json")
+            setRequestProperty("Content-Type", "application/json; charset=utf-8")
+            if (accessToken != null) {
+                setRequestProperty("Authorization", "Bearer $accessToken")
+            }
+            doInput = true
+        }
+
+        try {
+            if (body != null) {
+                connection.doOutput = true
+                connection.outputStream.use { output ->
+                    output.write(body.toByteArray(StandardCharsets.UTF_8))
+                }
+            }
+
+            val statusCode = connection.responseCode
+            val responseBody =
+                readStream(
+                    if (statusCode in SUCCESS_STATUS_CODE_RANGE) {
+                        connection.inputStream
+                    } else {
+                        connection.errorStream
+                    },
+                )
+
+            if (statusCode !in SUCCESS_STATUS_CODE_RANGE) {
+                throw CloudApiException(
+                    statusCode = statusCode,
+                    message = responseBody.toBackendMessage(),
+                )
+            }
+
+            return json.decodeFromString<Response>(responseBody)
+        } catch (error: SerializationException) {
+            throw CloudApiException(
+                statusCode = connection.responseCode.takeIf { it > 0 } ?: 0,
+                message = error.message ?: "Failed to parse cloud response",
+            )
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private suspend fun normalizedBaseUrl(): String = baseUrlProvider().trim().trimEnd('/')
+
+    private fun AuthSessionResponse.toSession(): CloudSession =
+        CloudSession(
+            accessToken = accessToken,
+            accessTokenExpiresAt = Instant.parse(accessTokenExpiresAt).toEpochMilli(),
+            refreshToken = refreshToken,
+            sessionId = session.id,
+            userId = user.id,
+            username = user.username,
+        )
+
+    companion object {
+        private const val CONNECT_TIMEOUT_MILLIS = 15_000
+        private const val READ_TIMEOUT_MILLIS = 15_000
+        private val SUCCESS_STATUS_CODE_RANGE = 200..299
+    }
+}
+
+class CloudApiException(
+    val statusCode: Int,
+    override val message: String,
+) : IllegalStateException(message)
+
+private fun readStream(inputStream: InputStream?): String {
+    if (inputStream == null) {
+        return ""
+    }
+
+    return BufferedReader(InputStreamReader(inputStream, StandardCharsets.UTF_8)).use { reader ->
+        reader.readText()
+    }
+}
+
+private fun String.toBackendMessage(): String {
+    if (isBlank()) {
+        return "Cloud request failed"
+    }
+
+    return runCatching {
+        val root = Json.parseToJsonElement(this)
+        val message = (root as? JsonObject)?.get("message")
+
+        when (message) {
+            is JsonPrimitive -> message.content
+            is JsonArray -> message.joinToString("\n") { element -> (element as? JsonPrimitive)?.content ?: element.toString() }
+            else -> this
+        }
+    }.getOrDefault(this)
+}

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudAuthRepository.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudAuthRepository.kt
@@ -1,0 +1,70 @@
+package dev.narumi.kestrel.core.cloud
+
+import android.content.Context
+import dev.narumi.kestrel.core.data.KestrelPrefs
+
+class CloudAuthRepository private constructor(
+    context: Context,
+) {
+    private val applicationContext = context.applicationContext
+    private val prefs = KestrelPrefs(applicationContext)
+    private val sessionStore = CloudSessionStore(applicationContext)
+    private val apiClient = CloudApiClient(baseUrlProvider = { prefs.cloudSettingsValue().apiBaseUrl })
+
+    fun currentSession(): CloudSession? = sessionStore.load()
+
+    suspend fun loginWithTotp(
+        username: String,
+        password: String,
+        totpCode: String,
+    ): CloudSession {
+        val session = apiClient.loginWithTotp(username = username, password = password, totpCode = totpCode)
+        sessionStore.save(session)
+        return session
+    }
+
+    suspend fun loginWithRecoveryCode(
+        username: String,
+        password: String,
+        recoveryCode: String,
+    ): CloudSession {
+        val session =
+            apiClient.loginWithRecoveryCode(
+                username = username,
+                password = password,
+                recoveryCode = recoveryCode,
+            )
+        sessionStore.save(session)
+        return session
+    }
+
+    suspend fun refreshSession(): CloudSession? {
+        val currentSession = sessionStore.load() ?: return null
+        return runCatching {
+            apiClient.refresh(currentSession.refreshToken)
+        }.getOrNull()?.also(sessionStore::save)
+            ?: run {
+                sessionStore.clear()
+                null
+            }
+    }
+
+    suspend fun logout() {
+        val currentSession = sessionStore.load()
+        runCatching {
+            if (currentSession != null) {
+                apiClient.revokeSession(currentSession.accessToken)
+            }
+        }
+        sessionStore.clear()
+    }
+
+    companion object {
+        @Volatile private var instance: CloudAuthRepository? = null
+
+        fun getInstance(context: Context): CloudAuthRepository =
+            instance ?: synchronized(this) {
+                instance ?: CloudAuthRepository(context.applicationContext).also { instance = it }
+            }
+    }
+}

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudModels.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudModels.kt
@@ -1,0 +1,85 @@
+package dev.narumi.kestrel.core.cloud
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CloudSession(
+    val accessToken: String,
+    val accessTokenExpiresAt: Long,
+    val refreshToken: String,
+    val sessionId: String,
+    val userId: String,
+    val username: String,
+)
+
+@Serializable
+internal data class LoginWithTotpRequest(
+    val username: String,
+    val password: String,
+    val totpCode: String,
+)
+
+@Serializable
+internal data class LoginWithRecoveryCodeRequest(
+    val username: String,
+    val password: String,
+    val recoveryCode: String,
+)
+
+@Serializable
+internal data class RefreshSessionRequest(
+    val refreshToken: String,
+)
+
+@Serializable
+internal data class AuthSessionResponse(
+    val accessToken: String,
+    val accessTokenExpiresAt: String,
+    val refreshToken: String,
+    val session: SessionPayload,
+    val user: UserPayload,
+)
+
+@Serializable
+internal data class SessionPayload(
+    val id: String,
+)
+
+@Serializable
+internal data class UserPayload(
+    val id: String,
+    val username: String,
+)
+
+@Serializable
+internal data class ErrorResponse(
+    val code: String? = null,
+    val message: ErrorMessage? = null,
+)
+
+@Serializable
+internal data class RevokeSessionResponse(
+    val session: RevokedSessionPayload,
+)
+
+@Serializable
+internal data class RevokedSessionPayload(
+    val id: String,
+    val revokedAt: String,
+)
+
+@Serializable
+internal sealed interface ErrorMessage {
+    @Serializable
+    @SerialName("string")
+    data class Single(
+        val value: String,
+    ) : ErrorMessage
+
+    @Serializable
+    @SerialName("array")
+    data class Many(
+        val value: List<String>,
+    ) : ErrorMessage
+}

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSessionStore.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSessionStore.kt
@@ -1,0 +1,95 @@
+package dev.narumi.kestrel.core.cloud
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import kotlinx.serialization.json.Json
+import java.nio.charset.StandardCharsets
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class CloudSessionStore(
+    context: Context,
+) {
+    private val applicationContext = context.applicationContext
+    private val json = Json { ignoreUnknownKeys = true }
+    private val prefs = applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): CloudSession? {
+        val encodedValue = prefs.getString(KEY_SESSION, null) ?: return null
+        return runCatching {
+            json.decodeFromString(CloudSession.serializer(), decrypt(encodedValue))
+        }.getOrNull()
+    }
+
+    fun save(session: CloudSession) {
+        val encodedValue = encrypt(json.encodeToString(CloudSession.serializer(), session))
+        prefs.edit().putString(KEY_SESSION, encodedValue).apply()
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_SESSION).apply()
+    }
+
+    private fun encrypt(plainText: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+        val encryptedBytes = cipher.doFinal(plainText.toByteArray(StandardCharsets.UTF_8))
+        val iv = Base64.encodeToString(cipher.iv, Base64.NO_WRAP)
+        val ciphertext = Base64.encodeToString(encryptedBytes, Base64.NO_WRAP)
+        return "$iv:$ciphertext"
+    }
+
+    private fun decrypt(encodedValue: String): String {
+        val parts = encodedValue.split(':', limit = 2)
+        require(parts.size == 2) { "Malformed cloud session payload" }
+        val iv = Base64.decode(parts[0], Base64.NO_WRAP)
+        val cipherBytes = Base64.decode(parts[1], Base64.NO_WRAP)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            getOrCreateSecretKey(),
+            GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv),
+        )
+        return cipher.doFinal(cipherBytes).toString(StandardCharsets.UTF_8)
+    }
+
+    private fun getOrCreateSecretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+        val existingKey = (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
+
+        if (existingKey != null) {
+            return existingKey
+        }
+
+        val keyGenerator =
+            KeyGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_AES,
+                ANDROID_KEY_STORE,
+            )
+        val parameterSpec =
+            KeyGenParameterSpec
+                .Builder(
+                    KEY_ALIAS,
+                    KeyProperties.PURPOSE_DECRYPT or KeyProperties.PURPOSE_ENCRYPT,
+                ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build()
+        keyGenerator.init(parameterSpec)
+        return keyGenerator.generateKey()
+    }
+
+    companion object {
+        private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+        private const val GCM_TAG_LENGTH_BITS = 128
+        private const val KEY_ALIAS = "kestrel-cloud-session"
+        private const val KEY_SESSION = "cloud_session"
+        private const val PREFS_NAME = "kestrel_cloud_auth"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    }
+}

--- a/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
@@ -78,6 +78,15 @@ data class RandomRoutePreference(
     val usesLastSettings: Boolean get() = lastPointCount != null && lastSpacingMeters != null
 }
 
+@Serializable
+data class CloudSettings(
+    val apiBaseUrl: String = DEFAULT_API_BASE_URL,
+) {
+    companion object {
+        const val DEFAULT_API_BASE_URL = "http://10.0.2.2:3000"
+    }
+}
+
 private val Context.prefStore by preferencesDataStore("kestrel_prefs")
 
 private object Keys {
@@ -88,6 +97,7 @@ private object Keys {
     val MOCK_STATE = stringPreferencesKey("mock_state_json")
     val STARTUP_PREF = stringPreferencesKey("startup_pref_json")
     val RANDOM_ROUTE_PREF = stringPreferencesKey("random_route_pref_json")
+    val CLOUD_SETTINGS = stringPreferencesKey("cloud_settings_json")
 }
 
 class KestrelPrefs(
@@ -103,6 +113,7 @@ class KestrelPrefs(
     val startupPreference: Flow<StartupPreference> = store.data.map { it.toStartupPref(json) }
     val randomRoutePreference: Flow<RandomRoutePreference> =
         store.data.map { it.toRandomRoutePref(json) }
+    val cloudSettings: Flow<CloudSettings> = store.data.map { it.toCloudSettings(json) }
 
     suspend fun setLastCamera(snap: CameraSnapshot) {
         store.edit {
@@ -173,7 +184,20 @@ class KestrelPrefs(
         }
     }
 
+    suspend fun setCloudApiBaseUrl(apiBaseUrl: String) {
+        store.edit { prefs ->
+            val current = prefs.toCloudSettings(json)
+            prefs[Keys.CLOUD_SETTINGS] =
+                json.encodeToString(
+                    CloudSettings.serializer(),
+                    current.copy(apiBaseUrl = apiBaseUrl.trim()),
+                )
+        }
+    }
+
     suspend fun startupPreferenceValue(): StartupPreference = startupPreference.first()
+
+    suspend fun cloudSettingsValue(): CloudSettings = cloudSettings.first()
 
     private fun Preferences.toCamera(): CameraSnapshot? {
         val lat = this[Keys.LAST_CAM_LAT] ?: return null
@@ -208,5 +232,12 @@ class KestrelPrefs(
         return runCatching {
             json.decodeFromString(RandomRoutePreference.serializer(), raw)
         }.getOrDefault(RandomRoutePreference())
+    }
+
+    private fun Preferences.toCloudSettings(json: Json): CloudSettings {
+        val raw = this[Keys.CLOUD_SETTINGS] ?: return CloudSettings()
+        return runCatching {
+            json.decodeFromString(CloudSettings.serializer(), raw)
+        }.getOrDefault(CloudSettings())
     }
 }

--- a/app/src/main/java/dev/narumi/kestrel/feature/options/OptionsScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/options/OptionsScreen.kt
@@ -27,8 +27,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.narumi.kestrel.core.cloud.CloudApiException
+import dev.narumi.kestrel.core.cloud.CloudAuthRepository
+import dev.narumi.kestrel.core.cloud.CloudSession
+import dev.narumi.kestrel.core.data.CloudSettings
 import dev.narumi.kestrel.core.data.KestrelPrefs
 import dev.narumi.kestrel.core.data.RandomRoutePreference
 import dev.narumi.kestrel.core.data.StartupPreference
@@ -36,19 +41,40 @@ import dev.narumi.kestrel.core.library.LibraryItemWithContent
 import dev.narumi.kestrel.core.library.LibraryRepository
 import dev.narumi.kestrel.core.library.description
 import kotlinx.coroutines.launch
+import java.util.Date
 
 @Composable
 fun OptionsScreen(modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val prefs = remember { KestrelPrefs(context) }
+    val authRepository = remember { CloudAuthRepository.getInstance(context) }
     val libraryRepository = remember { LibraryRepository.getInstance(context) }
     val scope = rememberCoroutineScope()
 
+    val cloudSettings by prefs.cloudSettings.collectAsStateWithLifecycle(CloudSettings())
     val items by libraryRepository.items.collectAsStateWithLifecycle(emptyList())
     val startup by prefs.startupPreference.collectAsStateWithLifecycle(StartupPreference())
     val randomRoute by prefs.randomRoutePreference.collectAsStateWithLifecycle(RandomRoutePreference())
+
+    var apiBaseUrl by remember { mutableStateOf(cloudSettings.apiBaseUrl) }
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var oneTimeCode by remember { mutableStateOf("") }
+    var useRecoveryCode by remember { mutableStateOf(false) }
+    var cloudSession by remember { mutableStateOf<CloudSession?>(null) }
+    var cloudMessage by remember { mutableStateOf<String?>(null) }
+    var cloudError by remember { mutableStateOf<String?>(null) }
+    var cloudLoading by remember { mutableStateOf(false) }
     var defaultPointCount by remember { mutableStateOf("") }
     var defaultSpacingMeters by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        cloudSession = authRepository.currentSession()
+    }
+
+    LaunchedEffect(cloudSettings.apiBaseUrl) {
+        apiBaseUrl = cloudSettings.apiBaseUrl
+    }
 
     LaunchedEffect(randomRoute.defaultPointCount, randomRoute.defaultSpacingMeters) {
         defaultPointCount = randomRoute.defaultPointCount.toString()
@@ -67,6 +93,96 @@ fun OptionsScreen(modifier: Modifier = Modifier) {
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
+        CloudSettingsCard(
+            apiBaseUrl = apiBaseUrl,
+            cloudError = cloudError,
+            cloudLoading = cloudLoading,
+            cloudMessage = cloudMessage,
+            cloudSession = cloudSession,
+            onApiBaseUrlChange = { apiBaseUrl = it },
+            onLogin = {
+                scope.launch {
+                    cloudLoading = true
+                    cloudError = null
+                    cloudMessage = null
+                    try {
+                        val session =
+                            if (useRecoveryCode) {
+                                authRepository.loginWithRecoveryCode(
+                                    username = username,
+                                    password = password,
+                                    recoveryCode = oneTimeCode,
+                                )
+                            } else {
+                                authRepository.loginWithTotp(
+                                    username = username,
+                                    password = password,
+                                    totpCode = oneTimeCode,
+                                )
+                            }
+                        cloudSession = session
+                        cloudMessage = "Signed in as ${session.username}"
+                        oneTimeCode = ""
+                    } catch (error: Exception) {
+                        cloudError = error.toCloudErrorMessage()
+                    } finally {
+                        cloudLoading = false
+                    }
+                }
+            },
+            onLogout = {
+                scope.launch {
+                    cloudLoading = true
+                    cloudError = null
+                    cloudMessage = null
+                    try {
+                        authRepository.logout()
+                        cloudSession = null
+                        cloudMessage = "Signed out"
+                    } catch (error: Exception) {
+                        cloudError = error.toCloudErrorMessage()
+                    } finally {
+                        cloudLoading = false
+                    }
+                }
+            },
+            onPasswordChange = { password = it },
+            onRefreshSession = {
+                scope.launch {
+                    cloudLoading = true
+                    cloudError = null
+                    cloudMessage = null
+                    try {
+                        val refreshedSession = authRepository.refreshSession()
+                        cloudSession = refreshedSession
+                        if (refreshedSession == null) {
+                            cloudError = "Session expired. Please sign in again."
+                        } else {
+                            cloudMessage = "Session refreshed"
+                        }
+                    } catch (error: Exception) {
+                        cloudError = error.toCloudErrorMessage()
+                    } finally {
+                        cloudLoading = false
+                    }
+                }
+            },
+            onSaveApiBaseUrl = {
+                scope.launch {
+                    prefs.setCloudApiBaseUrl(apiBaseUrl)
+                    cloudMessage = "Saved API base URL"
+                    cloudError = null
+                }
+            },
+            onToggleRecoveryCode = { useRecoveryCode = it },
+            onUsernameChange = { username = it },
+            onOneTimeCodeChange = { oneTimeCode = it },
+            oneTimeCode = oneTimeCode,
+            password = password,
+            useRecoveryCode = useRecoveryCode,
+            username = username,
+        )
+
         StartupPreferenceCard(
             items = items,
             startup = startup,
@@ -104,6 +220,117 @@ fun OptionsScreen(modifier: Modifier = Modifier) {
                 )
             },
         )
+    }
+}
+
+@Composable
+private fun CloudSettingsCard(
+    apiBaseUrl: String,
+    cloudError: String?,
+    cloudLoading: Boolean,
+    cloudMessage: String?,
+    cloudSession: CloudSession?,
+    username: String,
+    password: String,
+    oneTimeCode: String,
+    useRecoveryCode: Boolean,
+    onApiBaseUrlChange: (String) -> Unit,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onOneTimeCodeChange: (String) -> Unit,
+    onToggleRecoveryCode: (Boolean) -> Unit,
+    onSaveApiBaseUrl: () -> Unit,
+    onLogin: () -> Unit,
+    onRefreshSession: () -> Unit,
+    onLogout: () -> Unit,
+) {
+    Text(
+        text = "Cloud sync (Phase 5 foundation)",
+        style = MaterialTheme.typography.titleMedium,
+    )
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedTextField(
+                value = apiBaseUrl,
+                onValueChange = onApiBaseUrlChange,
+                label = { Text("API base URL") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedButton(onClick = onSaveApiBaseUrl) { Text("Save API URL") }
+
+            if (cloudSession == null) {
+                OutlinedTextField(
+                    value = username,
+                    onValueChange = onUsernameChange,
+                    label = { Text("Username") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = onPasswordChange,
+                    label = { Text("Password") },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = oneTimeCode,
+                    onValueChange = onOneTimeCodeChange,
+                    label = { Text(if (useRecoveryCode) "Recovery code" else "TOTP code") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                StartupRadioRow(
+                    label = "Use recovery code instead of TOTP",
+                    selected = useRecoveryCode,
+                    onSelect = { onToggleRecoveryCode(!useRecoveryCode) },
+                )
+                Button(
+                    onClick = onLogin,
+                    enabled = !cloudLoading && username.isNotBlank() && password.isNotBlank() && oneTimeCode.isNotBlank(),
+                ) {
+                    Text(if (cloudLoading) "Signing in…" else "Sign in")
+                }
+            } else {
+                Text(
+                    text = "Signed in as ${cloudSession.username}",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = "Access token expires at ${Date(cloudSession.accessTokenExpiresAt)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = onRefreshSession, enabled = !cloudLoading) {
+                        Text("Refresh session")
+                    }
+                    OutlinedButton(onClick = onLogout, enabled = !cloudLoading) {
+                        Text("Sign out")
+                    }
+                }
+            }
+
+            cloudMessage?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            cloudError?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
     }
 }
 
@@ -272,6 +499,12 @@ private fun formatDistance(meters: Double): String =
         "%.1f km".format(meters / 1000.0)
     } else {
         "${formatMeters(meters)} m"
+    }
+
+private fun Exception.toCloudErrorMessage(): String =
+    when (this) {
+        is CloudApiException -> message
+        else -> message ?: "Unexpected cloud error"
     }
 
 @Composable


### PR DESCRIPTION
## Summary
- add a Phase 5 Android cloud sync plan document
- add Android cloud auth foundation types, API client, auth repository, and Keystore-backed session storage
- extend DataStore preferences with cloud API base URL settings
- add an Options screen cloud card for API URL, username/password + TOTP or recovery-code login, refresh session, and sign out

## Validation
- not run: Android build / lint / detekt could not be executed in this environment because Java / Android Studio JBR is unavailable