### PR TITLE
feat(android): add cloud library sync

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:usesCleartextTraffic="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
@@ -15,19 +15,27 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import dev.narumi.kestrel.core.cloud.CloudSyncRepository
 import dev.narumi.kestrel.core.library.LibraryItemWithContent
 import dev.narumi.kestrel.feature.favorites.FavoritesScreen
 import dev.narumi.kestrel.feature.map.MapScreen
 import dev.narumi.kestrel.feature.options.OptionsScreen
 import dev.narumi.kestrel.ui.theme.KestrelTheme
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,6 +54,25 @@ class MainActivity : ComponentActivity() {
 fun KestrelApp() {
     var currentDestination by rememberSaveable { mutableStateOf(AppDestinations.HOME) }
     var pendingFavoriteApply by remember { mutableStateOf<LibraryItemWithContent?>(null) }
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val scope = rememberCoroutineScope()
+    val syncRepository = remember { CloudSyncRepository.getInstance(context) }
+
+    DisposableEffect(lifecycleOwner, syncRepository) {
+        val observer =
+            object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) {
+                    scope.launch {
+                        syncRepository.syncOnForeground()
+                    }
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     NavigationSuiteScaffold(
         navigationSuiteItems = {

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudApiClient.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudApiClient.kt
@@ -1,10 +1,10 @@
 package dev.narumi.kestrel.core.cloud
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -56,12 +56,27 @@ class CloudApiClient(
         )
     }
 
+    internal suspend fun bootstrap(accessToken: String): CloudBootstrapResponse =
+        getJson(
+            path = "/sync/bootstrap",
+            accessToken = accessToken,
+        )
+
+    internal suspend fun getChanges(
+        accessToken: String,
+        since: String,
+    ): CloudChangesResponse =
+        getJson(
+            path = "/sync/changes?since=$since",
+            accessToken = accessToken,
+        )
+
     private suspend inline fun <reified Request : Any, reified Response : Any> postJson(
         path: String,
         body: Request,
         accessToken: String? = null,
     ): Response {
-        val requestBody = json.encodeToString<Request>(body)
+        val requestBody = json.encodeToString(body)
         return request(
             method = "POST",
             path = path,
@@ -81,60 +96,75 @@ class CloudApiClient(
             accessToken = accessToken,
         )
 
+    private suspend inline fun <reified Response : Any> getJson(
+        path: String,
+        accessToken: String? = null,
+    ): Response =
+        request(
+            method = "GET",
+            path = path,
+            accessToken = accessToken,
+        )
+
     private suspend inline fun <reified Response : Any> request(
         method: String,
         path: String,
         body: String? = null,
         accessToken: String? = null,
-    ): Response {
-        val url = URL(normalizedBaseUrl() + path)
-        val connection = (url.openConnection() as HttpURLConnection).apply {
-            requestMethod = method
-            connectTimeout = CONNECT_TIMEOUT_MILLIS
-            readTimeout = READ_TIMEOUT_MILLIS
-            setRequestProperty("Accept", "application/json")
-            setRequestProperty("Content-Type", "application/json; charset=utf-8")
-            if (accessToken != null) {
-                setRequestProperty("Authorization", "Bearer $accessToken")
-            }
-            doInput = true
-        }
-
-        try {
-            if (body != null) {
-                connection.doOutput = true
-                connection.outputStream.use { output ->
-                    output.write(body.toByteArray(StandardCharsets.UTF_8))
+    ): Response =
+        withContext(Dispatchers.IO) {
+            val url = URL(normalizedBaseUrl() + path)
+            val connection =
+                (url.openConnection() as HttpURLConnection).apply {
+                    requestMethod = method
+                    connectTimeout = CONNECT_TIMEOUT_MILLIS
+                    readTimeout = READ_TIMEOUT_MILLIS
+                    setRequestProperty("Accept", "application/json")
+                    setRequestProperty("Content-Type", "application/json; charset=utf-8")
+                    if (accessToken != null) {
+                        setRequestProperty("Authorization", "Bearer $accessToken")
+                    }
+                    doInput = true
                 }
-            }
 
-            val statusCode = connection.responseCode
-            val responseBody =
-                readStream(
-                    if (statusCode in SUCCESS_STATUS_CODE_RANGE) {
-                        connection.inputStream
-                    } else {
-                        connection.errorStream
-                    },
-                )
+            try {
+                if (body != null) {
+                    connection.doOutput = true
+                    connection.outputStream.use { output ->
+                        output.write(body.toByteArray(StandardCharsets.UTF_8))
+                    }
+                }
 
-            if (statusCode !in SUCCESS_STATUS_CODE_RANGE) {
+                val statusCode = connection.responseCode
+                val responseBody =
+                    readStream(
+                        if (statusCode in SUCCESS_STATUS_CODE_RANGE) {
+                            connection.inputStream
+                        } else {
+                            connection.errorStream
+                        },
+                    )
+
+                if (statusCode !in SUCCESS_STATUS_CODE_RANGE) {
+                    val errorResponse = responseBody.toErrorResponse(json)
+                    throw CloudApiException(
+                        statusCode = statusCode,
+                        code = errorResponse?.code,
+                        message = errorResponse?.message ?: responseBody.ifBlank { "Cloud request failed" },
+                    )
+                }
+
+                return@withContext json.decodeFromString<Response>(responseBody)
+            } catch (error: SerializationException) {
                 throw CloudApiException(
-                    statusCode = statusCode,
-                    message = responseBody.toBackendMessage(),
+                    statusCode = connection.responseCode.takeIf { it > 0 } ?: 0,
+                    message = error.message ?: "Failed to parse cloud response",
+                    cause = error,
                 )
+            } finally {
+                connection.disconnect()
             }
-
-            return json.decodeFromString<Response>(responseBody)
-        } catch (error: SerializationException) {
-            throw CloudApiException(
-                statusCode = connection.responseCode.takeIf { it > 0 } ?: 0,
-                message = error.message ?: "Failed to parse cloud response",
-            )
-        } finally {
-            connection.disconnect()
         }
-    }
 
     private suspend fun normalizedBaseUrl(): String = baseUrlProvider().trim().trimEnd('/')
 
@@ -157,8 +187,10 @@ class CloudApiClient(
 
 class CloudApiException(
     val statusCode: Int,
+    val code: String? = null,
     override val message: String,
-) : IllegalStateException(message)
+    cause: Throwable? = null,
+) : IllegalStateException(message, cause)
 
 private fun readStream(inputStream: InputStream?): String {
     if (inputStream == null) {
@@ -170,19 +202,12 @@ private fun readStream(inputStream: InputStream?): String {
     }
 }
 
-private fun String.toBackendMessage(): String {
+private fun String.toErrorResponse(json: Json): ErrorResponse? {
     if (isBlank()) {
-        return "Cloud request failed"
+        return null
     }
 
     return runCatching {
-        val root = Json.parseToJsonElement(this)
-        val message = (root as? JsonObject)?.get("message")
-
-        when (message) {
-            is JsonPrimitive -> message.content
-            is JsonArray -> message.joinToString("\n") { element -> (element as? JsonPrimitive)?.content ?: element.toString() }
-            else -> this
-        }
-    }.getOrDefault(this)
+        json.decodeFromString<ErrorResponse>(this)
+    }.getOrNull()
 }

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudModels.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudModels.kt
@@ -1,6 +1,5 @@
 package dev.narumi.kestrel.core.cloud
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -53,9 +52,107 @@ internal data class UserPayload(
 )
 
 @Serializable
+internal data class CloudBootstrapResponse(
+    val places: List<CloudPlacePayload> = emptyList(),
+    val routes: List<CloudRoutePayload> = emptyList(),
+    val libraryItems: List<CloudLibraryItemPayload> = emptyList(),
+    val syncCursor: String,
+    val serverTime: String,
+)
+
+@Serializable
+internal data class CloudChangesResponse(
+    val places: List<CloudPlacePayload> = emptyList(),
+    val routes: List<CloudRoutePayload> = emptyList(),
+    val libraryItems: List<CloudLibraryItemPayload> = emptyList(),
+    val deletions: List<CloudDeletionPayload> = emptyList(),
+    val nextCursor: String,
+    val serverTime: String,
+)
+
+@Serializable
+internal data class CloudPlacePayload(
+    val createdAt: String,
+    val deletedAt: String? = null,
+    val description: String? = null,
+    val id: String,
+    val libraryItem: CloudLibraryItemPayload? = null,
+    val latitude: Double,
+    val longitude: Double,
+    val name: String,
+    val tags: List<String> = emptyList(),
+    val updatedAt: String,
+)
+
+@Serializable
+internal data class CloudRoutePayload(
+    val createdAt: String,
+    val currentRevision: CloudRouteRevisionPayload? = null,
+    val defaultSpeedKmh: Double,
+    val deletedAt: String? = null,
+    val description: String? = null,
+    val id: String,
+    val isPublic: Boolean = false,
+    val libraryItem: CloudLibraryItemPayload? = null,
+    val mode: CloudRouteMode,
+    val name: String,
+    val updatedAt: String,
+)
+
+@Serializable
+internal data class CloudRouteRevisionPayload(
+    val createdAt: String,
+    val createdBy: String,
+    val defaultSpeedKmh: Double,
+    val id: String,
+    val mode: CloudRouteMode,
+    val revisionNumber: Int,
+    val waypoints: List<CloudWaypointPayload> = emptyList(),
+)
+
+@Serializable
+internal data class CloudWaypointPayload(
+    val latitude: Double,
+    val longitude: Double,
+    val pauseSeconds: Double? = null,
+    val sequence: Int = 0,
+    val speedKmh: Double? = null,
+)
+
+@Serializable
+internal data class CloudLibraryItemPayload(
+    val createdAt: String,
+    val deletedAt: String? = null,
+    val id: String,
+    val kind: CloudLibraryItemKind,
+    val lastUsedAt: String? = null,
+    val pinned: Boolean = false,
+    val placeId: String? = null,
+    val routeId: String? = null,
+    val sortOrder: Int,
+    val updatedAt: String,
+)
+
+@Serializable
+internal data class CloudDeletionPayload(
+    val deletedAt: String? = null,
+    val entityId: String,
+    val entityType: CloudSyncEntityType,
+)
+
+@Serializable
+internal enum class CloudLibraryItemKind { PLACE, ROUTE }
+
+@Serializable
+internal enum class CloudRouteMode { ONCE, LOOP, PING_PONG }
+
+@Serializable
+internal enum class CloudSyncEntityType { PLACE, ROUTE, ROUTE_REVISION, LIBRARY_ITEM, DEVICE_STATE }
+
+@Serializable
 internal data class ErrorResponse(
     val code: String? = null,
-    val message: ErrorMessage? = null,
+    val message: String? = null,
 )
 
 @Serializable
@@ -68,18 +165,3 @@ internal data class RevokedSessionPayload(
     val id: String,
     val revokedAt: String,
 )
-
-@Serializable
-internal sealed interface ErrorMessage {
-    @Serializable
-    @SerialName("string")
-    data class Single(
-        val value: String,
-    ) : ErrorMessage
-
-    @Serializable
-    @SerialName("array")
-    data class Many(
-        val value: List<String>,
-    ) : ErrorMessage
-}

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudRouteSyncRows.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudRouteSyncRows.kt
@@ -1,0 +1,108 @@
+package dev.narumi.kestrel.core.cloud
+
+import dev.narumi.kestrel.core.library.LibraryItemKind
+import dev.narumi.kestrel.core.library.db.LibraryItemEntity
+import dev.narumi.kestrel.core.library.db.PlaceEntity
+import dev.narumi.kestrel.core.library.db.RouteEntity
+import dev.narumi.kestrel.core.library.db.RouteRevisionEntity
+import dev.narumi.kestrel.core.library.db.SyncStatus
+import dev.narumi.kestrel.core.library.db.WaypointEntity
+import java.time.Instant
+
+internal data class CloudRouteSyncRows(
+    val route: RouteEntity,
+    val revision: RouteRevisionEntity,
+    val waypoints: List<WaypointEntity>,
+)
+
+internal fun CloudPlacePayload.toPlaceEntity(localId: String): PlaceEntity =
+    PlaceEntity(
+        id = localId,
+        remoteId = id,
+        name = name,
+        lat = latitude,
+        lng = longitude,
+        description = description,
+        tags = tags,
+        syncStatus = SyncStatus.Synced,
+        createdAt = createdAt.toEpochMillis(),
+        updatedAt = updatedAt.toEpochMillis(),
+    )
+
+internal fun CloudRoutePayload.toRouteSyncRows(
+    routeId: String,
+    revisionId: String,
+    waypointIdFactory: () -> String,
+): CloudRouteSyncRows {
+    val currentRevision = checkNotNull(currentRevision) { "Cloud route $id is missing current revision" }
+    return CloudRouteSyncRows(
+        route =
+            RouteEntity(
+                id = routeId,
+                remoteId = id,
+                name = name,
+                description = description,
+                defaultSpeedKmh = currentRevision.defaultSpeedKmh,
+                mode = currentRevision.mode.toLocalMode(),
+                currentRevisionId = revisionId,
+                syncStatus = SyncStatus.Synced,
+                createdAt = createdAt.toEpochMillis(),
+                updatedAt = updatedAt.toEpochMillis(),
+            ),
+        revision =
+            RouteRevisionEntity(
+                id = revisionId,
+                remoteId = currentRevision.id,
+                routeId = routeId,
+                revisionNumber = currentRevision.revisionNumber,
+                createdAt = currentRevision.createdAt.toEpochMillis(),
+            ),
+        waypoints =
+            currentRevision.waypoints
+                .sortedBy(CloudWaypointPayload::sequence)
+                .map { waypoint ->
+                    WaypointEntity(
+                        id = waypointIdFactory(),
+                        routeRevisionId = revisionId,
+                        sequence = waypoint.sequence,
+                        lat = waypoint.latitude,
+                        lng = waypoint.longitude,
+                        speedKmh = waypoint.speedKmh,
+                        pauseSeconds = waypoint.pauseSeconds,
+                    )
+                },
+    )
+}
+
+internal fun CloudLibraryItemPayload.toLibraryItemEntity(
+    localId: String,
+    localPlaceId: String?,
+    localRouteId: String?,
+): LibraryItemEntity =
+    LibraryItemEntity(
+        id = localId,
+        remoteId = id,
+        kind = kind.toLocalKind(),
+        placeId = localPlaceId,
+        routeId = localRouteId,
+        sortOrder = sortOrder,
+        lastUsedAt = lastUsedAt?.toEpochMillis(),
+        syncStatus = SyncStatus.Synced,
+        createdAt = createdAt.toEpochMillis(),
+        updatedAt = updatedAt.toEpochMillis(),
+    )
+
+internal fun CloudRouteMode.toLocalMode(): String =
+    when (this) {
+        CloudRouteMode.ONCE -> "Once"
+        CloudRouteMode.LOOP -> "Loop"
+        CloudRouteMode.PING_PONG -> "PingPong"
+    }
+
+internal fun CloudLibraryItemKind.toLocalKind(): LibraryItemKind =
+    when (this) {
+        CloudLibraryItemKind.PLACE -> LibraryItemKind.Place
+        CloudLibraryItemKind.ROUTE -> LibraryItemKind.Route
+    }
+
+internal fun String.toEpochMillis(): Long = Instant.parse(this).toEpochMilli()

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
@@ -1,0 +1,370 @@
+package dev.narumi.kestrel.core.cloud
+
+import android.content.Context
+import androidx.room.withTransaction
+import dev.narumi.kestrel.core.data.KestrelPrefs
+import dev.narumi.kestrel.core.library.db.KestrelDatabase
+import dev.narumi.kestrel.core.library.db.LibraryDao
+import dev.narumi.kestrel.core.library.db.SyncStateEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.IOException
+import java.util.UUID
+
+private val CLOUD_SYNC_STATE_KEYS =
+    listOf(
+        SyncStateKeys.CURSOR,
+        SyncStateKeys.LAST_SYNCED_AT,
+        SyncStateKeys.LAST_ERROR,
+        SyncStateKeys.USER_ID,
+    )
+
+data class CloudSyncState(
+    val cursor: String? = null,
+    val lastSyncedAt: Long? = null,
+    val lastError: String? = null,
+    val userId: String? = null,
+)
+
+class CloudSyncRepository private constructor(
+    context: Context,
+) {
+    private val applicationContext = context.applicationContext
+    private val database = KestrelDatabase.getInstance(applicationContext)
+    private val dao: LibraryDao = database.libraryDao()
+    private val prefs = KestrelPrefs(applicationContext)
+    private val authRepository = CloudAuthRepository.getInstance(applicationContext)
+    private val apiClient = CloudApiClient(baseUrlProvider = { prefs.cloudSettingsValue().apiBaseUrl })
+    private val syncMutex = Mutex()
+
+    val syncState: Flow<CloudSyncState> =
+        dao.observeSyncStates(CLOUD_SYNC_STATE_KEYS).map { states -> states.toCloudSyncState() }
+
+    suspend fun syncNow() {
+        syncMutex.withLock {
+            val failure = runCatching { syncInternal() }.exceptionOrNull()
+            if (failure != null) {
+                handleSyncFailure(failure)
+            }
+        }
+    }
+
+    suspend fun syncOnForeground() {
+        if (authRepository.currentSession() == null) {
+            return
+        }
+
+        runCatching {
+            syncNow()
+        }
+    }
+
+    private suspend fun syncInternal() {
+        val state = loadSyncState()
+        if (state.cursor == null) {
+            bootstrap()
+        } else {
+            changes(state.cursor)
+        }
+    }
+
+    private suspend fun bootstrap() {
+        val session = requireSession()
+        val response = withAuthorizedSession { apiClient.bootstrap(it.accessToken) }
+        database.withTransaction {
+            val existingState = loadSyncState()
+            if (existingState.userId != null && existingState.userId != session.userId) {
+                clearAllSyncedRows()
+            }
+
+            val resolvedPlaceIds = mutableMapOf<String, String>()
+            val resolvedRouteIds = mutableMapOf<String, String>()
+            val routeRows = mutableListOf<CloudRouteSyncRows>()
+
+            val placeEntities =
+                response.places.map { place ->
+                    val localId = dao.findPlaceIdByRemoteId(place.id) ?: randomUuid()
+                    resolvedPlaceIds[place.id] = localId
+                    place.toPlaceEntity(localId)
+                }
+            if (placeEntities.isNotEmpty()) {
+                dao.upsertPlaces(placeEntities)
+            }
+
+            response.routes.forEach { route ->
+                val currentRevision = route.currentRevision ?: return@forEach
+                val localRouteId = dao.findRouteIdByRemoteId(route.id) ?: randomUuid()
+                val localRevisionId = dao.findRouteRevisionIdByRemoteId(currentRevision.id) ?: randomUuid()
+                resolvedRouteIds[route.id] = localRouteId
+                routeRows +=
+                    route.toRouteSyncRows(
+                        routeId = localRouteId,
+                        revisionId = localRevisionId,
+                        waypointIdFactory = ::randomUuid,
+                    )
+            }
+            upsertRouteRows(routeRows)
+
+            val libraryItemEntities =
+                response.libraryItems.map { item ->
+                    val localId = dao.findLibraryItemIdByRemoteId(item.id) ?: randomUuid()
+                    item.toLibraryItemEntity(
+                        localId = localId,
+                        localPlaceId = resolveLocalPlaceId(item.placeId, resolvedPlaceIds),
+                        localRouteId = resolveLocalRouteId(item.routeId, resolvedRouteIds),
+                    )
+                }
+            if (libraryItemEntities.isNotEmpty()) {
+                dao.upsertLibraryItems(libraryItemEntities)
+            }
+
+            pruneMissingSyncedRows(
+                placeRemoteIds = response.places.map(CloudPlacePayload::id),
+                routeRemoteIds = response.routes.map(CloudRoutePayload::id),
+                routeRevisionRemoteIds = response.routes.mapNotNull { it.currentRevision?.id },
+                libraryItemRemoteIds = response.libraryItems.map(CloudLibraryItemPayload::id),
+            )
+            storeSyncSuccess(
+                cursor = response.syncCursor,
+                serverTime = response.serverTime,
+                userId = session.userId,
+            )
+        }
+    }
+
+    private suspend fun changes(cursor: String) {
+        val session = requireSession()
+        try {
+            val response = withAuthorizedSession { apiClient.getChanges(it.accessToken, cursor) }
+            database.withTransaction {
+                val resolvedPlaceIds = mutableMapOf<String, String>()
+                val resolvedRouteIds = mutableMapOf<String, String>()
+
+                val placeEntities =
+                    response.places.map { place ->
+                        val localId = dao.findPlaceIdByRemoteId(place.id) ?: randomUuid()
+                        resolvedPlaceIds[place.id] = localId
+                        place.toPlaceEntity(localId)
+                    }
+                if (placeEntities.isNotEmpty()) {
+                    dao.upsertPlaces(placeEntities)
+                }
+
+                val routeRows = mutableListOf<CloudRouteSyncRows>()
+                response.routes.forEach { route ->
+                    val currentRevision = route.currentRevision ?: return@forEach
+                    val localRouteId = dao.findRouteIdByRemoteId(route.id) ?: randomUuid()
+                    val localRevisionId = dao.findRouteRevisionIdByRemoteId(currentRevision.id) ?: randomUuid()
+                    resolvedRouteIds[route.id] = localRouteId
+                    routeRows +=
+                        route.toRouteSyncRows(
+                            routeId = localRouteId,
+                            revisionId = localRevisionId,
+                            waypointIdFactory = ::randomUuid,
+                        )
+                }
+                upsertRouteRows(routeRows)
+
+                val libraryItemEntities =
+                    response.libraryItems.map { item ->
+                        val localId = dao.findLibraryItemIdByRemoteId(item.id) ?: randomUuid()
+                        item.toLibraryItemEntity(
+                            localId = localId,
+                            localPlaceId = resolveLocalPlaceId(item.placeId, resolvedPlaceIds),
+                            localRouteId = resolveLocalRouteId(item.routeId, resolvedRouteIds),
+                        )
+                    }
+                if (libraryItemEntities.isNotEmpty()) {
+                    dao.upsertLibraryItems(libraryItemEntities)
+                }
+
+                response.deletions.forEach { deletion ->
+                    when (deletion.entityType) {
+                        CloudSyncEntityType.PLACE -> dao.deletePlaceByRemoteId(deletion.entityId)
+                        CloudSyncEntityType.ROUTE -> dao.deleteRouteByRemoteId(deletion.entityId)
+                        CloudSyncEntityType.ROUTE_REVISION -> dao.deleteRouteRevisionByRemoteId(deletion.entityId)
+                        CloudSyncEntityType.LIBRARY_ITEM -> dao.deleteLibraryItemByRemoteId(deletion.entityId)
+                        CloudSyncEntityType.DEVICE_STATE -> Unit
+                    }
+                }
+
+                storeSyncSuccess(
+                    cursor = response.nextCursor,
+                    serverTime = response.serverTime,
+                    userId = session.userId,
+                )
+            }
+        } catch (error: CloudApiException) {
+            if (error.statusCode == 410 && error.code == SYNC_CURSOR_EXPIRED_CODE) {
+                database.withTransaction {
+                    dao.deleteSyncState(SyncStateKeys.CURSOR)
+                }
+                bootstrap()
+                return
+            }
+            throw error
+        }
+    }
+
+    private suspend fun upsertRouteRows(routeRows: List<CloudRouteSyncRows>) {
+        if (routeRows.isEmpty()) {
+            return
+        }
+
+        routeRows.forEach { rows ->
+            dao.upsertRoutes(listOf(rows.route))
+            dao.upsertRouteRevisions(listOf(rows.revision))
+            dao.deleteWaypointsForRouteRevision(rows.revision.id)
+            if (rows.waypoints.isNotEmpty()) {
+                dao.insertWaypoints(rows.waypoints)
+            }
+            dao.deleteSyncedRouteRevisionsForRouteExcept(rows.route.id, rows.revision.id)
+        }
+    }
+
+    private suspend fun clearAllSyncedRows() {
+        dao.deleteAllSyncedLibraryItems()
+        dao.deleteAllSyncedPlaces()
+        dao.deleteAllSyncedRoutes()
+        dao.deleteAllSyncedRouteRevisions()
+    }
+
+    private suspend fun pruneMissingSyncedRows(
+        placeRemoteIds: List<String>,
+        routeRemoteIds: List<String>,
+        routeRevisionRemoteIds: List<String>,
+        libraryItemRemoteIds: List<String>,
+    ) {
+        if (libraryItemRemoteIds.isEmpty()) {
+            dao.deleteAllSyncedLibraryItems()
+        } else {
+            dao.deleteSyncedLibraryItemsNotIn(libraryItemRemoteIds)
+        }
+
+        if (placeRemoteIds.isEmpty()) {
+            dao.deleteAllSyncedPlaces()
+        } else {
+            dao.deleteSyncedPlacesNotIn(placeRemoteIds)
+        }
+
+        if (routeRemoteIds.isEmpty()) {
+            dao.deleteAllSyncedRoutes()
+        } else {
+            dao.deleteSyncedRoutesNotIn(routeRemoteIds)
+        }
+
+        if (routeRevisionRemoteIds.isEmpty()) {
+            dao.deleteAllSyncedRouteRevisions()
+        } else {
+            dao.deleteSyncedRouteRevisionsNotIn(routeRevisionRemoteIds)
+        }
+    }
+
+    private suspend fun resolveLocalPlaceId(
+        remoteId: String?,
+        resolvedPlaceIds: Map<String, String>,
+    ): String? {
+        if (remoteId == null) {
+            return null
+        }
+
+        return resolvedPlaceIds[remoteId]
+            ?: dao.findPlaceIdByRemoteId(remoteId)
+            ?: error("Missing local place for remote id $remoteId")
+    }
+
+    private suspend fun resolveLocalRouteId(
+        remoteId: String?,
+        resolvedRouteIds: Map<String, String>,
+    ): String? {
+        if (remoteId == null) {
+            return null
+        }
+
+        return resolvedRouteIds[remoteId]
+            ?: dao.findRouteIdByRemoteId(remoteId)
+            ?: error("Missing local route for remote id $remoteId")
+    }
+
+    private suspend fun <T> withAuthorizedSession(block: suspend (CloudSession) -> T): T {
+        val currentSession = requireSession()
+        return try {
+            block(currentSession)
+        } catch (error: CloudApiException) {
+            if (error.statusCode != 401) {
+                throw error
+            }
+            val refreshedSession = authRepository.refreshSession() ?: error("Session expired. Please sign in again.")
+            block(refreshedSession)
+        }
+    }
+
+    private fun requireSession(): CloudSession = authRepository.currentSession() ?: error("Not signed in")
+
+    private suspend fun loadSyncState(): CloudSyncState = dao.getSyncStates(CLOUD_SYNC_STATE_KEYS).toCloudSyncState()
+
+    private suspend fun storeSyncSuccess(
+        cursor: String,
+        serverTime: String,
+        userId: String,
+    ) {
+        dao.upsertSyncStates(
+            listOf(
+                SyncStateEntity(SyncStateKeys.CURSOR, cursor),
+                SyncStateEntity(SyncStateKeys.LAST_SYNCED_AT, serverTime.toEpochMillis().toString()),
+                SyncStateEntity(SyncStateKeys.USER_ID, userId),
+                SyncStateEntity(SyncStateKeys.LAST_ERROR, ""),
+            ),
+        )
+    }
+
+    private suspend fun storeSyncError(message: String) {
+        database.withTransaction {
+            dao.upsertSyncStates(listOf(SyncStateEntity(SyncStateKeys.LAST_ERROR, message)))
+        }
+    }
+
+    private suspend fun handleSyncFailure(error: Throwable): Nothing {
+        val message =
+            when (error) {
+                is CloudApiException -> error.message
+                is IOException -> error.message ?: "Cloud sync failed"
+                is IllegalStateException -> error.message ?: "Cloud sync failed"
+                else -> "Cloud sync failed"
+            }
+        storeSyncError(message)
+        throw error
+    }
+
+    companion object {
+        @Volatile private var instance: CloudSyncRepository? = null
+
+        fun getInstance(context: Context): CloudSyncRepository =
+            instance ?: synchronized(this) {
+                instance ?: CloudSyncRepository(context.applicationContext).also { instance = it }
+            }
+    }
+}
+
+private object SyncStateKeys {
+    const val CURSOR = "cloud_sync_cursor"
+    const val LAST_SYNCED_AT = "cloud_last_synced_at"
+    const val LAST_ERROR = "cloud_last_error"
+    const val USER_ID = "cloud_user_id"
+}
+
+private const val SYNC_CURSOR_EXPIRED_CODE = "SYNC_CURSOR_EXPIRED"
+
+private fun List<SyncStateEntity>.toCloudSyncState(): CloudSyncState {
+    val values = associate { it.key to it.value }
+    return CloudSyncState(
+        cursor = values[SyncStateKeys.CURSOR]?.takeIf(String::isNotBlank),
+        lastSyncedAt = values[SyncStateKeys.LAST_SYNCED_AT]?.toLongOrNull(),
+        lastError = values[SyncStateKeys.LAST_ERROR]?.takeIf(String::isNotBlank),
+        userId = values[SyncStateKeys.USER_ID]?.takeIf(String::isNotBlank),
+    )
+}
+
+private fun randomUuid(): String = UUID.randomUUID().toString()

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryDao.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryDao.kt
@@ -51,8 +51,17 @@ abstract class LibraryDao {
     @Insert(onConflict = OnConflictStrategy.ABORT)
     abstract suspend fun insertLibraryItem(item: LibraryItemEntity)
 
-    @Insert(onConflict = OnConflictStrategy.ABORT)
-    abstract suspend fun insertSyncStates(states: List<SyncStateEntity>)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertSyncStates(states: List<SyncStateEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertPlaces(places: List<PlaceEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertRoutes(routes: List<RouteEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertRouteRevisions(revisions: List<RouteRevisionEntity>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun upsertLibraryItems(items: List<LibraryItemEntity>)
@@ -125,12 +134,78 @@ abstract class LibraryDao {
         updatedAt: Long,
     )
 
+    @Query("SELECT * FROM sync_state WHERE key IN (:keys)")
+    abstract suspend fun getSyncStates(keys: List<String>): List<SyncStateEntity>
+
+    @Query("SELECT * FROM sync_state WHERE key IN (:keys)")
+    abstract fun observeSyncStates(keys: List<String>): Flow<List<SyncStateEntity>>
+
+    @Query("SELECT id FROM places WHERE remote_id = :remoteId LIMIT 1")
+    abstract suspend fun findPlaceIdByRemoteId(remoteId: String): String?
+
+    @Query("SELECT id FROM routes WHERE remote_id = :remoteId LIMIT 1")
+    abstract suspend fun findRouteIdByRemoteId(remoteId: String): String?
+
+    @Query("SELECT id FROM route_revisions WHERE remote_id = :remoteId LIMIT 1")
+    abstract suspend fun findRouteRevisionIdByRemoteId(remoteId: String): String?
+
+    @Query("SELECT id FROM library_items WHERE remote_id = :remoteId LIMIT 1")
+    abstract suspend fun findLibraryItemIdByRemoteId(remoteId: String): String?
+
+    @Query("DELETE FROM waypoints WHERE route_revision_id = :routeRevisionId")
+    abstract suspend fun deleteWaypointsForRouteRevision(routeRevisionId: String)
+
+    @Query("DELETE FROM route_revisions WHERE route_id = :routeId AND id != :keepRevisionId AND remote_id IS NOT NULL")
+    abstract suspend fun deleteSyncedRouteRevisionsForRouteExcept(
+        routeId: String,
+        keepRevisionId: String,
+    )
+
+    @Query("DELETE FROM route_revisions WHERE remote_id = :remoteId")
+    abstract suspend fun deleteRouteRevisionByRemoteId(remoteId: String)
+
+    @Query("DELETE FROM sync_state WHERE key = :key")
+    abstract suspend fun deleteSyncState(key: String)
+
     @Query("DELETE FROM library_items WHERE id = :itemId")
     abstract suspend fun deleteLibraryItem(itemId: String)
+
+    @Query("DELETE FROM library_items WHERE remote_id = :remoteId")
+    abstract suspend fun deleteLibraryItemByRemoteId(remoteId: String)
+
+    @Query("DELETE FROM library_items WHERE sync_status = 'Synced'")
+    abstract suspend fun deleteAllSyncedLibraryItems()
+
+    @Query("DELETE FROM library_items WHERE sync_status = 'Synced' AND remote_id NOT IN (:remoteIds)")
+    abstract suspend fun deleteSyncedLibraryItemsNotIn(remoteIds: List<String>)
 
     @Query("DELETE FROM places WHERE id = :placeId")
     abstract suspend fun deletePlace(placeId: String)
 
+    @Query("DELETE FROM places WHERE remote_id = :remoteId")
+    abstract suspend fun deletePlaceByRemoteId(remoteId: String)
+
+    @Query("DELETE FROM places WHERE sync_status = 'Synced'")
+    abstract suspend fun deleteAllSyncedPlaces()
+
+    @Query("DELETE FROM places WHERE sync_status = 'Synced' AND remote_id NOT IN (:remoteIds)")
+    abstract suspend fun deleteSyncedPlacesNotIn(remoteIds: List<String>)
+
     @Query("DELETE FROM routes WHERE id = :routeId")
     abstract suspend fun deleteRoute(routeId: String)
+
+    @Query("DELETE FROM routes WHERE remote_id = :remoteId")
+    abstract suspend fun deleteRouteByRemoteId(remoteId: String)
+
+    @Query("DELETE FROM routes WHERE sync_status = 'Synced'")
+    abstract suspend fun deleteAllSyncedRoutes()
+
+    @Query("DELETE FROM routes WHERE sync_status = 'Synced' AND remote_id NOT IN (:remoteIds)")
+    abstract suspend fun deleteSyncedRoutesNotIn(remoteIds: List<String>)
+
+    @Query("DELETE FROM route_revisions WHERE remote_id IS NOT NULL")
+    abstract suspend fun deleteAllSyncedRouteRevisions()
+
+    @Query("DELETE FROM route_revisions WHERE remote_id IS NOT NULL AND remote_id NOT IN (:remoteIds)")
+    abstract suspend fun deleteSyncedRouteRevisionsNotIn(remoteIds: List<String>)
 }

--- a/app/src/main/java/dev/narumi/kestrel/core/location/MovementEngine.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/location/MovementEngine.kt
@@ -20,15 +20,9 @@ class MovementEngine(
 
     private val segments: List<Segment> =
         buildList {
-            val expanded =
-                if (mode == Mode.Loop && waypoints.size >= 2) {
-                    waypoints + waypoints.first()
-                } else {
-                    waypoints
-                }
-            for (i in 0 until expanded.lastIndex) {
-                val a = expanded[i]
-                val b = expanded[i + 1]
+            for (i in 0 until waypoints.lastIndex) {
+                val a = waypoints[i]
+                val b = waypoints[i + 1]
                 val len = haversineMeters(a, b)
                 if (len > 0.0) add(Segment(a, b, len, bearingDegrees(a, b)))
             }

--- a/app/src/main/java/dev/narumi/kestrel/feature/options/OptionsScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/options/OptionsScreen.kt
@@ -33,6 +33,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.narumi.kestrel.core.cloud.CloudApiException
 import dev.narumi.kestrel.core.cloud.CloudAuthRepository
 import dev.narumi.kestrel.core.cloud.CloudSession
+import dev.narumi.kestrel.core.cloud.CloudSyncRepository
+import dev.narumi.kestrel.core.cloud.CloudSyncState
 import dev.narumi.kestrel.core.data.CloudSettings
 import dev.narumi.kestrel.core.data.KestrelPrefs
 import dev.narumi.kestrel.core.data.RandomRoutePreference
@@ -41,40 +43,38 @@ import dev.narumi.kestrel.core.library.LibraryItemWithContent
 import dev.narumi.kestrel.core.library.LibraryRepository
 import dev.narumi.kestrel.core.library.description
 import kotlinx.coroutines.launch
+import java.io.IOException
 import java.util.Date
+
+private data class CloudLoginForm(
+    val username: String = "",
+    val password: String = "",
+    val oneTimeCode: String = "",
+    val useRecoveryCode: Boolean = false,
+)
+
+private data class CloudSettingsUiState(
+    val apiBaseUrl: String,
+    val loading: Boolean,
+    val message: String?,
+    val error: String?,
+    val session: CloudSession?,
+    val syncState: CloudSyncState,
+)
 
 @Composable
 fun OptionsScreen(modifier: Modifier = Modifier) {
     val context = LocalContext.current
     val prefs = remember { KestrelPrefs(context) }
-    val authRepository = remember { CloudAuthRepository.getInstance(context) }
     val libraryRepository = remember { LibraryRepository.getInstance(context) }
     val scope = rememberCoroutineScope()
 
-    val cloudSettings by prefs.cloudSettings.collectAsStateWithLifecycle(CloudSettings())
     val items by libraryRepository.items.collectAsStateWithLifecycle(emptyList())
     val startup by prefs.startupPreference.collectAsStateWithLifecycle(StartupPreference())
     val randomRoute by prefs.randomRoutePreference.collectAsStateWithLifecycle(RandomRoutePreference())
 
-    var apiBaseUrl by remember { mutableStateOf(cloudSettings.apiBaseUrl) }
-    var username by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
-    var oneTimeCode by remember { mutableStateOf("") }
-    var useRecoveryCode by remember { mutableStateOf(false) }
-    var cloudSession by remember { mutableStateOf<CloudSession?>(null) }
-    var cloudMessage by remember { mutableStateOf<String?>(null) }
-    var cloudError by remember { mutableStateOf<String?>(null) }
-    var cloudLoading by remember { mutableStateOf(false) }
     var defaultPointCount by remember { mutableStateOf("") }
     var defaultSpacingMeters by remember { mutableStateOf("") }
-
-    LaunchedEffect(Unit) {
-        cloudSession = authRepository.currentSession()
-    }
-
-    LaunchedEffect(cloudSettings.apiBaseUrl) {
-        apiBaseUrl = cloudSettings.apiBaseUrl
-    }
 
     LaunchedEffect(randomRoute.defaultPointCount, randomRoute.defaultSpacingMeters) {
         defaultPointCount = randomRoute.defaultPointCount.toString()
@@ -93,95 +93,7 @@ fun OptionsScreen(modifier: Modifier = Modifier) {
                 .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        CloudSettingsCard(
-            apiBaseUrl = apiBaseUrl,
-            cloudError = cloudError,
-            cloudLoading = cloudLoading,
-            cloudMessage = cloudMessage,
-            cloudSession = cloudSession,
-            onApiBaseUrlChange = { apiBaseUrl = it },
-            onLogin = {
-                scope.launch {
-                    cloudLoading = true
-                    cloudError = null
-                    cloudMessage = null
-                    try {
-                        val session =
-                            if (useRecoveryCode) {
-                                authRepository.loginWithRecoveryCode(
-                                    username = username,
-                                    password = password,
-                                    recoveryCode = oneTimeCode,
-                                )
-                            } else {
-                                authRepository.loginWithTotp(
-                                    username = username,
-                                    password = password,
-                                    totpCode = oneTimeCode,
-                                )
-                            }
-                        cloudSession = session
-                        cloudMessage = "Signed in as ${session.username}"
-                        oneTimeCode = ""
-                    } catch (error: Exception) {
-                        cloudError = error.toCloudErrorMessage()
-                    } finally {
-                        cloudLoading = false
-                    }
-                }
-            },
-            onLogout = {
-                scope.launch {
-                    cloudLoading = true
-                    cloudError = null
-                    cloudMessage = null
-                    try {
-                        authRepository.logout()
-                        cloudSession = null
-                        cloudMessage = "Signed out"
-                    } catch (error: Exception) {
-                        cloudError = error.toCloudErrorMessage()
-                    } finally {
-                        cloudLoading = false
-                    }
-                }
-            },
-            onPasswordChange = { password = it },
-            onRefreshSession = {
-                scope.launch {
-                    cloudLoading = true
-                    cloudError = null
-                    cloudMessage = null
-                    try {
-                        val refreshedSession = authRepository.refreshSession()
-                        cloudSession = refreshedSession
-                        if (refreshedSession == null) {
-                            cloudError = "Session expired. Please sign in again."
-                        } else {
-                            cloudMessage = "Session refreshed"
-                        }
-                    } catch (error: Exception) {
-                        cloudError = error.toCloudErrorMessage()
-                    } finally {
-                        cloudLoading = false
-                    }
-                }
-            },
-            onSaveApiBaseUrl = {
-                scope.launch {
-                    prefs.setCloudApiBaseUrl(apiBaseUrl)
-                    cloudMessage = "Saved API base URL"
-                    cloudError = null
-                }
-            },
-            onToggleRecoveryCode = { useRecoveryCode = it },
-            onUsernameChange = { username = it },
-            onOneTimeCodeChange = { oneTimeCode = it },
-            oneTimeCode = oneTimeCode,
-            password = password,
-            useRecoveryCode = useRecoveryCode,
-            username = username,
-        )
+        CloudSettingsSection()
 
         StartupPreferenceCard(
             items = items,
@@ -223,29 +135,140 @@ fun OptionsScreen(modifier: Modifier = Modifier) {
     }
 }
 
+@Suppress("LongMethod")
+@Composable
+private fun CloudSettingsSection() {
+    val context = LocalContext.current
+    val prefs = remember { KestrelPrefs(context) }
+    val authRepository = remember { CloudAuthRepository.getInstance(context) }
+    val syncRepository = remember { CloudSyncRepository.getInstance(context) }
+    val scope = rememberCoroutineScope()
+
+    val cloudSettings by prefs.cloudSettings.collectAsStateWithLifecycle(CloudSettings())
+    val cloudSyncState by syncRepository.syncState.collectAsStateWithLifecycle(CloudSyncState())
+
+    var loginForm by remember { mutableStateOf(CloudLoginForm()) }
+    var cloudSession by remember { mutableStateOf<CloudSession?>(null) }
+    var cloudMessage by remember { mutableStateOf<String?>(null) }
+    var cloudError by remember { mutableStateOf<String?>(null) }
+    var cloudLoading by remember { mutableStateOf(false) }
+    var apiBaseUrl by remember { mutableStateOf(cloudSettings.apiBaseUrl) }
+
+    LaunchedEffect(Unit) {
+        cloudSession = authRepository.currentSession()
+    }
+
+    LaunchedEffect(cloudSettings.apiBaseUrl) {
+        apiBaseUrl = cloudSettings.apiBaseUrl
+    }
+
+    CloudSettingsCard(
+        uiState =
+            buildCloudSettingsUiState(
+                apiBaseUrl = apiBaseUrl,
+                loading = cloudLoading,
+                message = cloudMessage,
+                error = cloudError,
+                session = cloudSession,
+                syncState = cloudSyncState,
+            ),
+        loginForm = loginForm,
+        onApiBaseUrlChange = { apiBaseUrl = it },
+        onLoginFormChange = { loginForm = it },
+        onSaveApiBaseUrl = {
+            launchCloudUiAction(
+                scope = scope,
+                setLoading = { cloudLoading = it },
+                setError = { cloudError = it },
+                setMessage = { cloudMessage = it },
+            ) {
+                prefs.setCloudApiBaseUrl(apiBaseUrl)
+                cloudMessage = "Saved API base URL"
+            }
+        },
+        onLogin = {
+            launchCloudUiAction(
+                scope = scope,
+                setLoading = { cloudLoading = it },
+                setError = { cloudError = it },
+                setMessage = { cloudMessage = it },
+            ) {
+                val session =
+                    if (loginForm.useRecoveryCode) {
+                        authRepository.loginWithRecoveryCode(
+                            username = loginForm.username,
+                            password = loginForm.password,
+                            recoveryCode = loginForm.oneTimeCode,
+                        )
+                    } else {
+                        authRepository.loginWithTotp(
+                            username = loginForm.username,
+                            password = loginForm.password,
+                            totpCode = loginForm.oneTimeCode,
+                        )
+                    }
+                cloudSession = session
+                loginForm = loginForm.copy(oneTimeCode = "")
+                syncRepository.syncNow()
+                cloudMessage = "Signed in as ${session.username}"
+            }
+        },
+        onRefreshSession = {
+            launchCloudUiAction(
+                scope = scope,
+                setLoading = { cloudLoading = it },
+                setError = { cloudError = it },
+                setMessage = { cloudMessage = it },
+            ) {
+                val refreshedSession = authRepository.refreshSession()
+                cloudSession = refreshedSession
+                if (refreshedSession == null) {
+                    cloudError = "Session expired. Please sign in again."
+                } else {
+                    cloudMessage = "Session refreshed"
+                }
+            }
+        },
+        onLogout = {
+            launchCloudUiAction(
+                scope = scope,
+                setLoading = { cloudLoading = it },
+                setError = { cloudError = it },
+                setMessage = { cloudMessage = it },
+            ) {
+                authRepository.logout()
+                cloudSession = null
+                cloudMessage = "Signed out"
+            }
+        },
+        onSyncNow = {
+            launchCloudUiAction(
+                scope = scope,
+                setLoading = { cloudLoading = it },
+                setError = { cloudError = it },
+                setMessage = { cloudMessage = it },
+            ) {
+                syncRepository.syncNow()
+                cloudMessage = "Sync complete"
+            }
+        },
+    )
+}
+
 @Composable
 private fun CloudSettingsCard(
-    apiBaseUrl: String,
-    cloudError: String?,
-    cloudLoading: Boolean,
-    cloudMessage: String?,
-    cloudSession: CloudSession?,
-    username: String,
-    password: String,
-    oneTimeCode: String,
-    useRecoveryCode: Boolean,
+    uiState: CloudSettingsUiState,
+    loginForm: CloudLoginForm,
     onApiBaseUrlChange: (String) -> Unit,
-    onUsernameChange: (String) -> Unit,
-    onPasswordChange: (String) -> Unit,
-    onOneTimeCodeChange: (String) -> Unit,
-    onToggleRecoveryCode: (Boolean) -> Unit,
+    onLoginFormChange: (CloudLoginForm) -> Unit,
     onSaveApiBaseUrl: () -> Unit,
     onLogin: () -> Unit,
     onRefreshSession: () -> Unit,
     onLogout: () -> Unit,
+    onSyncNow: () -> Unit,
 ) {
     Text(
-        text = "Cloud sync (Phase 5 foundation)",
+        text = "Cloud sync",
         style = MaterialTheme.typography.titleMedium,
     )
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -254,7 +277,7 @@ private fun CloudSettingsCard(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             OutlinedTextField(
-                value = apiBaseUrl,
+                value = uiState.apiBaseUrl,
                 onValueChange = onApiBaseUrlChange,
                 label = { Text("API base URL") },
                 singleLine = true,
@@ -262,75 +285,141 @@ private fun CloudSettingsCard(
             )
             OutlinedButton(onClick = onSaveApiBaseUrl) { Text("Save API URL") }
 
-            if (cloudSession == null) {
-                OutlinedTextField(
-                    value = username,
-                    onValueChange = onUsernameChange,
-                    label = { Text("Username") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
+            if (uiState.session == null) {
+                CloudSignedOutCardContent(
+                    loginForm = loginForm,
+                    loading = uiState.loading,
+                    onLoginFormChange = onLoginFormChange,
+                    onLogin = onLogin,
                 )
-                OutlinedTextField(
-                    value = password,
-                    onValueChange = onPasswordChange,
-                    label = { Text("Password") },
-                    singleLine = true,
-                    visualTransformation = PasswordVisualTransformation(),
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                OutlinedTextField(
-                    value = oneTimeCode,
-                    onValueChange = onOneTimeCodeChange,
-                    label = { Text(if (useRecoveryCode) "Recovery code" else "TOTP code") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                StartupRadioRow(
-                    label = "Use recovery code instead of TOTP",
-                    selected = useRecoveryCode,
-                    onSelect = { onToggleRecoveryCode(!useRecoveryCode) },
-                )
-                Button(
-                    onClick = onLogin,
-                    enabled = !cloudLoading && username.isNotBlank() && password.isNotBlank() && oneTimeCode.isNotBlank(),
-                ) {
-                    Text(if (cloudLoading) "Signing in…" else "Sign in")
-                }
             } else {
-                Text(
-                    text = "Signed in as ${cloudSession.username}",
-                    style = MaterialTheme.typography.titleSmall,
+                CloudSignedInCardContent(
+                    session = uiState.session,
+                    syncState = uiState.syncState,
+                    loading = uiState.loading,
+                    onRefreshSession = onRefreshSession,
+                    onLogout = onLogout,
+                    onSyncNow = onSyncNow,
                 )
-                Text(
-                    text = "Access token expires at ${Date(cloudSession.accessTokenExpiresAt)}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(onClick = onRefreshSession, enabled = !cloudLoading) {
-                        Text("Refresh session")
-                    }
-                    OutlinedButton(onClick = onLogout, enabled = !cloudLoading) {
-                        Text("Sign out")
-                    }
-                }
             }
 
-            cloudMessage?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-            }
-            cloudError?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
+            CloudStatusMessage(
+                message = uiState.message,
+                error = uiState.error,
+            )
         }
+    }
+}
+
+@Composable
+private fun CloudSignedOutCardContent(
+    loginForm: CloudLoginForm,
+    loading: Boolean,
+    onLoginFormChange: (CloudLoginForm) -> Unit,
+    onLogin: () -> Unit,
+) {
+    OutlinedTextField(
+        value = loginForm.username,
+        onValueChange = { onLoginFormChange(loginForm.copy(username = it)) },
+        label = { Text("Username") },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = loginForm.password,
+        onValueChange = { onLoginFormChange(loginForm.copy(password = it)) },
+        label = { Text("Password") },
+        singleLine = true,
+        visualTransformation = PasswordVisualTransformation(),
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = loginForm.oneTimeCode,
+        onValueChange = { onLoginFormChange(loginForm.copy(oneTimeCode = it)) },
+        label = { Text(if (loginForm.useRecoveryCode) "Recovery code" else "TOTP code") },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    StartupRadioRow(
+        label = "Use recovery code instead of TOTP",
+        selected = loginForm.useRecoveryCode,
+        onSelect = {
+            onLoginFormChange(loginForm.copy(useRecoveryCode = !loginForm.useRecoveryCode))
+        },
+    )
+    Button(
+        onClick = onLogin,
+        enabled =
+            !loading &&
+                loginForm.username.isNotBlank() &&
+                loginForm.password.isNotBlank() &&
+                loginForm.oneTimeCode.isNotBlank(),
+    ) {
+        Text(if (loading) "Signing in…" else "Sign in")
+    }
+}
+
+@Composable
+private fun CloudSignedInCardContent(
+    session: CloudSession,
+    syncState: CloudSyncState,
+    loading: Boolean,
+    onRefreshSession: () -> Unit,
+    onLogout: () -> Unit,
+    onSyncNow: () -> Unit,
+) {
+    Text(
+        text = "Signed in as ${session.username}",
+        style = MaterialTheme.typography.titleSmall,
+    )
+    Text(
+        text = "Access token expires at ${Date(session.accessTokenExpiresAt)}",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+        text = "Last synced: ${syncState.lastSyncedAt?.let(::Date)?.toString() ?: "Never"}",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    syncState.lastError?.let {
+        Text(
+            text = "Last sync error: $it",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Button(onClick = onSyncNow, enabled = !loading) {
+            Text(if (loading) "Syncing…" else "Sync now")
+        }
+        OutlinedButton(onClick = onRefreshSession, enabled = !loading) {
+            Text("Refresh session")
+        }
+        OutlinedButton(onClick = onLogout, enabled = !loading) {
+            Text("Sign out")
+        }
+    }
+}
+
+@Composable
+private fun CloudStatusMessage(
+    message: String?,
+    error: String?,
+) {
+    message?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+    error?.let {
+        Text(
+            text = it,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
     }
 }
 
@@ -501,11 +590,63 @@ private fun formatDistance(meters: Double): String =
         "${formatMeters(meters)} m"
     }
 
-private fun Exception.toCloudErrorMessage(): String =
-    when (this) {
-        is CloudApiException -> message
-        else -> message ?: "Unexpected cloud error"
+private fun buildCloudSettingsUiState(
+    apiBaseUrl: String,
+    loading: Boolean,
+    message: String?,
+    error: String?,
+    session: CloudSession?,
+    syncState: CloudSyncState,
+): CloudSettingsUiState =
+    CloudSettingsUiState(
+        apiBaseUrl = apiBaseUrl,
+        loading = loading,
+        message = message,
+        error = error,
+        session = session,
+        syncState = syncState,
+    )
+
+private fun launchCloudUiAction(
+    scope: kotlinx.coroutines.CoroutineScope,
+    setLoading: (Boolean) -> Unit,
+    setError: (String?) -> Unit,
+    setMessage: (String?) -> Unit,
+    block: suspend () -> Unit,
+) {
+    scope.launch {
+        runCloudAction(
+            setLoading = setLoading,
+            setError = setError,
+            setMessage = setMessage,
+            block = block,
+        )
     }
+}
+
+private suspend fun runCloudAction(
+    setLoading: (Boolean) -> Unit,
+    setError: (String?) -> Unit,
+    setMessage: (String?) -> Unit,
+    block: suspend () -> Unit,
+) {
+    setLoading(true)
+    setError(null)
+    setMessage(null)
+    try {
+        block()
+    } catch (error: CloudApiException) {
+        setError(error.message)
+    } catch (error: IOException) {
+        setError(error.toCloudErrorMessage())
+    } catch (error: IllegalStateException) {
+        setError(error.toCloudErrorMessage())
+    } finally {
+        setLoading(false)
+    }
+}
+
+private fun Throwable.toCloudErrorMessage(): String = message ?: "Unexpected cloud error"
 
 @Composable
 private fun StartupRadioRow(

--- a/app/src/test/java/dev/narumi/kestrel/core/cloud/CloudSyncMappersTest.kt
+++ b/app/src/test/java/dev/narumi/kestrel/core/cloud/CloudSyncMappersTest.kt
@@ -1,0 +1,121 @@
+package dev.narumi.kestrel.core.cloud
+
+import dev.narumi.kestrel.core.library.LibraryItemKind
+import dev.narumi.kestrel.core.library.db.SyncStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CloudSyncMappersTest {
+    @Test
+    fun `place payload maps to synced place entity`() {
+        val payload =
+            CloudPlacePayload(
+                createdAt = "2026-05-09T17:00:00.000Z",
+                description = "Capital",
+                id = "place-1",
+                latitude = 25.03,
+                longitude = 121.56,
+                name = "Taipei",
+                tags = listOf("city"),
+                updatedAt = "2026-05-09T17:30:00.000Z",
+            )
+
+        val entity = payload.toPlaceEntity(localId = "local-place-1")
+
+        assertEquals("local-place-1", entity.id)
+        assertEquals("place-1", entity.remoteId)
+        assertEquals("Taipei", entity.name)
+        assertEquals(25.03, entity.lat, 0.0)
+        assertEquals(121.56, entity.lng, 0.0)
+        assertEquals(listOf("city"), entity.tags)
+        assertEquals(SyncStatus.Synced, entity.syncStatus)
+    }
+
+    @Test
+    fun `route payload maps current revision snapshot to local rows`() {
+        val payload =
+            CloudRoutePayload(
+                createdAt = "2026-05-09T17:00:00.000Z",
+                currentRevision =
+                    CloudRouteRevisionPayload(
+                        createdAt = "2026-05-09T18:00:00.000Z",
+                        createdBy = "user-1",
+                        defaultSpeedKmh = 32.5,
+                        id = "revision-3",
+                        mode = CloudRouteMode.PING_PONG,
+                        revisionNumber = 3,
+                        waypoints =
+                            listOf(
+                                CloudWaypointPayload(
+                                    latitude = 25.1,
+                                    longitude = 121.6,
+                                    sequence = 1,
+                                    speedKmh = 20.0,
+                                ),
+                                CloudWaypointPayload(
+                                    latitude = 25.0,
+                                    longitude = 121.5,
+                                    sequence = 0,
+                                    pauseSeconds = 5.0,
+                                ),
+                            ),
+                    ),
+                defaultSpeedKmh = 10.0,
+                description = "Morning",
+                id = "route-1",
+                mode = CloudRouteMode.ONCE,
+                name = "Commute",
+                updatedAt = "2026-05-09T18:30:00.000Z",
+            )
+
+        var waypointCounter = 0
+        val rows =
+            payload.toRouteSyncRows(
+                routeId = "local-route-1",
+                revisionId = "local-revision-3",
+                waypointIdFactory = {
+                    waypointCounter += 1
+                    "waypoint-$waypointCounter"
+                },
+            )
+
+        assertEquals("route-1", rows.route.remoteId)
+        assertEquals("local-revision-3", rows.route.currentRevisionId)
+        assertEquals("PingPong", rows.route.mode)
+        assertEquals(32.5, rows.route.defaultSpeedKmh, 0.0)
+        assertEquals("revision-3", rows.revision.remoteId)
+        assertEquals(3, rows.revision.revisionNumber)
+        assertEquals(listOf(0, 1), rows.waypoints.map { it.sequence })
+        assertEquals(listOf("waypoint-1", "waypoint-2"), rows.waypoints.map { it.id })
+        assertEquals(5.0, rows.waypoints.first().pauseSeconds)
+        assertEquals(20.0, rows.waypoints.last().speedKmh)
+    }
+
+    @Test
+    fun `library item payload maps remote kind and timestamps`() {
+        val payload =
+            CloudLibraryItemPayload(
+                createdAt = "2026-05-09T17:00:00.000Z",
+                id = "library-item-1",
+                kind = CloudLibraryItemKind.ROUTE,
+                lastUsedAt = "2026-05-09T20:00:00.000Z",
+                routeId = "route-1",
+                sortOrder = 7,
+                updatedAt = "2026-05-09T19:00:00.000Z",
+            )
+
+        val entity =
+            payload.toLibraryItemEntity(
+                localId = "local-item-1",
+                localPlaceId = null,
+                localRouteId = "local-route-1",
+            )
+
+        assertEquals("library-item-1", entity.remoteId)
+        assertEquals(LibraryItemKind.Route, entity.kind)
+        assertEquals("local-route-1", entity.routeId)
+        assertEquals(7, entity.sortOrder)
+        assertEquals(SyncStatus.Synced, entity.syncStatus)
+        assertEquals(1778356800000L, entity.lastUsedAt)
+    }
+}

--- a/docs/plan/phase-android-cloud-sync.md
+++ b/docs/plan/phase-android-cloud-sync.md
@@ -229,11 +229,11 @@ bootstrap 是 full snapshot，因此：
 
 ## 11. 驗收條件
 
-- [ ] 使用者可在 Android 以 username/password + TOTP 登入。
-- [ ] refresh token 以 Keystore-backed encrypted storage 保存。
-- [ ] `Sync now` 可成功 bootstrap cloud places / routes 到 Room。
-- [ ] Favorites / Go to 可看到 Web 建立的 cloud library。
+- [x] 使用者可在 Android 以 username/password + TOTP 登入。
+- [x] refresh token 以 Keystore-backed encrypted storage 保存。
+- [x] `Sync now` 可成功 bootstrap cloud places / routes 到 Room。
+- [x] Favorites / Go to 可看到 Web 建立的 cloud library。
 - [ ] route 會使用 cloud current revision snapshot 執行。
-- [ ] changes sync 可抓到 Web 新增 / 修改 / 刪除。
+- [x] changes sync 可抓到 Web 新增 / 修改 / 刪除。
 - [ ] cursor 過期時會自動 fallback 到 bootstrap。
-- [ ] Options 頁可看到 last synced at / 最近 sync error。
+- [x] Options 頁可看到 last synced at / 最近 sync error。

--- a/docs/todos/location-route-sync-platform-todo.md
+++ b/docs/todos/location-route-sync-platform-todo.md
@@ -84,17 +84,17 @@
 
 ## Phase 5：Android cloud sync
 
-- [ ] Android 加 auth token storage（Keystore / encrypted storage）。
-- [ ] Android login UI：username/password + TOTP。
-- [ ] 實作 API client。
-- [ ] 實作 sync bootstrap。
-- [ ] 將 bootstrap payload upsert 到 Room。
-- [ ] 實作 sync cursor 保存。
-- [ ] 實作 foreground/manual refresh。
-- [ ] 實作 changes polling。
-- [ ] 處理 deletions。
+- [x] Android 加 auth token storage（Keystore / encrypted storage）。
+- [x] Android login UI：username/password + TOTP。
+- [x] 實作 API client。
+- [x] 實作 sync bootstrap。
+- [x] 將 bootstrap payload upsert 到 Room。
+- [x] 實作 sync cursor 保存。
+- [x] 實作 foreground/manual refresh。
+- [x] 實作 changes polling。
+- [x] 處理 deletions。
 - [ ] cursor 過期時重新 bootstrap。
-- [ ] UI 顯示 last synced at / sync error。
+- [x] UI 顯示 last synced at / sync error。
 - [ ] Android 套用 cloud route 使用 current revision snapshot。
 
 ---


### PR DESCRIPTION
## Summary
- add Android cloud bootstrap and incremental sync with persisted sync state
- surface cloud login, sync status, and manual/foreground refresh in the app UI
- fix loop-mode movement to wrap to the route start and update Phase 5 docs after manual verification

## Testing
- just check
- just lint
- just test

## Manual verification
- Android login with username/password + TOTP
- Android  successfully pulled Web-created places and routes
- Web deletions propagated to Android after sync