### PR TITLE
fix(deploy): run production compose stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Previous dev-stack deploys bind-mounted the checkout and may have left
+          # root-owned ignored build artifacts (for example web/.next).
+          clean: false
 
       - name: Prepare environment file
         env:
@@ -40,11 +44,11 @@ jobs:
 
       - name: Validate Docker Compose config
         run: |
-          docker compose config --quiet
+          docker compose -f compose.deploy.yaml config --quiet
 
       - name: Deploy with Docker Compose
         run: |
-          docker compose up -d --build --remove-orphans
+          docker compose -f compose.deploy.yaml up -d --build --remove-orphans
 
       - name: Remove environment file
         if: always()

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,8 @@ COPY prisma ./prisma
 RUN npx prisma generate
 
 COPY . .
+RUN npm run build
 
 EXPOSE 3300
 
-CMD ["npm", "run", "start:dev"]
+CMD ["npm", "run", "start:prod"]

--- a/compose.deploy.yaml
+++ b/compose.deploy.yaml
@@ -1,0 +1,53 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-kestrel}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    ports:
+      - "${KESTREL_POSTGRES_PORT:-15432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-kestrel}?schema=public
+      AUTH_ACCESS_TOKEN_SECRET: ${AUTH_ACCESS_TOKEN_SECRET:?AUTH_ACCESS_TOKEN_SECRET is required}
+      AUTH_ACCESS_TOKEN_TTL_SECONDS: "900"
+      AUTH_RATE_LIMIT_MAX_ATTEMPTS: "5"
+      AUTH_RATE_LIMIT_WINDOW_SECONDS: "900"
+      AUTH_RATE_LIMIT_BLOCK_SECONDS: "900"
+      AUTH_TOTP_ENCRYPTION_KEY: ${AUTH_TOTP_ENCRYPTION_KEY:?AUTH_TOTP_ENCRYPTION_KEY is required}
+      AUTH_TOTP_ISSUER: Kestrel Cloud
+      PORT: "3300"
+    ports:
+      - "${KESTREL_BACKEND_PORT:-3300}:3300"
+    command: sh -c "npx prisma migrate deploy && npm run start:prod"
+
+  web:
+    build:
+      context: ./web
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_started
+    environment:
+      KESTREL_API_BASE_URL: http://backend:3300
+    ports:
+      - "${KESTREL_WEB_PORT:-3301}:3301"
+
+volumes:
+  postgres-data:

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,0 +1,7 @@
+## GOTCHA
+
+- Deploy must not use the dev Compose stack. `compose.yaml` bind-mounts source and runs `next dev`/`nest start --watch`; this can leave root-owned `.next` files on the host and serve non-production dev assets. Use `compose.deploy.yaml` for GitHub Actions deploys.
+
+## TASTE
+
+- Keep local Docker Compose optimized for live reload, but keep deploy Compose production-only: no source bind mounts, built images, `next start`, and Nest `start:prod` after Prisma migrations.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,7 +6,8 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
+RUN npm run build
 
 EXPOSE 3301
 
-CMD ["npx", "next", "dev", "--hostname", "0.0.0.0", "--port", "3301"]
+CMD ["npx", "next", "start", "--hostname", "0.0.0.0", "--port", "3301"]


### PR DESCRIPTION
## Summary
- add a deploy-specific Docker Compose file without live-reload bind mounts
- build backend/web images and run production start commands in deploy
- point GitHub Actions deploy at the production Compose file

## Verification
- docker compose -f compose.deploy.yaml config --quiet
- docker build backend -t kestrel-backend-test
- docker build web -t kestrel-web-test