### PR TITLE
fix(web): proxy backend API with runtime config

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,6 +1,7 @@
 ## GOTCHA
 
 - Deploy must not use the dev Compose stack. `compose.yaml` bind-mounts source and runs `next dev`/`nest start --watch`; this can leave root-owned `.next` files on the host and serve non-production dev assets. Use `compose.deploy.yaml` for GitHub Actions deploys.
+- Next rewrites in `next.config.ts` bake the backend URL at `next build`; deploy images built without `KESTREL_API_BASE_URL` proxy to `localhost:3300`. Use the runtime `/api/backend/[...path]` route proxy instead.
 
 ## TASTE
 

--- a/web/app/api/backend/[...path]/route.ts
+++ b/web/app/api/backend/[...path]/route.ts
@@ -1,0 +1,88 @@
+import type { NextRequest } from 'next/server';
+
+const API_BASE_URL = process.env.KESTREL_API_BASE_URL ?? 'http://localhost:3300';
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+export async function GET(request: NextRequest, context: RouteContext<'/api/backend/[...path]'>) {
+  return proxyRequest(request, context);
+}
+
+export async function POST(request: NextRequest, context: RouteContext<'/api/backend/[...path]'>) {
+  return proxyRequest(request, context);
+}
+
+export async function PUT(request: NextRequest, context: RouteContext<'/api/backend/[...path]'>) {
+  return proxyRequest(request, context);
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext<'/api/backend/[...path]'>) {
+  return proxyRequest(request, context);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  context: RouteContext<'/api/backend/[...path]'>,
+) {
+  return proxyRequest(request, context);
+}
+
+async function proxyRequest(request: NextRequest, context: RouteContext<'/api/backend/[...path]'>) {
+  const { path } = await context.params;
+  const url = new URL(request.url);
+  const backendUrl = new URL(path.join('/'), normalizedApiBaseUrl());
+  backendUrl.search = url.search;
+
+  const response = await fetch(backendUrl, {
+    body:
+      request.method === 'GET' || request.method === 'HEAD'
+        ? undefined
+        : await request.arrayBuffer(),
+    headers: createForwardHeaders(request.headers),
+    method: request.method,
+    redirect: 'manual',
+  });
+
+  return new Response(response.body, {
+    headers: createResponseHeaders(response.headers),
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function normalizedApiBaseUrl(): string {
+  return API_BASE_URL.endsWith('/') ? API_BASE_URL : `${API_BASE_URL}/`;
+}
+
+function createForwardHeaders(headers: Headers): Headers {
+  const forwardedHeaders = new Headers();
+
+  for (const [name, value] of headers) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+      forwardedHeaders.set(name, value);
+    }
+  }
+
+  return forwardedHeaders;
+}
+
+function createResponseHeaders(headers: Headers): Headers {
+  const responseHeaders = new Headers();
+
+  for (const [name, value] of headers) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+      responseHeaders.set(name, value);
+    }
+  }
+
+  return responseHeaders;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -2,17 +2,6 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ['127.0.0.1'],
-
-  async rewrites() {
-    const apiBaseUrl = process.env.KESTREL_API_BASE_URL ?? 'http://localhost:3300';
-
-    return [
-      {
-        source: '/api/backend/:path*',
-        destination: `${apiBaseUrl}/:path*`,
-      },
-    ];
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- replace build-time Next rewrites with a runtime API route proxy
- forward backend API requests using KESTREL_API_BASE_URL at request time
- document the deploy proxy gotcha

## Verification
- cd web && npx biome check app/api/backend/[...path]/route.ts next.config.ts
- cd web && npm run typecheck
- cd web && npm run build