### PR TITLE
fix(android): recover from ahead sync cursors

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
@@ -197,7 +197,7 @@ class CloudSyncRepository private constructor(
                 )
             }
         } catch (error: CloudApiException) {
-            if (error.statusCode == 410 && error.code == SYNC_CURSOR_EXPIRED_CODE) {
+            if (error.isRecoverableCursorError()) {
                 database.withTransaction {
                     dao.deleteSyncState(SyncStateKeys.CURSOR)
                 }
@@ -356,6 +356,11 @@ private object SyncStateKeys {
 }
 
 private const val SYNC_CURSOR_EXPIRED_CODE = "SYNC_CURSOR_EXPIRED"
+private const val SYNC_CURSOR_AHEAD_MESSAGE = "since cursor is ahead of server state"
+
+private fun CloudApiException.isRecoverableCursorError(): Boolean =
+    (statusCode == 410 && code == SYNC_CURSOR_EXPIRED_CODE) ||
+        (statusCode == 400 && message == SYNC_CURSOR_AHEAD_MESSAGE)
 
 private fun List<SyncStateEntity>.toCloudSyncState(): CloudSyncState {
     val values = associate { it.key to it.value }


### PR DESCRIPTION
## Summary
- treat `since cursor is ahead of server state` as a recoverable sync cursor error
- clear only the cloud sync cursor and rerun bootstrap instead of requiring app data reset
- keep existing expired-cursor recovery behavior

## Verification
- Not run: `just check` cannot start because this environment has no valid Java installation (`JAVA_HOME` points to `/Applications/Android Studio.app/...`, and `java` is not installed here).
