### PR TITLE
docs: sync completed plan checklists

### DIFF
--- a/docs/plan/location-route-sync-platform.md
+++ b/docs/plan/location-route-sync-platform.md
@@ -403,13 +403,13 @@ Android 端改為 cloud-shaped local library：
 
 ## 12. 驗收條件（產品級 MVP）
 
-- [ ] 使用者可在 Web 以 username/password + TOTP 登入。
-- [ ] Web 可建立 / 編輯 place。
-- [ ] Web 可建立 / 編輯 route waypoints、default speed、mode。
-- [ ] Android 可登入同帳號。
-- [ ] Android 首次 bootstrap 後看得到 Web 建立的 places / routes。
-- [ ] Web 修改 route 後產生新 revision，Android changes sync 後取得最新版。
-- [ ] Android 可套用單點並 mock。
-- [ ] Android 可播放同步下來的 route。
+- [x] 使用者可在 Web 以 username/password + TOTP 登入。
+- [x] Web 可建立 / 編輯 place。
+- [x] Web 可建立 / 編輯 route waypoints、default speed、mode。
+- [x] Android 可登入同帳號。
+- [x] Android 首次 bootstrap 後看得到 Web 建立的 places / routes。
+- [x] Web 修改 route 後產生新 revision，Android changes sync 後取得最新版。
+- [x] Android 可套用單點並 mock。
+- [x] Android 可播放同步下來的 route。
 - [ ] Web 可產生 public latest share link。
 - [ ] 登入使用者可 copy public route 到自己的 library。

--- a/docs/plan/phase-android-cloud-sync.md
+++ b/docs/plan/phase-android-cloud-sync.md
@@ -233,7 +233,7 @@ bootstrap 是 full snapshot，因此：
 - [x] refresh token 以 Keystore-backed encrypted storage 保存。
 - [x] `Sync now` 可成功 bootstrap cloud places / routes 到 Room。
 - [x] Favorites / Go to 可看到 Web 建立的 cloud library。
-- [ ] route 會使用 cloud current revision snapshot 執行。
+- [x] route 會使用 cloud current revision snapshot 執行。
 - [x] changes sync 可抓到 Web 新增 / 修改 / 刪除。
-- [ ] cursor 過期時會自動 fallback 到 bootstrap。
+- [x] cursor 過期時會自動 fallback 到 bootstrap。
 - [x] Options 頁可看到 last synced at / 最近 sync error。

--- a/docs/plan/phase-cloud-shaped-library.md
+++ b/docs/plan/phase-cloud-shaped-library.md
@@ -411,18 +411,19 @@ data class LibraryItemWithContent(
 
 ## 11. 驗收條件
 
-- [ ] 首次啟動會把既有 DataStore favorites migrate 到 Room。
-- [ ] Migration 後 Points / Routes 數量與原本一致。
-- [ ] Go to 面板可套用 migrated point。
-- [ ] Go to 面板可套用 migrated route，speed / mode 正確。
-- [ ] Save point 會建立 `Place + LibraryItem`，重啟後仍存在。
-- [ ] Save route 會建立 `Route + RouteRevision + Waypoints + LibraryItem`，重啟後仍存在。
-- [ ] Rename 不改變 item identity；startup reference 不會斷。
-- [ ] Recent sorting 使用 `LibraryItem.lastUsedAt`。
-- [ ] Manual sorting 使用 `LibraryItem.sortOrder`，重啟後保留。
-- [ ] Startup favorite 改用 `libraryItemId`，舊 `favoriteName` 可 migration。
-- [ ] UI 不再直接依賴 `Favorite.name` 作操作 key。
-- [ ] `just check` / `just lint` 通過。
+- [x] 首次啟動會把既有 DataStore favorites migrate 到 Room。
+- [x] Migration 後 Points / Routes 數量與原本一致。
+- [x] Go to 面板可套用 migrated point。
+- [x] Go to 面板可套用 migrated route，speed / mode 正確。
+- [x] Save point 會建立 `Place + LibraryItem`，重啟後仍存在。
+- [x] Save route 會建立 `Route + RouteRevision + Waypoints + LibraryItem`，重啟後仍存在。
+- [x] Rename 不改變 item identity；startup reference 不會斷。
+- [x] Recent sorting 使用 `LibraryItem.lastUsedAt`。
+- [x] Manual sorting 使用 `LibraryItem.sortOrder`，重啟後保留。
+- [x] Startup favorite 改用 `libraryItemId`。
+- [x] 舊 `favoriteName` 可 migration。
+- [x] UI 不再直接依賴 `Favorite.name` 作操作 key。
+- [x] `just check` / `just lint` 通過。
 
 ---
 

--- a/docs/plan/phase-quick-jump-and-favorites.md
+++ b/docs/plan/phase-quick-jump-and-favorites.md
@@ -212,13 +212,13 @@ Favorites 列表每個 row 加一個 overflow icon，下拉選：
 
 ## 8. 驗收條件
 
-- [ ] 貼 `25.0330, 121.5654` / `25.0330 121.5654` / Google Maps URL 都能跳轉
-- [ ] Go to 面板能套用某個單點 favorite，套完面板自動關、底部 sheet 顯示 Mock this point
-- [ ] Go to 面板能套用某個 route favorite，套完不自動播、speed/mode 都已套上
-- [ ] route 跑步中按 Go to 套東西，會先停舊 mock 再套新
-- [ ] Favorites 頁兩個 tab 切換正常、空狀態文案合理
-- [ ] 三種排序模式皆可運作，重啟保留設定
+- [x] 貼 `25.0330, 121.5654` / `25.0330 121.5654` / Google Maps URL 都能跳轉
+- [x] Go to 面板能套用某個單點 favorite，套完面板自動關、底部 sheet 顯示 Mock this point
+- [x] Go to 面板能套用某個 route favorite，套完不自動播、speed/mode 都已套上
+- [x] route 跑步中按 Go to 套東西，會先停舊 mock 再套新
+- [x] Favorites 頁兩個 tab 切換正常、空狀態文案合理
+- [x] 三種排序模式皆可運作，重啟保留設定
 - [ ] Manual 模式下能拖曳重排、順序持久化
-- [ ] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作
-- [ ] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化
+- [x] Rename / Edit coords / Edit speed-mode / Delete / Apply now 都可運作
+- [x] 套用 favorite 會更新 `lastUsedAt`，Recent 排序順序如預期變化
 - [ ] `just check` / `just lint` 通過

--- a/docs/todos/TODO.md
+++ b/docs/todos/TODO.md
@@ -44,7 +44,7 @@
 - [ ] **CI（GitHub Actions）**：push / PR 跑 `just check` / `just lint` / `:app:assembleDebug`。順便 cache `~/.gradle`。
 - [ ] **Generate route 進階參數**：dialog 多兩欄 — 起始 bearing（auto vs 指定度數）、turn variance（目前 hardcode 60°）；可選「seed」讓使用者重現。
 - [ ] **Favorite detail + Apply now**：點 Favorites 列項目進到 detail，看完整資訊（座標、route 縮圖、speed、mode），按鈕「Apply to map」直接套用而不必設成預設啟動。
-- [ ] **移除 legacy DataStore favorites JSON**：cloud-shaped library migration 穩定後，移除 `Favorite` / `FavoriteRoute` schema 與 `favorites_json` legacy helpers。
+- [x] **移除 legacy DataStore favorites JSON**：cloud-shaped library migration 穩定後，移除 `Favorite` / `FavoriteRoute` schema 與 `favorites_json` legacy helpers。
 - [ ] **MapScreen / KestrelMap 拆 sub-composables**：兩個都在 `detekt-baseline.xml` 裡是 LongMethod。拆完可從 baseline 移除。
 - [ ] **Release / ProGuard 規則**：能跑的 release variant，先用 `isMinifyEnabled = false` 確認簽名流程，再分階段開 R8。
 - [ ] **地圖風格切換**：OSM raster ↔ 自寫淺色 / 深色 vector style。Settings 暴露 toggle。

--- a/docs/todos/location-route-sync-platform-todo.md
+++ b/docs/todos/location-route-sync-platform-todo.md
@@ -8,10 +8,10 @@
 
 > 詳細拆解見 `docs/todos/phase-cloud-shaped-library-todo.md`。
 
-- [ ] 新增 Room-based Library domain。
-- [ ] DataStore favorites migration 到 Room。
-- [ ] Favorites / Go to / Save flows 改接 LibraryRepository。
-- [ ] 移除 UI 對 `Favorite.name` identity 的依賴。
+- [x] 新增 Room-based Library domain。
+- [x] DataStore favorites migration 到 Room。
+- [x] Favorites / Go to / Save flows 改接 LibraryRepository。
+- [x] 移除 UI 對 `Favorite.name` identity 的依賴。
 
 ---
 
@@ -93,9 +93,9 @@
 - [x] 實作 foreground/manual refresh。
 - [x] 實作 changes polling。
 - [x] 處理 deletions。
-- [ ] cursor 過期時重新 bootstrap。
+- [x] cursor 過期時重新 bootstrap。
 - [x] UI 顯示 last synced at / sync error。
-- [ ] Android 套用 cloud route 使用 current revision snapshot。
+- [x] Android 套用 cloud route 使用 current revision snapshot。
 
 ---
 

--- a/docs/todos/phase-cloud-shaped-library-todo.md
+++ b/docs/todos/phase-cloud-shaped-library-todo.md
@@ -234,7 +234,7 @@
 ## 13. 後續清理 / 非本 phase
 
 - [x] 移除 legacy DataStore favorites JSON（2026-05-10：刪除 `Favorite`/`FavoriteRoute`、`FAVORITES`/`LIBRARY_ROOM_MIGRATED` keys、deprecated 操作 methods、`StartupPreference.favoriteName`、`FavoriteToLibraryMigrator` 與其 test、`LibraryRepository.ensureMigrated`/`resolveLegacyStartupPreference`/`updateStartupPreference`，`LibraryDao.findLibraryItemIdByName`/`countLibraryItems`，UI fallback 路徑）。
-- [ ] 加 Android sync remote id binding。
+- [x] 加 Android sync remote id binding。
 - [ ] 加 dirty/local-only upload state。
 - [ ] 加完整 route revision history lazy load。
 - [ ] 加 per-segment speed / pause playback。


### PR DESCRIPTION
## Summary
- mark implemented cloud sync and current-revision Android behavior as complete
- sync cloud-shaped library checklist state across plan and todo docs
- mark completed web/auth/library MVP checklist items while leaving sharing and drag-reorder work open

## Verification
- Not run: docs-only checklist update.
