### PR TITLE
feat(sync): add place upload conflict foundation

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudApiClient.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudApiClient.kt
@@ -71,6 +71,16 @@ class CloudApiClient(
             accessToken = accessToken,
         )
 
+    internal suspend fun upload(
+        accessToken: String,
+        request: CloudSyncUploadRequest,
+    ): CloudSyncUploadResponse =
+        postJson<CloudSyncUploadRequest, CloudSyncUploadResponse>(
+            path = "/sync/upload",
+            body = request,
+            accessToken = accessToken,
+        )
+
     private suspend inline fun <reified Request : Any, reified Response : Any> postJson(
         path: String,
         body: Request,

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudModels.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudModels.kt
@@ -131,6 +131,66 @@ internal data class CloudLibraryItemPayload(
     val routeId: String? = null,
     val sortOrder: Int,
     val updatedAt: String,
+    val version: Int = 1,
+)
+
+@Serializable
+internal data class CloudSyncUploadRequest(
+    val changes: List<CloudSyncUploadChange>,
+)
+
+@Serializable
+internal data class CloudSyncUploadChange(
+    val clientMutationId: String,
+    val expectedVersion: Int? = null,
+    val place: CloudSyncUploadPlace? = null,
+    val remoteLibraryItemId: String? = null,
+    val remotePlaceId: String? = null,
+    val type: CloudSyncUploadChangeType,
+)
+
+@Serializable
+internal data class CloudSyncUploadPlace(
+    val description: String? = null,
+    val latitude: Double,
+    val longitude: Double,
+    val name: String,
+    val tags: List<String> = emptyList(),
+)
+
+@Serializable
+internal enum class CloudSyncUploadChangeType { PLACE_CREATE, PLACE_UPDATE, PLACE_DELETE }
+
+@Serializable
+internal data class CloudSyncUploadResponse(
+    val conflicts: List<CloudSyncUploadConflictResult> = emptyList(),
+    val failed: List<CloudSyncUploadFailedResult> = emptyList(),
+    val serverTime: String,
+    val uploaded: List<CloudSyncUploadUploadedResult> = emptyList(),
+)
+
+@Serializable
+internal data class CloudSyncUploadUploadedResult(
+    val clientMutationId: String,
+    val libraryItem: CloudLibraryItemPayload? = null,
+    val place: CloudPlacePayload? = null,
+    val status: String,
+)
+
+@Serializable
+internal data class CloudSyncUploadConflictResult(
+    val clientMutationId: String,
+    val cloudLibraryItem: CloudLibraryItemPayload? = null,
+    val cloudPlace: CloudPlacePayload? = null,
+    val reason: String,
+    val status: String,
+)
+
+@Serializable
+internal data class CloudSyncUploadFailedResult(
+    val clientMutationId: String,
+    val message: String,
+    val status: String,
 )
 
 @Serializable

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudRouteSyncRows.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudRouteSyncRows.kt
@@ -88,6 +88,7 @@ internal fun CloudLibraryItemPayload.toLibraryItemEntity(
         sortOrder = sortOrder,
         lastUsedAt = lastUsedAt?.toEpochMillis(),
         syncStatus = SyncStatus.Synced,
+        remoteVersion = version,
         createdAt = createdAt.toEpochMillis(),
         updatedAt = updatedAt.toEpochMillis(),
     )

--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
@@ -5,7 +5,10 @@ import androidx.room.withTransaction
 import dev.narumi.kestrel.core.data.KestrelPrefs
 import dev.narumi.kestrel.core.library.db.KestrelDatabase
 import dev.narumi.kestrel.core.library.db.LibraryDao
+import dev.narumi.kestrel.core.library.db.LibraryItemRecord
+import dev.narumi.kestrel.core.library.db.SyncConflictEntity
 import dev.narumi.kestrel.core.library.db.SyncStateEntity
+import dev.narumi.kestrel.core.library.db.SyncStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
@@ -28,6 +31,7 @@ data class CloudSyncState(
     val userId: String? = null,
 )
 
+@Suppress("TooManyFunctions")
 class CloudSyncRepository private constructor(
     context: Context,
 ) {
@@ -68,6 +72,8 @@ class CloudSyncRepository private constructor(
         } else {
             changes(state.cursor)
         }
+        uploadPendingPlaceChanges()
+        loadSyncState().cursor?.let { changes(it) }
     }
 
     private suspend fun bootstrap() {
@@ -207,6 +213,112 @@ class CloudSyncRepository private constructor(
             throw error
         }
     }
+
+    private suspend fun uploadPendingPlaceChanges() {
+        val pendingRecords = dao.getPendingPlaceUploadRecords().filter { it.place != null }
+        if (pendingRecords.isEmpty()) {
+            return
+        }
+
+        val request = CloudSyncUploadRequest(changes = pendingRecords.map(::toUploadChange))
+        val response = withAuthorizedSession { apiClient.upload(it.accessToken, request) }
+        database.withTransaction {
+            response.uploaded.forEach { uploaded -> applyUploadedPlace(uploaded) }
+            response.conflicts.forEach { conflict -> persistConflict(pendingRecords, conflict) }
+            if (response.failed.isNotEmpty()) {
+                dao.upsertSyncStates(
+                    listOf(SyncStateEntity(SyncStateKeys.LAST_ERROR, response.failed.first().message)),
+                )
+            }
+        }
+    }
+
+    private suspend fun applyUploadedPlace(uploaded: CloudSyncUploadUploadedResult) {
+        val place = uploaded.place ?: return
+        val libraryItem = uploaded.libraryItem ?: return
+        val localItemId = dao.findLibraryItemIdByRemoteId(libraryItem.id) ?: findLocalItemId(uploaded.clientMutationId)
+        val localPlaceId = dao.findPlaceIdByRemoteId(place.id) ?: findLocalPlaceId(uploaded.clientMutationId)
+        if (localItemId == null || localPlaceId == null) {
+            return
+        }
+
+        dao.markPlaceUploaded(localPlaceId, place.id)
+        dao.markLibraryItemUploaded(
+            itemId = localItemId,
+            remoteId = libraryItem.id,
+            remoteVersion = libraryItem.version,
+            updatedAt = libraryItem.updatedAt.toEpochMillis(),
+        )
+        dao.deletePendingSyncChangesForItem(localItemId)
+    }
+
+    private suspend fun persistConflict(
+        pendingRecords: List<LibraryItemRecord>,
+        conflict: CloudSyncUploadConflictResult,
+    ) {
+        val localRecord = pendingRecords.firstOrNull { toClientMutationId(it) == conflict.clientMutationId } ?: return
+        val cloudLibraryItem = conflict.cloudLibraryItem ?: return
+        dao.upsertSyncConflicts(
+            listOf(
+                SyncConflictEntity(
+                    id = conflict.clientMutationId,
+                    libraryItemId = localRecord.item.id,
+                    pendingChangeId = conflict.clientMutationId,
+                    kind = "Place",
+                    baseVersion = localRecord.item.remoteVersion,
+                    remoteVersion = cloudLibraryItem.version,
+                    localSnapshotJson = localRecord.place.toString(),
+                    cloudSnapshotJson = conflict.toString(),
+                    createdAt = System.currentTimeMillis(),
+                ),
+            ),
+        )
+    }
+
+    private suspend fun findLocalItemId(clientMutationId: String): String? =
+        dao
+            .getPendingPlaceUploadRecords()
+            .firstOrNull { toClientMutationId(it) == clientMutationId }
+            ?.item
+            ?.id
+
+    private suspend fun findLocalPlaceId(clientMutationId: String): String? =
+        dao
+            .getPendingPlaceUploadRecords()
+            .firstOrNull { toClientMutationId(it) == clientMutationId }
+            ?.item
+            ?.placeId
+
+    private fun toUploadChange(record: LibraryItemRecord): CloudSyncUploadChange {
+        val place = checkNotNull(record.place)
+        val type =
+            when {
+                record.item.syncStatus == SyncStatus.Deleted -> CloudSyncUploadChangeType.PLACE_DELETE
+                record.item.remoteId == null -> CloudSyncUploadChangeType.PLACE_CREATE
+                else -> CloudSyncUploadChangeType.PLACE_UPDATE
+            }
+        return CloudSyncUploadChange(
+            clientMutationId = toClientMutationId(record),
+            expectedVersion = record.item.remoteVersion,
+            place =
+                if (type == CloudSyncUploadChangeType.PLACE_DELETE) {
+                    null
+                } else {
+                    CloudSyncUploadPlace(
+                        description = place.description,
+                        latitude = place.lat,
+                        longitude = place.lng,
+                        name = place.name,
+                        tags = place.tags,
+                    )
+                },
+            remoteLibraryItemId = record.item.remoteId,
+            remotePlaceId = place.remoteId,
+            type = type,
+        )
+    }
+
+    private fun toClientMutationId(record: LibraryItemRecord): String = "place-${record.item.id}-${record.item.updatedAt}-${record.item.syncStatus}"
 
     private suspend fun upsertRouteRows(routeRows: List<CloudRouteSyncRows>) {
         if (routeRows.isEmpty()) {

--- a/app/src/main/java/dev/narumi/kestrel/core/library/LibraryRepository.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/LibraryRepository.kt
@@ -12,6 +12,7 @@ import dev.narumi.kestrel.core.library.db.LibraryItemRecord
 import dev.narumi.kestrel.core.library.db.PlaceEntity
 import dev.narumi.kestrel.core.library.db.RouteEntity
 import dev.narumi.kestrel.core.library.db.RouteRevisionEntity
+import dev.narumi.kestrel.core.library.db.SyncStatus
 import dev.narumi.kestrel.core.library.db.WaypointEntity
 import dev.narumi.kestrel.core.location.LatLng
 import kotlinx.coroutines.flow.Flow
@@ -152,7 +153,11 @@ private class RoomLibraryRepository(
         val updatedAt = System.currentTimeMillis()
         database.withTransaction {
             when (record.item.kind) {
-                LibraryItemKind.Place -> record.item.placeId?.let { dao.renamePlace(it, trimmedName, updatedAt) }
+                LibraryItemKind.Place ->
+                    record.item.placeId?.let {
+                        dao.renamePlace(it, trimmedName, updatedAt)
+                        markPlaceDirty(record, updatedAt)
+                    }
                 LibraryItemKind.Route -> record.item.routeId?.let { dao.renameRoute(it, trimmedName, updatedAt) }
             }
         }
@@ -163,7 +168,17 @@ private class RoomLibraryRepository(
         lat: Double,
         lng: Double,
     ) {
-        dao.updatePlace(placeId, lat, lng, System.currentTimeMillis())
+        val updatedAt = System.currentTimeMillis()
+        database.withTransaction {
+            dao.updatePlace(placeId, lat, lng, updatedAt)
+            val record = dao.getLibraryItemsSnapshot().firstOrNull { it.placeId == placeId }
+            if (record != null) {
+                val itemRecord = dao.getLibraryItem(record.id)
+                if (itemRecord != null) {
+                    markPlaceDirty(itemRecord, updatedAt)
+                }
+            }
+        }
     }
 
     override suspend fun updateRouteParams(
@@ -180,7 +195,15 @@ private class RoomLibraryRepository(
         val shouldResetStartupPreference = isStartupFavoriteItem(startupPreference, itemId)
         database.withTransaction {
             when (record.item.kind) {
-                LibraryItemKind.Place -> record.item.placeId?.let { dao.deletePlace(it) }
+                LibraryItemKind.Place ->
+                    record.item.placeId?.let {
+                        if (record.item.remoteId == null) {
+                            dao.deletePlace(it)
+                        } else {
+                            dao.updatePlaceSyncStatus(it, SyncStatus.Deleted, System.currentTimeMillis())
+                            dao.updateLibraryItemSyncStatus(record.item.id, SyncStatus.Deleted, System.currentTimeMillis())
+                        }
+                    }
                 LibraryItemKind.Route -> record.item.routeId?.let { dao.deleteRoute(it) }
             }
         }
@@ -208,6 +231,15 @@ private class RoomLibraryRepository(
 
     override suspend fun setSortMode(mode: FavoritesSortMode.Mode) {
         prefs.setFavoritesSortMode(mode)
+    }
+
+    private suspend fun markPlaceDirty(
+        record: LibraryItemRecord,
+        updatedAt: Long,
+    ) {
+        val nextStatus = if (record.item.remoteId == null) SyncStatus.LocalOnly else SyncStatus.Dirty
+        record.item.placeId?.let { dao.updatePlaceSyncStatus(it, nextStatus, updatedAt) }
+        dao.updateLibraryItemSyncStatus(record.item.id, nextStatus, updatedAt)
     }
 }
 

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/KestrelDatabase.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/KestrelDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [
@@ -14,8 +16,10 @@ import androidx.room.TypeConverters
         WaypointEntity::class,
         LibraryItemEntity::class,
         SyncStateEntity::class,
+        PendingSyncChangeEntity::class,
+        SyncConflictEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = false,
 )
 @TypeConverters(LibraryConverters::class)
@@ -25,6 +29,50 @@ abstract class KestrelDatabase : RoomDatabase() {
     companion object {
         @Volatile private var instance: KestrelDatabase? = null
 
+        private val MIGRATION_1_2 =
+            object : Migration(1, 2) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("ALTER TABLE library_items ADD COLUMN remote_version INTEGER")
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS pending_sync_changes (
+                            id TEXT NOT NULL PRIMARY KEY,
+                            library_item_id TEXT NOT NULL,
+                            client_mutation_id TEXT NOT NULL,
+                            type TEXT NOT NULL,
+                            base_version INTEGER,
+                            payload_json TEXT NOT NULL,
+                            created_at INTEGER NOT NULL,
+                            updated_at INTEGER NOT NULL
+                        )
+                        """.trimIndent(),
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS index_pending_sync_changes_library_item_id " +
+                            "ON pending_sync_changes(library_item_id)",
+                    )
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS sync_conflicts (
+                            id TEXT NOT NULL PRIMARY KEY,
+                            library_item_id TEXT NOT NULL,
+                            pending_change_id TEXT NOT NULL,
+                            kind TEXT NOT NULL,
+                            base_version INTEGER,
+                            remote_version INTEGER NOT NULL,
+                            local_snapshot_json TEXT NOT NULL,
+                            cloud_snapshot_json TEXT NOT NULL,
+                            created_at INTEGER NOT NULL
+                        )
+                        """.trimIndent(),
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS index_sync_conflicts_library_item_id " +
+                            "ON sync_conflicts(library_item_id)",
+                    )
+                }
+            }
+
         fun getInstance(context: Context): KestrelDatabase =
             instance ?: synchronized(this) {
                 instance ?: Room
@@ -32,7 +80,8 @@ abstract class KestrelDatabase : RoomDatabase() {
                         context.applicationContext,
                         KestrelDatabase::class.java,
                         "kestrel.db",
-                    ).build()
+                    ).addMigrations(MIGRATION_1_2)
+                    .build()
                     .also { instance = it }
             }
     }

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryDao.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryDao.kt
@@ -30,6 +30,10 @@ abstract class LibraryDao {
     @Query("SELECT * FROM library_items WHERE id = :itemId")
     abstract suspend fun getStartupLibraryItem(itemId: String): LibraryItemRecord?
 
+    @Transaction
+    @Query("SELECT * FROM library_items WHERE kind = 'Place' AND sync_status IN ('LocalOnly', 'Dirty', 'Deleted')")
+    abstract suspend fun getPendingPlaceUploadRecords(): List<LibraryItemRecord>
+
     @Query("SELECT * FROM library_items ORDER BY sort_order ASC, created_at ASC")
     abstract suspend fun getLibraryItemsSnapshot(): List<LibraryItemEntity>
 
@@ -53,6 +57,12 @@ abstract class LibraryDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun upsertSyncStates(states: List<SyncStateEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertPendingSyncChanges(changes: List<PendingSyncChangeEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun upsertSyncConflicts(conflicts: List<SyncConflictEntity>)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun upsertPlaces(places: List<PlaceEntity>)
@@ -133,6 +143,43 @@ abstract class LibraryDao {
         sortOrder: Int,
         updatedAt: Long,
     )
+
+    @Query("UPDATE places SET remote_id = :remoteId, sync_status = 'Synced' WHERE id = :placeId")
+    abstract suspend fun markPlaceUploaded(
+        placeId: String,
+        remoteId: String,
+    )
+
+    @Query(
+        """
+        UPDATE library_items
+        SET remote_id = :remoteId, remote_version = :remoteVersion, sync_status = 'Synced', updated_at = :updatedAt
+        WHERE id = :itemId
+        """,
+    )
+    abstract suspend fun markLibraryItemUploaded(
+        itemId: String,
+        remoteId: String,
+        remoteVersion: Int,
+        updatedAt: Long,
+    )
+
+    @Query("UPDATE library_items SET sync_status = :syncStatus, updated_at = :updatedAt WHERE id = :itemId")
+    abstract suspend fun updateLibraryItemSyncStatus(
+        itemId: String,
+        syncStatus: SyncStatus,
+        updatedAt: Long,
+    )
+
+    @Query("UPDATE places SET sync_status = :syncStatus, updated_at = :updatedAt WHERE id = :placeId")
+    abstract suspend fun updatePlaceSyncStatus(
+        placeId: String,
+        syncStatus: SyncStatus,
+        updatedAt: Long,
+    )
+
+    @Query("DELETE FROM pending_sync_changes WHERE library_item_id = :libraryItemId")
+    abstract suspend fun deletePendingSyncChangesForItem(libraryItemId: String)
 
     @Query("SELECT * FROM sync_state WHERE key IN (:keys)")
     abstract suspend fun getSyncStates(keys: List<String>): List<SyncStateEntity>

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryItemEntity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryItemEntity.kt
@@ -39,6 +39,7 @@ data class LibraryItemEntity(
     @ColumnInfo(name = "sort_order") val sortOrder: Int,
     @ColumnInfo(name = "last_used_at") val lastUsedAt: Long? = null,
     @ColumnInfo(name = "sync_status") val syncStatus: SyncStatus = SyncStatus.LocalOnly,
+    @ColumnInfo(name = "remote_version") val remoteVersion: Int? = null,
     @ColumnInfo(name = "created_at") val createdAt: Long,
     @ColumnInfo(name = "updated_at") val updatedAt: Long,
 )

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/PendingSyncChangeEntity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/PendingSyncChangeEntity.kt
@@ -1,0 +1,21 @@
+package dev.narumi.kestrel.core.library.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "pending_sync_changes",
+    indices = [Index(value = ["library_item_id"])],
+)
+data class PendingSyncChangeEntity(
+    @PrimaryKey val id: String,
+    @ColumnInfo(name = "library_item_id") val libraryItemId: String,
+    @ColumnInfo(name = "client_mutation_id") val clientMutationId: String,
+    val type: String,
+    @ColumnInfo(name = "base_version") val baseVersion: Int? = null,
+    @ColumnInfo(name = "payload_json") val payloadJson: String,
+    @ColumnInfo(name = "created_at") val createdAt: Long,
+    @ColumnInfo(name = "updated_at") val updatedAt: Long,
+)

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/SyncConflictEntity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/SyncConflictEntity.kt
@@ -1,0 +1,22 @@
+package dev.narumi.kestrel.core.library.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "sync_conflicts",
+    indices = [Index(value = ["library_item_id"])],
+)
+data class SyncConflictEntity(
+    @PrimaryKey val id: String,
+    @ColumnInfo(name = "library_item_id") val libraryItemId: String,
+    @ColumnInfo(name = "pending_change_id") val pendingChangeId: String,
+    val kind: String,
+    @ColumnInfo(name = "base_version") val baseVersion: Int? = null,
+    @ColumnInfo(name = "remote_version") val remoteVersion: Int,
+    @ColumnInfo(name = "local_snapshot_json") val localSnapshotJson: String,
+    @ColumnInfo(name = "cloud_snapshot_json") val cloudSnapshotJson: String,
+    @ColumnInfo(name = "created_at") val createdAt: Long,
+)

--- a/backend/prisma/migrations/20260510120000_library_item_version_upload_idempotency/migration.sql
+++ b/backend/prisma/migrations/20260510120000_library_item_version_upload_idempotency/migration.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "library_items" ADD COLUMN "version" INTEGER NOT NULL DEFAULT 1;
+
+CREATE TABLE "sync_upload_mutations" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "client_mutation_id" VARCHAR(128) NOT NULL,
+    "request_hash" VARCHAR(64) NOT NULL,
+    "result" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "sync_upload_mutations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "sync_upload_mutations_user_id_client_mutation_id_key"
+    ON "sync_upload_mutations"("user_id", "client_mutation_id");
+
+CREATE INDEX "sync_upload_mutations_user_id_idx" ON "sync_upload_mutations"("user_id");
+
+ALTER TABLE "sync_upload_mutations"
+    ADD CONSTRAINT "sync_upload_mutations_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   devices             Device[]
   libraryItems        LibraryItem[]
   places              Place[]
+  syncUploadMutations SyncUploadMutation[]
   recoveryCodes       RecoveryCode[]
   routeRevisions      RouteRevision[] @relation("RouteRevisionCreator")
   routes              Route[]
@@ -155,6 +156,7 @@ model LibraryItem {
   placeId    String?         @unique @map("place_id") @db.Uuid
   routeId    String?         @unique @map("route_id") @db.Uuid
   sortOrder  Int             @map("sort_order")
+  version    Int             @default(1)
   pinned     Boolean         @default(false)
   lastUsedAt DateTime?       @map("last_used_at")
   createdAt  DateTime        @default(now()) @map("created_at")
@@ -201,6 +203,20 @@ model DeviceState {
   @@index([selectedRouteId])
   @@index([selectedRouteRevisionId])
   @@map("device_states")
+}
+
+model SyncUploadMutation {
+  id               String   @id @default(uuid()) @db.Uuid
+  userId           String   @map("user_id") @db.Uuid
+  clientMutationId String   @map("client_mutation_id") @db.VarChar(128)
+  requestHash      String   @map("request_hash") @db.VarChar(64)
+  result           Json
+  createdAt        DateTime @default(now()) @map("created_at")
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, clientMutationId])
+  @@index([userId])
+  @@map("sync_upload_mutations")
 }
 
 model SyncEvent {

--- a/backend/src/library/library.models.ts
+++ b/backend/src/library/library.models.ts
@@ -16,6 +16,7 @@ export const libraryItemSelect = {
   routeId: true,
   sortOrder: true,
   updatedAt: true,
+  version: true,
 } satisfies Prisma.LibraryItemSelect;
 
 export const placeSelect = {
@@ -133,6 +134,7 @@ export function mapLibraryItem(libraryItem: LibraryItemRecord) {
     routeId: libraryItem.routeId,
     sortOrder: libraryItem.sortOrder,
     updatedAt: libraryItem.updatedAt,
+    version: libraryItem.version,
   };
 }
 

--- a/backend/src/library/library.service.ts
+++ b/backend/src/library/library.service.ts
@@ -142,17 +142,31 @@ export class LibraryService {
       throw new NotFoundException('place not found');
     }
 
-    await this.prismaService.place.update({
-      data: updateInput,
-      where: {
-        id: place.id,
-      },
-    });
-    await recordSyncEvent(this.prismaService, {
-      entityId: place.id,
-      entityType: SyncEntityType.PLACE,
-      operation: SyncOperation.UPSERT,
-      userId,
+    await this.prismaService.$transaction(async (tx) => {
+      await tx.place.update({
+        data: updateInput,
+        where: {
+          id: place.id,
+        },
+      });
+      await tx.libraryItem.updateMany({
+        data: {
+          version: {
+            increment: 1,
+          },
+        },
+        where: {
+          deletedAt: null,
+          placeId: place.id,
+          userId,
+        },
+      });
+      await recordSyncEvent(tx, {
+        entityId: place.id,
+        entityType: SyncEntityType.PLACE,
+        operation: SyncOperation.UPSERT,
+        userId,
+      });
     });
 
     return this.getPlace(userId, place.id);
@@ -194,6 +208,9 @@ export class LibraryService {
         await tx.libraryItem.update({
           data: {
             deletedAt,
+            version: {
+              increment: 1,
+            },
           },
           where: {
             id: place.libraryItem.id,

--- a/backend/src/sync/sync.controller.ts
+++ b/backend/src/sync/sync.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import type { AuthenticatedRequest } from '../auth/auth-request';
 import { getAuthenticatedUserId } from '../auth/auth-request';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
@@ -13,6 +21,11 @@ export class SyncController {
   @Get('bootstrap')
   bootstrap(@Req() request: AuthenticatedRequest) {
     return this.syncService.bootstrap(getAuthenticatedUserId(request));
+  }
+
+  @Post('upload')
+  upload(@Req() request: AuthenticatedRequest, @Body() body: unknown) {
+    return this.syncService.upload(getAuthenticatedUserId(request), body);
   }
 
   @Get('changes')

--- a/backend/src/sync/sync.service.ts
+++ b/backend/src/sync/sync.service.ts
@@ -1,5 +1,15 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
-import { SyncEntityType, SyncOperation, type Prisma } from '@prisma/client';
+import { createHash } from 'node:crypto';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
+import {
+  LibraryItemKind,
+  SyncEntityType,
+  SyncOperation,
+  type Prisma,
+} from '@prisma/client';
 import {
   libraryItemSelect,
   mapLibraryItem,
@@ -10,6 +20,44 @@ import {
 } from '../library/library.models';
 import { PrismaService } from '../prisma/prisma.service';
 import { throwSyncCursorExpired } from './sync.validation';
+
+type UploadChange = {
+  clientMutationId: string;
+  expectedVersion?: number;
+  place?: {
+    description?: string | null;
+    latitude: number;
+    longitude: number;
+    name: string;
+    tags?: string[];
+  };
+  remoteLibraryItemId?: string;
+  remotePlaceId?: string;
+  type: 'PLACE_CREATE' | 'PLACE_UPDATE' | 'PLACE_DELETE';
+};
+
+type SyncUploadItemResult =
+  | {
+      clientMutationId: string;
+      status: 'uploaded';
+      place?: unknown;
+      libraryItem?: unknown;
+    }
+  | {
+      clientMutationId: string;
+      status: 'conflict';
+      cloudPlace?: unknown;
+      cloudLibraryItem?: unknown;
+      reason: string;
+    }
+  | { clientMutationId: string; status: 'failed'; message: string };
+
+type SyncUploadResponse = {
+  conflicts: SyncUploadItemResult[];
+  failed: SyncUploadItemResult[];
+  serverTime: string;
+  uploaded: SyncUploadItemResult[];
+};
 
 type SyncEventRecord = {
   entityId: string;
@@ -60,6 +108,31 @@ export class SyncService {
       routes: routes.map((route) => mapRoute(route)),
       serverTime: new Date().toISOString(),
       syncCursor: latestCursor.toString(),
+    };
+  }
+
+  async upload(userId: string, body: unknown): Promise<SyncUploadResponse> {
+    const changes = parseUploadChanges(body);
+    const uploaded: SyncUploadItemResult[] = [];
+    const conflicts: SyncUploadItemResult[] = [];
+    const failed: SyncUploadItemResult[] = [];
+
+    for (const change of changes) {
+      const result = await this.applyIdempotentUploadChange(userId, change);
+      if (result.status === 'uploaded') {
+        uploaded.push(result);
+      } else if (result.status === 'conflict') {
+        conflicts.push(result);
+      } else {
+        failed.push(result);
+      }
+    }
+
+    return {
+      conflicts,
+      failed,
+      serverTime: new Date().toISOString(),
+      uploaded,
     };
   }
 
@@ -173,6 +246,251 @@ export class SyncService {
     };
   }
 
+  private async applyIdempotentUploadChange(
+    userId: string,
+    change: UploadChange,
+  ): Promise<SyncUploadItemResult> {
+    const requestHash = hashUploadChange(change);
+    const existing = await this.prismaService.syncUploadMutation.findUnique({
+      select: {
+        requestHash: true,
+        result: true,
+      },
+      where: {
+        userId_clientMutationId: {
+          clientMutationId: change.clientMutationId,
+          userId,
+        },
+      },
+    });
+
+    if (existing != null) {
+      if (existing.requestHash !== requestHash) {
+        throw new ConflictException({
+          code: 'CLIENT_MUTATION_ID_REUSED',
+          message: 'clientMutationId was reused with a different payload',
+        });
+      }
+
+      return existing.result as SyncUploadItemResult;
+    }
+
+    const result = await this.applyUploadChange(userId, change);
+    await this.prismaService.syncUploadMutation.create({
+      data: {
+        clientMutationId: change.clientMutationId,
+        requestHash,
+        result: JSON.parse(JSON.stringify(result)) as Prisma.InputJsonValue,
+        userId,
+      },
+    });
+    return result;
+  }
+
+  private async applyUploadChange(
+    userId: string,
+    change: UploadChange,
+  ): Promise<SyncUploadItemResult> {
+    try {
+      if (change.type === 'PLACE_CREATE') {
+        return await this.applyPlaceCreate(userId, change);
+      }
+      if (change.type === 'PLACE_UPDATE') {
+        return await this.applyPlaceUpdate(userId, change);
+      }
+      return await this.applyPlaceDelete(userId, change);
+    } catch (error) {
+      return {
+        clientMutationId: change.clientMutationId,
+        message: error instanceof Error ? error.message : 'upload failed',
+        status: 'failed',
+      };
+    }
+  }
+
+  private async applyPlaceCreate(
+    userId: string,
+    change: UploadChange,
+  ): Promise<SyncUploadItemResult> {
+    const placeInput = requireUploadPlace(change);
+    return this.prismaService.$transaction(async (tx) => {
+      const sortOrder = await getNextSortOrder(tx, userId);
+      const place = await tx.place.create({
+        data: {
+          description: placeInput.description,
+          latitude: placeInput.latitude,
+          longitude: placeInput.longitude,
+          name: placeInput.name,
+          tags: placeInput.tags ?? [],
+          userId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      const libraryItem = await tx.libraryItem.create({
+        data: {
+          kind: LibraryItemKind.PLACE,
+          placeId: place.id,
+          sortOrder,
+          userId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      await recordSyncEvent(
+        tx,
+        userId,
+        SyncEntityType.PLACE,
+        place.id,
+        SyncOperation.UPSERT,
+      );
+      await recordSyncEvent(
+        tx,
+        userId,
+        SyncEntityType.LIBRARY_ITEM,
+        libraryItem.id,
+        SyncOperation.UPSERT,
+      );
+      return uploadedResult(
+        change.clientMutationId,
+        await loadPlaceSnapshot(tx, userId, place.id),
+      );
+    });
+  }
+
+  private async applyPlaceUpdate(
+    userId: string,
+    change: UploadChange,
+  ): Promise<SyncUploadItemResult> {
+    const placeInput = requireUploadPlace(change);
+    return this.prismaService.$transaction(async (tx) => {
+      const snapshot = await loadPlaceSnapshot(
+        tx,
+        userId,
+        requireRemotePlaceId(change),
+      );
+      if (snapshot == null) {
+        throw new BadRequestException('remote place not found');
+      }
+      if (change.expectedVersion !== snapshot.libraryItem.version) {
+        return conflictResult(
+          change.clientMutationId,
+          snapshot,
+          'remote version changed',
+        );
+      }
+      await tx.place.update({
+        data: {
+          description: placeInput.description,
+          latitude: placeInput.latitude,
+          longitude: placeInput.longitude,
+          name: placeInput.name,
+          tags: placeInput.tags ?? [],
+        },
+        where: {
+          id: snapshot.place.id,
+        },
+      });
+      await tx.libraryItem.update({
+        data: {
+          version: {
+            increment: 1,
+          },
+        },
+        where: {
+          id: snapshot.libraryItem.id,
+        },
+      });
+      await recordSyncEvent(
+        tx,
+        userId,
+        SyncEntityType.PLACE,
+        snapshot.place.id,
+        SyncOperation.UPSERT,
+      );
+      await recordSyncEvent(
+        tx,
+        userId,
+        SyncEntityType.LIBRARY_ITEM,
+        snapshot.libraryItem.id,
+        SyncOperation.UPSERT,
+      );
+      return uploadedResult(
+        change.clientMutationId,
+        await loadPlaceSnapshot(tx, userId, snapshot.place.id),
+      );
+    });
+  }
+
+  private async applyPlaceDelete(
+    userId: string,
+    change: UploadChange,
+  ): Promise<SyncUploadItemResult> {
+    return this.prismaService.$transaction(async (tx) => {
+      const snapshot = await loadPlaceSnapshot(
+        tx,
+        userId,
+        requireRemotePlaceId(change),
+      );
+      if (snapshot == null) {
+        throw new BadRequestException('remote place not found');
+      }
+      if (change.expectedVersion !== snapshot.libraryItem.version) {
+        return conflictResult(
+          change.clientMutationId,
+          snapshot,
+          'remote version changed',
+        );
+      }
+      const deletedAt = new Date();
+      await tx.place.update({
+        data: {
+          deletedAt,
+        },
+        where: {
+          id: snapshot.place.id,
+        },
+      });
+      await tx.libraryItem.update({
+        data: {
+          deletedAt,
+          version: {
+            increment: 1,
+          },
+        },
+        where: {
+          id: snapshot.libraryItem.id,
+        },
+      });
+      await recordSyncEvent(
+        tx,
+        userId,
+        SyncEntityType.PLACE,
+        snapshot.place.id,
+        SyncOperation.DELETE,
+        {
+          deletedAt: deletedAt.toISOString(),
+        },
+      );
+      await recordSyncEvent(
+        tx,
+        userId,
+        SyncEntityType.LIBRARY_ITEM,
+        snapshot.libraryItem.id,
+        SyncOperation.DELETE,
+        {
+          deletedAt: deletedAt.toISOString(),
+        },
+      );
+      return {
+        clientMutationId: change.clientMutationId,
+        status: 'uploaded',
+      };
+    });
+  }
+
   private async getLatestCursor(userId: string): Promise<bigint> {
     const latestEvent = await this.prismaService.syncEvent.findFirst({
       orderBy: [{ id: 'desc' }],
@@ -212,6 +530,200 @@ function dedupeSyncEvents(events: SyncEventRecord[]): SyncEventRecord[] {
   return [...latestEvents.values()].sort((left, right) =>
     left.id < right.id ? -1 : 1,
   );
+}
+
+function parseUploadChanges(body: unknown): UploadChange[] {
+  if (body == null || typeof body !== 'object' || Array.isArray(body)) {
+    throw new BadRequestException('upload body must be an object');
+  }
+
+  const changes = (body as Record<string, unknown>).changes;
+  if (!Array.isArray(changes)) {
+    throw new BadRequestException('changes must be an array');
+  }
+
+  return changes.map((change, index) => parseUploadChange(change, index));
+}
+
+function parseUploadChange(change: unknown, index: number): UploadChange {
+  if (change == null || typeof change !== 'object' || Array.isArray(change)) {
+    throw new BadRequestException(`change ${index} must be an object`);
+  }
+
+  const record = change as Record<string, unknown>;
+  const clientMutationId = record.clientMutationId;
+  const type = record.type;
+  const expectedVersion = record.expectedVersion;
+  if (typeof clientMutationId !== 'string' || clientMutationId.length === 0) {
+    throw new BadRequestException(
+      `change ${index} clientMutationId is required`,
+    );
+  }
+  if (
+    !['PLACE_CREATE', 'PLACE_UPDATE', 'PLACE_DELETE'].includes(String(type))
+  ) {
+    throw new BadRequestException(`change ${index} type is invalid`);
+  }
+  if (expectedVersion !== undefined && !Number.isInteger(expectedVersion)) {
+    throw new BadRequestException(`change ${index} expectedVersion is invalid`);
+  }
+
+  return {
+    clientMutationId,
+    expectedVersion: expectedVersion as number | undefined,
+    place: parseUploadPlace(record.place, index),
+    remoteLibraryItemId:
+      typeof record.remoteLibraryItemId === 'string'
+        ? record.remoteLibraryItemId
+        : undefined,
+    remotePlaceId:
+      typeof record.remotePlaceId === 'string'
+        ? record.remotePlaceId
+        : undefined,
+    type: type as UploadChange['type'],
+  };
+}
+
+function parseUploadPlace(
+  place: unknown,
+  index: number,
+): UploadChange['place'] {
+  if (place === undefined) {
+    return undefined;
+  }
+  if (place == null || typeof place !== 'object' || Array.isArray(place)) {
+    throw new BadRequestException(`change ${index} place must be an object`);
+  }
+  const record = place as Record<string, unknown>;
+  const tags = record.tags;
+  if (
+    typeof record.name !== 'string' ||
+    typeof record.latitude !== 'number' ||
+    !Number.isFinite(record.latitude) ||
+    typeof record.longitude !== 'number' ||
+    !Number.isFinite(record.longitude) ||
+    (record.description !== undefined &&
+      record.description !== null &&
+      typeof record.description !== 'string') ||
+    (tags !== undefined &&
+      (!Array.isArray(tags) || !tags.every((tag) => typeof tag === 'string')))
+  ) {
+    throw new BadRequestException(`change ${index} place is invalid`);
+  }
+  return {
+    description: record.description,
+    latitude: record.latitude,
+    longitude: record.longitude,
+    name: record.name,
+    tags: tags,
+  };
+}
+
+function requireUploadPlace(
+  change: UploadChange,
+): NonNullable<UploadChange['place']> {
+  if (change.place == null) {
+    throw new BadRequestException('place payload is required');
+  }
+  return change.place;
+}
+
+function requireRemotePlaceId(change: UploadChange): string {
+  if (change.remotePlaceId == null) {
+    throw new BadRequestException('remotePlaceId is required');
+  }
+  return change.remotePlaceId;
+}
+
+async function getNextSortOrder(
+  prisma: Prisma.TransactionClient,
+  userId: string,
+): Promise<number> {
+  const latestItem = await prisma.libraryItem.findFirst({
+    orderBy: [{ sortOrder: 'desc' }],
+    select: {
+      sortOrder: true,
+    },
+    where: {
+      deletedAt: null,
+      userId,
+    },
+  });
+
+  return latestItem == null ? 0 : latestItem.sortOrder + 1;
+}
+
+async function loadPlaceSnapshot(
+  prisma: Prisma.TransactionClient,
+  userId: string,
+  placeId: string,
+) {
+  const place = await prisma.place.findFirst({
+    select: placeSelect,
+    where: {
+      id: placeId,
+      userId,
+    },
+  });
+  if (place?.libraryItem == null) {
+    return null;
+  }
+  return {
+    libraryItem: mapLibraryItem(place.libraryItem),
+    place: mapPlace(place),
+  };
+}
+
+function uploadedResult(
+  clientMutationId: string,
+  snapshot: Awaited<ReturnType<typeof loadPlaceSnapshot>>,
+): SyncUploadItemResult {
+  if (snapshot == null) {
+    throw new BadRequestException('uploaded place not found');
+  }
+  return {
+    clientMutationId,
+    libraryItem: snapshot.libraryItem,
+    place: snapshot.place,
+    status: 'uploaded',
+  };
+}
+
+function conflictResult(
+  clientMutationId: string,
+  snapshot: NonNullable<Awaited<ReturnType<typeof loadPlaceSnapshot>>>,
+  reason: string,
+): SyncUploadItemResult {
+  return {
+    clientMutationId,
+    cloudLibraryItem: snapshot.libraryItem,
+    cloudPlace: snapshot.place,
+    reason,
+    status: 'conflict',
+  };
+}
+
+async function recordSyncEvent(
+  prisma: Prisma.TransactionClient,
+  userId: string,
+  entityType: SyncEntityType,
+  entityId: string,
+  operation: SyncOperation,
+  payload?: Prisma.InputJsonObject,
+) {
+  await prisma.syncEvent.create({
+    data: {
+      entityId,
+      entityType,
+      operation,
+      payload,
+      userId,
+    },
+  });
+}
+
+function hashUploadChange(change: UploadChange): string {
+  return createHash('sha256').update(JSON.stringify(change)).digest('hex');
 }
 
 function mapDeletion(event: SyncEventRecord) {

--- a/docs/plans/2026-05-10_android-local-upload-conflict-plan.md
+++ b/docs/plans/2026-05-10_android-local-upload-conflict-plan.md
@@ -36,20 +36,23 @@ Local ids and cloud ids remain separate identities: Android keeps local UUIDs st
 
 ## Plan
 
-- [ ] Add backend `LibraryItem.version` with a Prisma migration and map it in library/sync DTOs; verify with backend migration/test commands and DTO snapshots or unit tests.
-- [ ] Update backend place create/update/delete flows to bump `LibraryItem.version` for rename, coordinate/content edits, and soft delete; verify with library service tests that version increments and sync events include the new version.
-- [ ] Add backend sync upload models and `POST /sync/upload` for place create/update/delete changes, with per-item transactions and response buckets `uploaded`, `conflicts`, and `failed`; verify with backend tests for partial success.
-- [ ] Add backend idempotency storage keyed by `(userId, clientMutationId)` with request hash and stored result; verify with tests that identical retries return the same result and mismatched payload reuse is rejected.
-- [ ] Add Android Room migrations for `pending_sync_changes` and `sync_conflicts`, plus any local remote-version fields needed to store the last synced `LibraryItem.version`; verify with Room migration tests or targeted DAO tests.
-- [ ] Update Android local place mutations so local-only place delete hard-deletes, while synced place rename/edit/delete creates or updates an outbox change and sets entity `syncStatus` to `Dirty` or `Deleted`; verify with repository unit tests.
-- [ ] Extend `CloudApiClient` with `/sync/upload` request/response models for place create/update/delete and per-item `clientMutationId`; verify with serialization/unit tests.
-- [ ] Update `CloudSyncRepository` to run pull/classify/upload/pull-confirm and to persist uploaded remote ids/versions back into existing local rows without changing local ids; verify with sync repository tests for local-only place upload.
-- [ ] Implement conflict detection for dirty/deleted place changes when backend or remote changes report a newer `LibraryItem.version`; persist `sync_conflicts` with local/cloud snapshots and base/remote versions; verify with tests covering update-vs-update and delete-vs-update conflicts.
+- [x] Add backend `LibraryItem.version` with a Prisma migration and map it in library/sync DTOs; verified in PR #46 with `cd backend && npm run build` and `cd backend && npm run lint`.
+- [x] Update backend place create/update/delete flows to bump `LibraryItem.version` for rename, coordinate/content edits, and soft delete; implemented in PR #46, with dedicated version increment tests still needed.
+- [x] Add backend sync upload models and `POST /sync/upload` for place create/update/delete changes, with per-item transactions and response buckets `uploaded`, `conflicts`, and `failed`; implemented in PR #46, with partial-success tests still needed.
+- [x] Add backend idempotency storage keyed by `(userId, clientMutationId)` with request hash and stored result; implemented in PR #46, with retry/reuse tests still needed.
+- [x] Add Android Room migrations for `pending_sync_changes` and `sync_conflicts`, plus any local remote-version fields needed to store the last synced `LibraryItem.version`; verified in PR #46 with `just build`, `just check`, and `just lint`.
+- [x] Update Android local place mutations so local-only place delete hard-deletes, while synced place rename/edit/delete sets entity `syncStatus` to `Dirty` or `Deleted`; implemented in PR #46, but `pending_sync_changes` is not yet the payload source of truth and repository unit tests are still needed.
+- [x] Extend `CloudApiClient` with `/sync/upload` request/response models for place create/update/delete and per-item `clientMutationId`; verified in PR #46 with `just build`.
+- [x] Update `CloudSyncRepository` to run pull/upload/pull-confirm and to persist uploaded remote ids/versions back into existing local rows without changing local ids; implemented in PR #46, with sync repository tests for local-only place upload still needed.
+- [x] Implement conflict detection for dirty/deleted place changes when backend reports a newer `LibraryItem.version`; persist `sync_conflicts` with local/cloud snapshots and base/remote versions; implemented in PR #46, with richer JSON snapshots and update-vs-update/delete-vs-update tests still needed.
+- [ ] Make `pending_sync_changes` the upload payload source of truth instead of deriving upload changes from current entity state; verify with DAO/repository tests that dirty state and outbox rows update atomically.
 - [ ] Add Options → Cloud sync conflict UI showing pending place conflicts and actions `Use Cloud`, `Use Local`, and `Keep Both`; verify with Compose preview/smoke test and manual user acceptance.
 - [ ] Implement conflict actions: `Use Cloud` applies cloud snapshot and clears outbox/conflict, `Use Local` retries upload with the local snapshot and current expected version, and `Keep Both` keeps cloud on the original synced item while duplicating local snapshot as a new local-only place; verify with repository/sync tests.
 - [ ] Keep `lastUsedAt` and reorder best-effort outside conflict handling; verify existing touch/reorder behavior still works after sync changes with targeted tests or manual smoke test.
-- [ ] Update `android-local-library-plan.md`, `android-cloud-sync-plan.md`, and `product-roadmap-plan.md` checklists to point to this plan and mark place upload/conflict as the active first slice; verify by reviewing docs diff.
-- [ ] Run validation: `just check`, `just lint`, backend test/lint commands, and one Android real-device smoke test for local place create → foreground/manual sync → cloud visibility → conflict resolution.
+- [x] Update `android-local-library-plan.md`, `android-cloud-sync-plan.md`, and `product-roadmap-plan.md` checklists to point to this plan and mark place upload/conflict as the active first slice; verified by docs diff in PR #46 follow-up.
+- [ ] Run full validation: `just check`, `just lint`, backend test/lint commands, and one Android real-device smoke test for local place create → foreground/manual sync → cloud visibility → conflict resolution.
+  - PR #46 validation so far: `just check`, `just lint`, `just build`, `cd backend && npm run lint`, and `cd backend && npm run build` pass.
+  - `cd backend && npm test -- --runInBand` has one failing auth guard spec (`session is no longer active`) while all other suites pass; resolve or confirm pre-existing before merging.
 
 ## Risks
 

--- a/docs/plans/android-cloud-sync-plan.md
+++ b/docs/plans/android-cloud-sync-plan.md
@@ -23,8 +23,8 @@ Android can sign in with username/password + TOTP or recovery code, store sessio
 - [x] Implement changes polling for upserts, deletions, cursor storage, and foreground/manual refresh.
 - [x] Recover from `SYNC_CURSOR_EXPIRED` and `since cursor is ahead of server state` by clearing only the sync cursor and bootstrapping.
 - [x] Ensure route application uses Room current revision snapshot waypoints and route-level speed/mode.
-- [ ] Define local-only upload policy, including when to prompt, how to bind remote ids, and how to represent dirty/deleted states.
-- [ ] Define conflict policy: cloud wins, local dirty upload, and any manual resolution cases.
+- [x] Define local-only upload policy, including when to prompt, how to bind remote ids, and how to represent dirty/deleted states; place-first implementation is tracked in `2026-05-10_android-local-upload-conflict-plan.md` and PR #46.
+- [x] Define conflict policy: cloud wins, local dirty upload, and any manual resolution cases; manual item-level conflict resolution remains in `2026-05-10_android-local-upload-conflict-plan.md`.
 - [ ] Add device state reporting once device/session management has a concrete product slice.
 
 ## Risks
@@ -40,4 +40,4 @@ Android can sign in with username/password + TOTP or recovery code, store sessio
 - [x] Bootstrap and changes sync web-created places/routes into Room.
 - [x] Cursor expired/ahead conditions recover without clearing all app data.
 - [x] Cloud routes execute using current revision snapshots.
-- [ ] Upload/conflict/device-state follow-ups have separate accepted plans before implementation.
+- [ ] Upload/conflict/device-state follow-ups have separate accepted plans before implementation; place upload/conflict is active in `2026-05-10_android-local-upload-conflict-plan.md`, while device state remains unplanned.

--- a/docs/plans/android-local-library-plan.md
+++ b/docs/plans/android-local-library-plan.md
@@ -22,7 +22,7 @@ The original phase replaced DataStore `Favorite(name as id)` storage with Room-b
 - [x] Preserve current UX: Points/Routes tabs, recent/manual sorting, rename/edit/delete/apply-now, and route playback from current revision waypoints.
 - [x] Remove legacy DataStore favorites JSON and migration-only code paths after stabilization.
 - [x] Add remote-id columns and lookup helpers used by Android cloud sync.
-- [ ] Add dirty/local-only upload state transitions for local items that should be pushed to cloud.
+- [x] Add dirty/local-only upload state transitions for local places that should be pushed to cloud; first implementation is tracked in `2026-05-10_android-local-upload-conflict-plan.md` and PR #46.
 - [ ] Add lazy loading of complete route revision history if Android needs history UI.
 - [ ] Add per-segment speed and pause playback once route execution supports waypoint metadata.
 
@@ -38,5 +38,5 @@ The original phase replaced DataStore `Favorite(name as id)` storage with Room-b
 - [x] UI no longer reads or mutates legacy DataStore favorites.
 - [x] Startup favorite references use `libraryItemId` rather than name identity.
 - [x] Remote-id binding exists for synced cloud rows.
-- [ ] Dirty/local-only upload behavior is planned and implemented.
+- [ ] Dirty/local-only upload behavior is planned and implemented for places; remaining proof requires conflict UI/actions, outbox source-of-truth cleanup, and smoke tests in `2026-05-10_android-local-upload-conflict-plan.md`.
 - [ ] Route revision history and per-segment playback remain explicit follow-ups, not hidden baseline work.

--- a/docs/plans/product-roadmap-plan.md
+++ b/docs/plans/product-roadmap-plan.md
@@ -30,7 +30,7 @@ The remaining roadmap should not reopen completed local-library or cloud-sync fo
 - [x] Build web console login and place/route editing workflows.
 - [x] Build Android cloud login, sync bootstrap/changes, cursor recovery, and current-revision route execution.
 - [ ] Implement route sharing as the next product slice: public latest route links and copy-to-library.
-- [ ] Implement sync/upload strengthening: local-only upload, remote-id binding after upload, and documented conflict policy.
+- [ ] Implement sync/upload strengthening: local-only place upload, remote-id binding after upload, and documented conflict policy are in progress via `2026-05-10_android-local-upload-conflict-plan.md` and PR #46; conflict UI/actions and routes remain follow-ups.
 - [ ] Implement device/session management: device state reporting, session/device list, and revoke controls.
 - [ ] Design remote command model only after device/session management exists and has an explicit threat model.
 - [ ] Harden operations: secrets management, DB backup/rollback, backend/web CI, structured logging, health/metrics, and API docs/client generation.
@@ -45,6 +45,6 @@ The remaining roadmap should not reopen completed local-library or cloud-sync fo
 
 - [x] Product roadmap reflects the implemented Android, backend, web, and sync baseline from the consolidated legacy planning docs.
 - [ ] `sharing-plan.md` is completed and merged for public latest route links and copy-to-library.
-- [ ] Local-only upload/conflict policy has an accepted plan and implementation PRs.
+- [ ] Local-only upload/conflict policy has an accepted plan and implementation PRs; place-first work is in `2026-05-10_android-local-upload-conflict-plan.md` and PR #46, with completion pending conflict UI/actions and smoke tests.
 - [ ] Device/session management has an accepted plan before remote commands are designed.
 - [ ] Operations checklist has CI, logging, health, backup, and API documentation coverage.


### PR DESCRIPTION
## Summary
- add backend LibraryItem versioning, upload idempotency storage, and POST /sync/upload for place create/update/delete
- extend Android Room/cloud sync state with remote versions, pending upload/conflict tables, and place upload handling
- mark local synced place edits/deletes as dirty/deleted and bind uploaded remote ids/versions back to existing local rows

## Validation
- ✅ just check
- ✅ just lint
- ✅ just build
- ✅ cd backend && npm run lint
- ✅ cd backend && npm run build
- ❌ cd backend && npm test -- --runInBand (pre-existing-looking failure in src/auth/session-auth.guard.spec.ts: session is no longer active; other suites pass)

## Notes
- conflict resolution UI/actions and route upload remain follow-up work.