### PR TITLE
fix(web): verify stored session before exposing isAuthenticated

### DIFF
--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -30,15 +30,64 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const storedSession = window.localStorage.getItem(STORAGE_KEY);
 
-    if (storedSession != null) {
-      try {
-        setSession(JSON.parse(storedSession) as AuthSession);
-      } catch {
-        window.localStorage.removeItem(STORAGE_KEY);
-      }
+    if (storedSession == null) {
+      setIsHydrated(true);
+      return;
     }
 
-    setIsHydrated(true);
+    let parsedSession: AuthSession;
+
+    try {
+      parsedSession = JSON.parse(storedSession) as AuthSession;
+    } catch {
+      window.localStorage.removeItem(STORAGE_KEY);
+      setIsHydrated(true);
+      return;
+    }
+
+    // Verify the stored session by refreshing its access token before we
+    // expose `isAuthenticated = true`. Without this, a stale or
+    // server-rejected session would let `LoginPage` redirect to
+    // `/dashboard`, which then bounces back to `/login` once the first
+    // protected request 401s. During that loop the login form is
+    // technically mounted but its tab buttons feel unclickable because
+    // the router is mid-navigation.
+    let cancelled = false;
+
+    refreshSession(parsedSession.refreshToken)
+      .then((refreshed) => {
+        if (cancelled) {
+          return;
+        }
+
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(refreshed));
+        setSession(refreshed);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+
+        // Only drop the stored session when the backend explicitly
+        // rejected the refresh token. Network errors / 5xx keep it so a
+        // transient outage doesn't sign the user out.
+        if (error instanceof ApiError && error.status === 401) {
+          window.localStorage.removeItem(STORAGE_KEY);
+          setSession(null);
+          return;
+        }
+
+        setSession(parsedSession);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsHydrated(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const saveSession = useCallback((nextSession: AuthSession) => {


### PR DESCRIPTION
## Why

When the web app boots with a stale session in `localStorage` (e.g. the backend rotated `AUTH_ACCESS_TOKEN_SECRET`, or the database was reset for testing), the current flow is:

1. `AuthProvider` hydrates → `isAuthenticated = true`.
2. `LoginPage` sees `isHydrated && isAuthenticated` → `router.replace('/dashboard')`.
3. Dashboard's first protected request 401s → `/auth/refresh` fails → `logout()` → redirect back to `/login`.

During this redirect cycle the login form is mounted but the **Login / Register tab buttons feel unclickable** because the router is mid-navigation. The only recoveries today are clearing localStorage manually or using an incognito window. Hit during smoke-test setup for the upload/conflict plan; reproducible whenever the dev stack is rebuilt.

## What

In `AuthProvider`'s hydration `useEffect`:

- Parse the stored session, then call `refreshSession(refreshToken)` before setting `isHydrated = true`.
- On success, persist the rotated tokens and expose the session.
- On `ApiError` with `status === 401`, the backend has explicitly rejected the refresh token — clear localStorage and start unauthenticated.
- On any other error (network, 5xx), keep the stored session so a transient outage doesn't sign the user out.
- Guard against unmount with a `cancelled` flag.

The login form still renders while the in-flight verify runs (`isHydrated` stays false during that window, matching today's behavior), so tabs and inputs are interactive on cold load.

## Validation

- `just check`, `just lint` pass.
- Manual: with a stale `kestrel.web.session` injected into localStorage, page now stays on `/login` with working tabs instead of bouncing through `/dashboard`.

## Out of scope

- Refactoring AuthProvider to a finite state machine. Single boolean works for this fix.
- Adding a 'verifying session…' UI; current behavior renders the form during verification, which is acceptable.