### PR TITLE
ci: harden backend lane and tighten biome hook scope (PR #58 follow-ups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma client
+        run: npx prisma generate
+
       - name: Lint
         run: npm run lint
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
         entry: bash -c 'cd web && npm exec -- biome ci .'
         language: system
         pass_filenames: false
-        files: ^web/.*$
+        files: ^web/.*\.(ts|tsx|js|jsx|json|jsonc|css)$

--- a/backend/README.md
+++ b/backend/README.md
@@ -52,6 +52,7 @@ npm run lint
 npm run test
 npm run test:e2e
 npm run typecheck
+npm run build
 ```
 
 ## Database utilities

--- a/docs/plans/2026-05-12_pr58-ci-followups-plan.md
+++ b/docs/plans/2026-05-12_pr58-ci-followups-plan.md
@@ -23,13 +23,13 @@ PR #58 adds `backend` and `web` jobs to `.github/workflows/ci.yml`, renames the 
 
 ## Plan
 
-Ordered; steps 1–4 are merge-blockers for #58, step 5 is post-merge backlog grooming.
+Ordered; steps 1–4 are merge-blockers for #58, step 5 is post-merge backlog grooming. PR #58 merged before this plan executed (merge commit `92aa04f`), so the follow-ups land in PR #59 against `main`.
 
-- [ ] **Verify branch protection required checks** on `main` via `gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts`; if `ci` is listed, update to `android`, `backend`, `web` (or ask user to do it in repo settings) before merging #58. Acceptance: command output shows the new job names, or user confirms update done.
-- [ ] **Add explicit `prisma generate` step** in the `backend` job of `.github/workflows/ci.yml`, right after `npm ci`, running `npx prisma generate`; verify by re-running the workflow on the PR and seeing the step succeed (`gh run watch` or PR checks tab).
-- [ ] **Restore `npm run build` in `backend/README.md`** alongside `npm run typecheck` (do not replace one with the other); verify by `grep -E 'typecheck|build' backend/README.md` showing both lines under the available-commands block.
-- [ ] **Tighten pre-commit `biome` hook `files:` pattern** in `.pre-commit-config.yaml` from `^web/.*$` to `^web/.*\.(ts|tsx|js|jsx|json|jsonc|css)$`; verify with `prek run biome --files web/README.md` skipping and `prek run biome --files web/app/page.tsx` running.
-- [ ] **File backlog entries** in `docs/plans/engineering-backlog-plan.md` for: (a) per-workspace `paths:` filter on CI jobs, (b) optional `nest build` step in backend CI, (c) decide policy for promoting backend `test:e2e` to CI. Verify by `grep` finding the three new `- [ ]` lines.
+- [x] Not applicable: `gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts` returned `Branch not protected` — `main` has no required status checks, so the `ci` → `android`/`backend`/`web` rename does not need a settings update.
+- [x] **Added explicit `prisma generate` step** in the `backend` job of `.github/workflows/ci.yml` after `npm ci`. Verified by `gh run view --job 75413868903 --log | grep "Generate Prisma client"` showing `Prisma schema loaded from prisma/schema.prisma` and the step succeeding.
+- [x] **Restored `npm run build` in `backend/README.md`** alongside `npm run typecheck`. Verified by `grep -E 'typecheck|build' backend/README.md` showing both `npm run typecheck` and `npm run build` in the validation block.
+- [x] **Tightened pre-commit `biome` hook `files:` pattern** in `.pre-commit-config.yaml` to `^web/.*\.(ts|tsx|js|jsx|json|jsonc|css)$`. Verified by `prek run biome --files web/README.md` → `Skipped (no files to check)` and `prek run biome --files web/app/layout.tsx` → `Passed`.
+- [x] **Filed three backlog entries** in `docs/plans/engineering-backlog-plan.md` for: (a) per-workspace `paths:` filter on CI jobs, (b) optional `nest build` step in backend CI, (c) policy for promoting backend `test:e2e` into CI. Verified by `grep -c 'Surfaced by PR #58 review' docs/plans/engineering-backlog-plan.md` → `3`.
 
 ## Risks
 
@@ -43,9 +43,10 @@ Ordered; steps 1–4 are merge-blockers for #58, step 5 is post-merge backlog gr
 
 ## Completion Checklist
 
-- [ ] `gh pr checks 58` shows `android`, `backend`, `web` all green, with `backend` including a visible `Generate Prisma client` step in the job log.
-- [ ] `main` branch protection required checks list matches the three job names, verified by `gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts` or explicit user confirmation.
-- [ ] `backend/README.md` lists both `npm run typecheck` and `npm run build` in the commands block (verified by `grep`).
-- [ ] `.pre-commit-config.yaml` `biome` hook `files:` pattern excludes `web/README.md` and includes `web/app/**/*.tsx` (verified by two `prek run biome --files …` invocations).
-- [ ] `docs/plans/engineering-backlog-plan.md` contains three new `- [ ]` items for the deferred follow-ups (paths filter, `nest build` in CI, e2e-in-CI policy), verified by `grep`.
-- [ ] PR #58 is merged to `main` (verified by `gh pr view 58 --json state -q .state` returning `MERGED`).
+- [x] `gh pr checks 59` shows `android`, `backend`, `web` all `pass` (run `25687177914`); `backend` job log contains the `Generate Prisma client` step with `Prisma schema loaded from prisma/schema.prisma`.
+- [x] Not applicable: `main` has no branch protection (`gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts` → `Branch not protected`), so there is no required-check list to align.
+- [x] `backend/README.md` lists both `npm run typecheck` and `npm run build` in the validation block (`grep -E 'typecheck|build' backend/README.md`).
+- [x] `.pre-commit-config.yaml` `biome` hook `files:` pattern excludes `web/README.md` and includes `web/app/**/*.tsx`, verified by `prek run biome --files web/README.md` (Skipped) and `prek run biome --files web/app/layout.tsx` (Passed).
+- [x] `docs/plans/engineering-backlog-plan.md` contains three new `- [ ]` items tagged `Surfaced by PR #58 review` (paths filter, `nest build` in CI, e2e-in-CI policy), verified by `grep -c 'Surfaced by PR #58 review' docs/plans/engineering-backlog-plan.md` → `3`.
+- [x] PR #58 is merged to `main` (`gh pr view 58 --json state -q .state` → `MERGED`, merge commit `92aa04f`).
+- [ ] PR #59 is merged to `main` (verified by `gh pr view 59 --json state -q .state` returning `MERGED`).

--- a/docs/plans/2026-05-12_pr58-ci-followups-plan.md
+++ b/docs/plans/2026-05-12_pr58-ci-followups-plan.md
@@ -1,0 +1,51 @@
+# PR #58 CI Lanes Follow-ups
+
+## Goal
+
+Address review feedback on PR #58 (`copilot/add-backend-ci-test-lint-typecheck`) so that backend/web CI lanes are robust, do not silently break `main` merges, and have explicit (not implicit) dependencies. Success = PR #58 merges cleanly with required checks green, and the four follow-up items below are either landed or filed as bounded backlog entries.
+
+## Context
+
+PR #58 adds `backend` and `web` jobs to `.github/workflows/ci.yml`, renames the original `ci` job to `android`, adds a `biome` pre-commit hook, a `typecheck` script in `backend/`, and a `lint` script in `web/`. Review surfaced 8 points; this plan tracks the ones that affect correctness/merge-ability and pushes the rest to backlog.
+
+## Non-Goals
+
+- Adding `paths:` filter / per-workspace job gating (deferred to backlog).
+- Adding web unit tests or e2e tests.
+- Promoting backend `test:e2e` into CI.
+- Making Android unit tests blocking.
+
+## Assumptions
+
+- `main` branch protection currently lists `ci` (the old single job name) as a required status check. To be verified in step 1.
+- `@prisma/client` v5+ auto-runs `prisma generate` via its own postinstall, so backend specs currently type-check by accident; we want this explicit.
+- Backend `*.spec.ts` files are pure unit tests with mocks and need no live Postgres or env vars.
+
+## Plan
+
+Ordered; steps 1–4 are merge-blockers for #58, step 5 is post-merge backlog grooming.
+
+- [ ] **Verify branch protection required checks** on `main` via `gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts`; if `ci` is listed, update to `android`, `backend`, `web` (or ask user to do it in repo settings) before merging #58. Acceptance: command output shows the new job names, or user confirms update done.
+- [ ] **Add explicit `prisma generate` step** in the `backend` job of `.github/workflows/ci.yml`, right after `npm ci`, running `npx prisma generate`; verify by re-running the workflow on the PR and seeing the step succeed (`gh run watch` or PR checks tab).
+- [ ] **Restore `npm run build` in `backend/README.md`** alongside `npm run typecheck` (do not replace one with the other); verify by `grep -E 'typecheck|build' backend/README.md` showing both lines under the available-commands block.
+- [ ] **Tighten pre-commit `biome` hook `files:` pattern** in `.pre-commit-config.yaml` from `^web/.*$` to `^web/.*\.(ts|tsx|js|jsx|json|jsonc|css)$`; verify with `prek run biome --files web/README.md` skipping and `prek run biome --files web/app/page.tsx` running.
+- [ ] **File backlog entries** in `docs/plans/engineering-backlog-plan.md` for: (a) per-workspace `paths:` filter on CI jobs, (b) optional `nest build` step in backend CI, (c) decide policy for promoting backend `test:e2e` to CI. Verify by `grep` finding the three new `- [ ]` lines.
+
+## Risks
+
+- **Branch protection drift**: if step 1 is skipped, `main` will be unmergeable after #58 lands because the old `ci` check never reports. Mitigation: step 1 is gating.
+- **Prisma postinstall behavior change**: future Prisma majors may drop auto-generate. Step 2 makes this explicit and immune to that change.
+- **Pre-commit pattern over-tightening**: tightening `files:` could miss future config files (e.g. `web/biome.json` edits). Mitigation: included `json`/`jsonc` in the pattern.
+
+## Rollback / Recovery
+
+- Revert via `git revert` of the follow-up commit; the only production-touching surface is `.github/workflows/ci.yml`, which has no deploy side effects. Branch protection rule changes are reversible in repo settings.
+
+## Completion Checklist
+
+- [ ] `gh pr checks 58` shows `android`, `backend`, `web` all green, with `backend` including a visible `Generate Prisma client` step in the job log.
+- [ ] `main` branch protection required checks list matches the three job names, verified by `gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts` or explicit user confirmation.
+- [ ] `backend/README.md` lists both `npm run typecheck` and `npm run build` in the commands block (verified by `grep`).
+- [ ] `.pre-commit-config.yaml` `biome` hook `files:` pattern excludes `web/README.md` and includes `web/app/**/*.tsx` (verified by two `prek run biome --files …` invocations).
+- [ ] `docs/plans/engineering-backlog-plan.md` contains three new `- [ ]` items for the deferred follow-ups (paths filter, `nest build` in CI, e2e-in-CI policy), verified by `grep`.
+- [ ] PR #58 is merged to `main` (verified by `gh pr view 58 --json state -q .state` returning `MERGED`).

--- a/docs/plans/engineering-backlog-plan.md
+++ b/docs/plans/engineering-backlog-plan.md
@@ -13,6 +13,9 @@ This backlog comes from the general TODO and the operations/DX sections of the c
 - [ ] Add Android GitHub Actions CI for PRs: `just check`, `just lint`, and `:app:assembleDebug`, with Gradle cache.
 - [x] Add backend CI for test, lint, and typecheck.
 - [x] Add web CI for lint/typecheck/build.
+- [ ] Add `paths:` filter (or `dorny/paths-filter`) to `.github/workflows/ci.yml` so `android`, `backend`, and `web` jobs only run when their respective workspace files change. Surfaced by PR #58 review.
+- [ ] Add an optional `nest build` step to the `backend` CI job to catch `nest-cli.json` / asset-copy regressions that `typecheck` misses. Surfaced by PR #58 review.
+- [ ] Decide policy for promoting backend `test:e2e` into CI (separate job with Postgres service vs. nightly vs. keep local-only). Surfaced by PR #58 review.
 - [ ] Add API structured logging with request id, auth user/session metadata where safe, and error classification.
 - [ ] Add API metrics and health checks suitable for Docker/production monitoring.
 - [ ] Write secrets management strategy for deploy: required env vars, rotation, and local `.env` guidance.


### PR DESCRIPTION
Follow-ups from the review of #58 (already merged). Implements `docs/plans/2026-05-12_pr58-ci-followups-plan.md`.

## Changes

- **backend CI** (`.github/workflows/ci.yml`): add explicit `npx prisma generate` step after `npm ci`, so type checks and tests stop silently relying on `@prisma/client` postinstall behavior.
- **backend/README.md**: restore `npm run build` next to `npm run typecheck` in the validation block; `nest build` does more than type checking and shouldn't disappear from docs.
- **.pre-commit-config.yaml**: tighten the `biome` hook `files:` pattern from `^web/.*$` to `^web/.*\.(ts|tsx|js|jsx|json|jsonc|css)$`, so editing `web/README.md` no longer re-lints the whole web tree.
- **docs/plans/engineering-backlog-plan.md**: file three deferred items flagged in the #58 review:
  - `paths:` filter for per-workspace CI jobs
  - optional `nest build` step in backend CI
  - policy for promoting backend `test:e2e` into CI
- **docs/plans/2026-05-12_pr58-ci-followups-plan.md**: the plan driving this PR.

## Plan reference

- Plan step 1 (branch protection sync): **N/A** — `gh api repos/.../branches/main/protection/required_status_checks/contexts` returned `Branch not protected`, so no required-check rename was needed.
- Plan steps 2–5: covered by this PR.

## Verification

- `prek run` against the changed files: all hooks Passed; the new `biome` hook correctly Skipped this changeset (no `web/**` files touched), confirming the tightened pattern still excludes non-source paths.
- Regex sanity check on the new pattern: matches `web/app/page.tsx`, `web/biome.json`, `web/app/layout.css`; excludes `web/README.md` and `app/build.gradle.kts`.
- The new `Generate Prisma client` step will be exercised by this PR's own `backend` CI job run.