### PR TITLE
docs(readme): document the three CI lanes and paths-filter gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ Use `just cloud-down` to stop the stack.
 
 ---
 
+## 🤖 Continuous Integration
+
+`.github/workflows/ci.yml` runs three lanes on every PR and push to `main`:
+
+| Lane | What it runs | Triggers on |
+|---|---|---|
+| `android` | `spotlessCheck`, `detekt`, `:app:assembleDebug`, unit tests (non-blocking), uploads `app-debug.apk` artifact | changes under `app/`, top-level Gradle files, `detekt*`, `justfile`, or `.github/workflows/ci.yml` |
+| `backend` | `npm ci`, `prisma generate`, `lint`, `test`, `test:e2e`, `typecheck`, `build` | changes under `backend/` or `.github/workflows/ci.yml` |
+| `web` | `npm ci`, `lint`, `typecheck`, `build` | changes under `web/` or `.github/workflows/ci.yml` |
+
+A leading `changes` job uses `dorny/paths-filter` to gate each lane, so a PR touching only one workspace skips the others. Push events to `main` always run all three.
+
+---
+
 ## 🔐 Permissions
 
 ```xml


### PR DESCRIPTION
Adds a short **Continuous Integration** section to `README.md` describing what each lane (`android` / `backend` / `web`) runs and when it triggers, after the gating added in #60.

Also serves as the **skip-behavior smoke** required by `docs/plans/2026-05-12_ci-lane-followups-plan.md`:
this PR only touches `README.md`, so `android`, `backend`, and `web` jobs should all report `Skipped` and only `changes` should run.

## Expected CI shape

- `changes`: pass (always runs)
- `android`: skipped (no path under `app/`, no Gradle/detekt/justfile/workflow change)
- `backend`: skipped (no path under `backend/`, no workflow change)
- `web`: skipped (no path under `web/`, no workflow change)

If any of the three lanes runs instead of skipping, the glob in `.github/workflows/ci.yml` is over-eager and needs tightening.