### PR TITLE
feat(sharing): add public route links and copy-to-library flow

### DIFF
--- a/backend/prisma/migrations/20260513110000_sharing_links/migration.sql
+++ b/backend/prisma/migrations/20260513110000_sharing_links/migration.sql
@@ -1,0 +1,36 @@
+CREATE TYPE "SharePermission" AS ENUM ('PUBLIC_READ');
+
+CREATE TABLE "share_links" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "owner_id" UUID NOT NULL,
+    "route_id" UUID NOT NULL,
+    "route_revision_id" UUID,
+    "token" VARCHAR(128) NOT NULL,
+    "permission" "SharePermission" NOT NULL DEFAULT 'PUBLIC_READ',
+    "disabled_at" TIMESTAMP(3),
+    "expires_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "share_links_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "share_links_token_key" ON "share_links"("token");
+CREATE INDEX "share_links_owner_id_idx" ON "share_links"("owner_id");
+CREATE INDEX "share_links_route_id_idx" ON "share_links"("route_id");
+CREATE INDEX "share_links_route_revision_id_idx" ON "share_links"("route_revision_id");
+CREATE UNIQUE INDEX "share_links_owner_id_route_id_active_latest_key"
+    ON "share_links"("owner_id", "route_id")
+    WHERE "disabled_at" IS NULL AND "route_revision_id" IS NULL;
+
+ALTER TABLE "share_links"
+    ADD CONSTRAINT "share_links_owner_id_fkey"
+    FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "share_links"
+    ADD CONSTRAINT "share_links_route_id_fkey"
+    FOREIGN KEY ("route_id") REFERENCES "routes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "share_links"
+    ADD CONSTRAINT "share_links_route_revision_id_fkey"
+    FOREIGN KEY ("route_revision_id") REFERENCES "route_revisions"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   devices             Device[]
   libraryItems        LibraryItem[]
   places              Place[]
+  shareLinks          ShareLink[]
   syncUploadMutations SyncUploadMutation[]
   recoveryCodes       RecoveryCode[]
   routeRevisions      RouteRevision[] @relation("RouteRevisionCreator")
@@ -109,22 +110,23 @@ model Place {
 }
 
 model Route {
-  id                String         @id @default(uuid()) @db.Uuid
-  userId            String         @map("user_id") @db.Uuid
-  name              String         @db.VarChar(128)
-  description       String?        @db.VarChar(1024)
-  defaultSpeedKmh   Float          @map("default_speed_kmh")
+  id                String          @id @default(uuid()) @db.Uuid
+  userId            String          @map("user_id") @db.Uuid
+  name              String          @db.VarChar(128)
+  description       String?         @db.VarChar(1024)
+  defaultSpeedKmh   Float           @map("default_speed_kmh")
   mode              RouteMode
-  currentRevisionId String?        @unique @map("current_revision_id") @db.Uuid
-  isPublic          Boolean        @default(false) @map("is_public")
-  createdAt         DateTime       @default(now()) @map("created_at")
-  updatedAt         DateTime       @updatedAt @map("updated_at")
-  deletedAt         DateTime?      @map("deleted_at")
-  user              User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-  currentRevision   RouteRevision? @relation("RouteCurrentRevision", fields: [currentRevisionId], references: [id], onDelete: SetNull)
+  currentRevisionId String?         @unique @map("current_revision_id") @db.Uuid
+  isPublic          Boolean         @default(false) @map("is_public")
+  createdAt         DateTime        @default(now()) @map("created_at")
+  updatedAt         DateTime        @updatedAt @map("updated_at")
+  deletedAt         DateTime?       @map("deleted_at")
+  user              User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  currentRevision   RouteRevision?  @relation("RouteCurrentRevision", fields: [currentRevisionId], references: [id], onDelete: SetNull)
   revisions         RouteRevision[] @relation("RouteRevisions")
+  shareLinks        ShareLink[]
   libraryItem       LibraryItem?
-  deviceStates      DeviceState[]  @relation("DeviceSelectedRoute")
+  deviceStates      DeviceState[]   @relation("DeviceSelectedRoute")
 
   @@index([userId])
   @@index([userId, deletedAt])
@@ -141,6 +143,7 @@ model RouteRevision {
   route             Route          @relation("RouteRevisions", fields: [routeId], references: [id], onDelete: Cascade)
   creator           User           @relation("RouteRevisionCreator", fields: [createdBy], references: [id], onDelete: Cascade)
   currentForRoute   Route?         @relation("RouteCurrentRevision")
+  shareLinks        ShareLink[]
   deviceStates      DeviceState[]  @relation("DeviceSelectedRouteRevision")
 
   @@unique([routeId, revisionNumber])
@@ -205,6 +208,27 @@ model DeviceState {
   @@map("device_states")
 }
 
+model ShareLink {
+  id              String          @id @default(uuid()) @db.Uuid
+  ownerId         String          @map("owner_id") @db.Uuid
+  routeId         String          @map("route_id") @db.Uuid
+  routeRevisionId String?         @map("route_revision_id") @db.Uuid
+  token           String          @unique @db.VarChar(128)
+  permission      SharePermission @default(PUBLIC_READ)
+  disabledAt      DateTime?       @map("disabled_at")
+  expiresAt       DateTime?       @map("expires_at")
+  createdAt       DateTime        @default(now()) @map("created_at")
+  updatedAt       DateTime        @updatedAt @map("updated_at")
+  owner           User            @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  route           Route           @relation(fields: [routeId], references: [id], onDelete: Cascade)
+  routeRevision   RouteRevision?  @relation(fields: [routeRevisionId], references: [id], onDelete: SetNull)
+
+  @@index([ownerId])
+  @@index([routeId])
+  @@index([routeRevisionId])
+  @@map("share_links")
+}
+
 model SyncUploadMutation {
   id               String   @id @default(uuid()) @db.Uuid
   userId           String   @map("user_id") @db.Uuid
@@ -251,6 +275,10 @@ enum PlaybackState {
   SINGLE
   ROUTE
   PAUSED
+}
+
+enum SharePermission {
+  PUBLIC_READ
 }
 
 enum RouteMode {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { LibraryModule } from './library/library.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { SyncModule } from './sync/sync.module';
+import { SharingModule } from './sharing/sharing.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { SyncModule } from './sync/sync.module';
     AuthModule,
     LibraryModule,
     SyncModule,
+    SharingModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/library/library.models.ts
+++ b/backend/src/library/library.models.ts
@@ -138,7 +138,7 @@ export function mapLibraryItem(libraryItem: LibraryItemRecord) {
   };
 }
 
-function mapRouteRevision(revision: {
+export function mapRouteRevision(revision: {
   createdAt: Date;
   createdBy: string;
   id: string;

--- a/backend/src/sharing/sharing.controller.ts
+++ b/backend/src/sharing/sharing.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { AuthenticatedRequest } from '../auth/auth-request';
+import { getAuthenticatedUserId } from '../auth/auth-request';
+import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { SharingService } from './sharing.service';
+
+@Controller()
+export class SharingController {
+  constructor(private readonly sharingService: SharingService) {}
+
+  @UseGuards(SessionAuthGuard)
+  @Get('routes/:routeId/share-link')
+  getRouteShareLink(
+    @Req() request: AuthenticatedRequest,
+    @Param('routeId') routeId: string,
+  ) {
+    return this.sharingService.getRouteShareLink(
+      getAuthenticatedUserId(request),
+      routeId,
+    );
+  }
+
+  @UseGuards(SessionAuthGuard)
+  @Post('routes/:routeId/share-link')
+  createRouteShareLink(
+    @Req() request: AuthenticatedRequest,
+    @Param('routeId') routeId: string,
+  ) {
+    return this.sharingService.createRouteShareLink(
+      getAuthenticatedUserId(request),
+      routeId,
+    );
+  }
+
+  @UseGuards(SessionAuthGuard)
+  @Patch('routes/:routeId/share-link')
+  updateRouteShareLink(
+    @Req() request: AuthenticatedRequest,
+    @Param('routeId') routeId: string,
+    @Body() body: unknown,
+  ) {
+    return this.sharingService.updateRouteShareLink(
+      getAuthenticatedUserId(request),
+      routeId,
+      body,
+    );
+  }
+
+  @Get('shares/:token')
+  getSharedRoute(@Param('token') token: string) {
+    return this.sharingService.getSharedRoute(token);
+  }
+
+  @UseGuards(SessionAuthGuard)
+  @Post('shares/:token/copy')
+  copySharedRoute(
+    @Req() request: AuthenticatedRequest,
+    @Param('token') token: string,
+  ) {
+    return this.sharingService.copySharedRoute(
+      getAuthenticatedUserId(request),
+      token,
+    );
+  }
+}

--- a/backend/src/sharing/sharing.models.ts
+++ b/backend/src/sharing/sharing.models.ts
@@ -1,0 +1,32 @@
+import { type Prisma } from '@prisma/client';
+
+export const shareLinkSelect = {
+  createdAt: true,
+  disabledAt: true,
+  expiresAt: true,
+  id: true,
+  permission: true,
+  routeId: true,
+  routeRevisionId: true,
+  token: true,
+  updatedAt: true,
+} satisfies Prisma.ShareLinkSelect;
+
+type ShareLinkRecord = Prisma.ShareLinkGetPayload<{
+  select: typeof shareLinkSelect;
+}>;
+
+export function mapShareLink(shareLink: ShareLinkRecord) {
+  return {
+    createdAt: shareLink.createdAt,
+    disabledAt: shareLink.disabledAt,
+    expiresAt: shareLink.expiresAt,
+    id: shareLink.id,
+    permission: shareLink.permission,
+    publicUrl: `/share/${shareLink.token}`,
+    routeId: shareLink.routeId,
+    routeRevisionId: shareLink.routeRevisionId,
+    token: shareLink.token,
+    updatedAt: shareLink.updatedAt,
+  };
+}

--- a/backend/src/sharing/sharing.module.ts
+++ b/backend/src/sharing/sharing.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SharingController } from './sharing.controller';
+import { SharingService } from './sharing.service';
+
+@Module({
+  imports: [AuthModule, PrismaModule],
+  controllers: [SharingController],
+  providers: [SharingService],
+})
+export class SharingModule {}

--- a/backend/src/sharing/sharing.service.spec.ts
+++ b/backend/src/sharing/sharing.service.spec.ts
@@ -1,0 +1,553 @@
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  LibraryItemKind,
+  RouteMode,
+  SyncEntityType,
+  SyncOperation,
+} from '@prisma/client';
+import { SharingService } from './sharing.service';
+
+describe('SharingService', () => {
+  let sharingService: SharingService;
+  let prismaService: ReturnType<typeof createMockPrismaService>;
+
+  beforeEach(() => {
+    prismaService = createMockPrismaService();
+    prismaService.$transaction.mockImplementation((callback) =>
+      callback({
+        libraryItem: prismaService.libraryItem,
+        route: prismaService.route,
+        routeRevision: prismaService.routeRevision,
+        shareLink: prismaService.shareLink,
+        syncEvent: prismaService.syncEvent,
+      }),
+    );
+    sharingService = new SharingService(prismaService as never);
+  });
+
+  it('returns not found when a different owner asks for a route share link', async () => {
+    prismaService.route.findFirst.mockResolvedValue(null);
+
+    await expect(
+      sharingService.getRouteShareLink('user-1', 'route-1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('creates one latest share link per owner route and reuses it later', async () => {
+    prismaService.route.findFirst
+      .mockResolvedValueOnce({
+        currentRevisionId: 'revision-1',
+        id: 'route-1',
+      })
+      .mockResolvedValueOnce({
+        id: 'route-1',
+      });
+    prismaService.shareLink.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        createShareLinkRecord({
+          disabledAt: null,
+          routeId: 'route-1',
+          token: 'share-token-1',
+        }),
+      );
+    prismaService.shareLink.create.mockResolvedValue(
+      createShareLinkRecord({
+        disabledAt: null,
+        routeId: 'route-1',
+        token: 'share-token-1',
+      }),
+    );
+
+    const created = await sharingService.createRouteShareLink(
+      'user-1',
+      'route-1',
+    );
+    const fetched = await sharingService.getRouteShareLink('user-1', 'route-1');
+
+    expect(created).toMatchObject({
+      publicUrl: '/share/share-token-1',
+      routeId: 'route-1',
+      token: 'share-token-1',
+    });
+    expect(fetched).toMatchObject({
+      publicUrl: '/share/share-token-1',
+      token: 'share-token-1',
+    });
+    expect(prismaService.shareLink.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables and re-enables an existing share link', async () => {
+    prismaService.route.findFirst.mockResolvedValue({
+      id: 'route-1',
+    });
+    prismaService.shareLink.findFirst.mockResolvedValue(
+      createShareLinkRecord({
+        disabledAt: null,
+        routeId: 'route-1',
+        token: 'share-token-1',
+      }),
+    );
+    prismaService.shareLink.update
+      .mockResolvedValueOnce(
+        createShareLinkRecord({
+          disabledAt: new Date('2026-05-13T12:00:00.000Z'),
+          routeId: 'route-1',
+          token: 'share-token-1',
+        }),
+      )
+      .mockResolvedValueOnce(
+        createShareLinkRecord({
+          disabledAt: null,
+          routeId: 'route-1',
+          token: 'share-token-1',
+        }),
+      );
+
+    const disabled = await sharingService.updateRouteShareLink(
+      'user-1',
+      'route-1',
+      {
+        disabled: true,
+      },
+    );
+    const enabled = await sharingService.updateRouteShareLink(
+      'user-1',
+      'route-1',
+      {
+        disabled: false,
+      },
+    );
+
+    expect(disabled.disabledAt).toEqual(new Date('2026-05-13T12:00:00.000Z'));
+    expect(enabled.disabledAt).toBeNull();
+  });
+
+  it('rejects disabled public links', async () => {
+    prismaService.shareLink.findUnique.mockResolvedValue(
+      createPublicShareRecord({
+        disabledAt: new Date('2026-05-13T12:00:00.000Z'),
+      }),
+    );
+
+    await expect(
+      sharingService.getSharedRoute('share-token-1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects expired public links', async () => {
+    prismaService.shareLink.findUnique.mockResolvedValue(
+      createPublicShareRecord({
+        expiresAt: new Date('2026-05-12T12:00:00.000Z'),
+      }),
+    );
+
+    await expect(
+      sharingService.getSharedRoute('share-token-1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('returns a sanitized public route snapshot without owner metadata', async () => {
+    prismaService.shareLink.findUnique.mockResolvedValue(
+      createPublicShareRecord({}),
+    );
+
+    const result = await sharingService.getSharedRoute('share-token-1');
+
+    expect(result).toMatchObject({
+      route: {
+        description: 'Morning commute',
+        name: 'River ride',
+        revision: {
+          defaultSpeedKmh: 24,
+          mode: RouteMode.LOOP,
+          revisionNumber: 3,
+        },
+      },
+      shareLink: {
+        publicUrl: '/share/share-token-1',
+        token: 'share-token-1',
+      },
+    });
+    expect(result.route.revision.waypoints[0]).toMatchObject({
+      latitude: 25.03,
+      longitude: 121.56,
+      pauseSeconds: null,
+      sequence: 0,
+      speedKmh: null,
+    });
+    expect(result.route.revision).not.toHaveProperty('createdBy');
+    expect(result.route).not.toHaveProperty('id');
+  });
+
+  it('copies the currently visible shared snapshot into the caller library', async () => {
+    prismaService.shareLink.findUnique.mockResolvedValue(
+      createPublicShareRecord({}),
+    );
+    prismaService.libraryItem.findFirst.mockResolvedValue({
+      sortOrder: 4,
+    });
+    prismaService.route.create.mockResolvedValue({
+      id: 'copied-route-1',
+    });
+    prismaService.routeRevision.create.mockResolvedValue({
+      id: 'copied-revision-1',
+    });
+    prismaService.route.update.mockResolvedValue({
+      id: 'copied-route-1',
+    });
+    prismaService.libraryItem.create.mockResolvedValue({
+      id: 'library-item-9',
+    });
+    prismaService.route.findUniqueOrThrow.mockResolvedValue(
+      createRouteRecord({
+        defaultSpeedKmh: 24,
+        id: 'copied-route-1',
+        libraryItemId: 'library-item-9',
+        mode: RouteMode.LOOP,
+        revisionId: 'copied-revision-1',
+        revisionNumber: 1,
+      }),
+    );
+
+    const copiedRoute = await sharingService.copySharedRoute(
+      'user-2',
+      'share-token-1',
+    );
+
+    expect(prismaService.route.create).toHaveBeenCalledWith({
+      data: {
+        defaultSpeedKmh: 24,
+        description: 'Morning commute',
+        isPublic: false,
+        mode: RouteMode.LOOP,
+        name: 'River ride',
+        userId: 'user-2',
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(prismaService.routeRevision.create).toHaveBeenCalledWith({
+      data: {
+        createdBy: 'user-2',
+        payload: {
+          defaultSpeedKmh: 24,
+          mode: RouteMode.LOOP,
+          waypoints: [
+            {
+              latitude: 25.03,
+              longitude: 121.56,
+              pauseSeconds: null,
+              sequence: 0,
+              speedKmh: null,
+            },
+            {
+              latitude: 25.04,
+              longitude: 121.57,
+              pauseSeconds: null,
+              sequence: 1,
+              speedKmh: null,
+            },
+          ],
+        },
+        revisionNumber: 1,
+        routeId: 'copied-route-1',
+      },
+      select: {
+        id: true,
+      },
+    });
+    expect(prismaService.libraryItem.create).toHaveBeenCalledWith({
+      data: {
+        kind: LibraryItemKind.ROUTE,
+        routeId: 'copied-route-1',
+        sortOrder: 5,
+        userId: 'user-2',
+      },
+      select: {
+        id: true,
+      },
+    });
+    expectSyncEvents(prismaService.syncEvent.create, [
+      {
+        entityId: 'copied-route-1',
+        entityType: SyncEntityType.ROUTE,
+        operation: SyncOperation.UPSERT,
+        userId: 'user-2',
+      },
+      {
+        entityId: 'library-item-9',
+        entityType: SyncEntityType.LIBRARY_ITEM,
+        operation: SyncOperation.UPSERT,
+        userId: 'user-2',
+      },
+    ]);
+    expect(copiedRoute).toMatchObject({
+      currentRevision: {
+        id: 'copied-revision-1',
+        revisionNumber: 1,
+      },
+      id: 'copied-route-1',
+      libraryItem: {
+        id: 'library-item-9',
+      },
+      mode: RouteMode.LOOP,
+      name: 'River ride',
+    });
+  });
+
+  it('rejects creating a share link for a route missing its current revision', async () => {
+    prismaService.route.findFirst.mockResolvedValue({
+      currentRevisionId: null,
+      id: 'route-1',
+    });
+
+    await expect(
+      sharingService.createRouteShareLink('user-1', 'route-1'),
+    ).rejects.toThrow(InternalServerErrorException);
+  });
+});
+
+function createMockPrismaService() {
+  const createMock = <TReturn, TArgs extends unknown[]>() =>
+    jest.fn<TReturn, TArgs>();
+
+  return {
+    $transaction: createMock<
+      Promise<unknown>,
+      [
+        (
+          callback: (tx: {
+            libraryItem: {
+              create: jest.Mock<Promise<{ id: string }>, [unknown]>;
+              findFirst: jest.Mock<
+                Promise<{ sortOrder: number } | null>,
+                [unknown]
+              >;
+            };
+            route: {
+              create: jest.Mock<Promise<{ id: string }>, [unknown]>;
+              findFirst: jest.Mock<
+                Promise<Record<string, unknown> | null>,
+                [unknown]
+              >;
+              findUniqueOrThrow: jest.Mock<
+                Promise<ReturnType<typeof createRouteRecord>>,
+                [unknown]
+              >;
+              update: jest.Mock<Promise<{ id: string }>, [unknown]>;
+            };
+            routeRevision: {
+              create: jest.Mock<Promise<{ id: string }>, [unknown]>;
+            };
+            shareLink: {
+              create: jest.Mock<
+                Promise<ReturnType<typeof createShareLinkRecord>>,
+                [unknown]
+              >;
+              findFirst: jest.Mock<
+                Promise<ReturnType<typeof createShareLinkRecord> | null>,
+                [unknown]
+              >;
+              findUnique: jest.Mock<
+                Promise<ReturnType<typeof createPublicShareRecord> | null>,
+                [unknown]
+              >;
+              update: jest.Mock<
+                Promise<ReturnType<typeof createShareLinkRecord>>,
+                [unknown]
+              >;
+            };
+            syncEvent: {
+              create: jest.Mock<Promise<{ id: bigint }>, [unknown]>;
+            };
+          }) => Promise<unknown>,
+        ) => Promise<unknown>,
+      ]
+    >(),
+    libraryItem: {
+      create: createMock<Promise<{ id: string }>, [unknown]>(),
+      findFirst: createMock<Promise<{ sortOrder: number } | null>, [unknown]>(),
+    },
+    route: {
+      create: createMock<Promise<{ id: string }>, [unknown]>(),
+      findFirst: createMock<
+        Promise<Record<string, unknown> | null>,
+        [unknown]
+      >(),
+      findUniqueOrThrow: createMock<
+        Promise<ReturnType<typeof createRouteRecord>>,
+        [unknown]
+      >(),
+      update: createMock<Promise<{ id: string }>, [unknown]>(),
+    },
+    routeRevision: {
+      create: createMock<Promise<{ id: string }>, [unknown]>(),
+    },
+    shareLink: {
+      create: createMock<
+        Promise<ReturnType<typeof createShareLinkRecord>>,
+        [unknown]
+      >(),
+      findFirst: createMock<
+        Promise<ReturnType<typeof createShareLinkRecord> | null>,
+        [unknown]
+      >(),
+      findUnique: createMock<
+        Promise<ReturnType<typeof createPublicShareRecord> | null>,
+        [unknown]
+      >(),
+      update: createMock<
+        Promise<ReturnType<typeof createShareLinkRecord>>,
+        [unknown]
+      >(),
+    },
+    syncEvent: {
+      create: createMock<Promise<{ id: bigint }>, [unknown]>(),
+    },
+  };
+}
+
+function createShareLinkRecord(input: {
+  disabledAt: Date | null;
+  expiresAt?: Date | null;
+  routeId: string;
+  token: string;
+}) {
+  return {
+    createdAt: new Date('2026-05-13T10:00:00.000Z'),
+    disabledAt: input.disabledAt,
+    expiresAt: input.expiresAt ?? null,
+    id: 'share-link-1',
+    permission: 'PUBLIC_READ' as const,
+    routeId: input.routeId,
+    routeRevisionId: null,
+    token: input.token,
+    updatedAt: new Date('2026-05-13T10:00:00.000Z'),
+  };
+}
+
+function createPublicShareRecord(input: {
+  disabledAt?: Date | null;
+  expiresAt?: Date | null;
+}) {
+  return {
+    createdAt: new Date('2026-05-13T10:00:00.000Z'),
+    disabledAt: input.disabledAt ?? null,
+    expiresAt: input.expiresAt ?? null,
+    id: 'share-link-1',
+    permission: 'PUBLIC_READ' as const,
+    route: {
+      currentRevision: {
+        createdAt: new Date('2026-05-13T09:00:00.000Z'),
+        createdBy: 'user-1',
+        id: 'revision-3',
+        payload: {
+          defaultSpeedKmh: 24,
+          mode: RouteMode.LOOP,
+          waypoints: [
+            {
+              latitude: 25.03,
+              longitude: 121.56,
+              pauseSeconds: null,
+              sequence: 0,
+              speedKmh: null,
+            },
+            {
+              latitude: 25.04,
+              longitude: 121.57,
+              pauseSeconds: null,
+              sequence: 1,
+              speedKmh: null,
+            },
+          ],
+        },
+        revisionNumber: 3,
+      },
+      deletedAt: null,
+      description: 'Morning commute',
+      name: 'River ride',
+    },
+    routeId: 'route-1',
+    routeRevision: null,
+    routeRevisionId: null,
+    token: 'share-token-1',
+    updatedAt: new Date('2026-05-13T10:00:00.000Z'),
+  };
+}
+
+function createRouteRecord(input: {
+  defaultSpeedKmh: number;
+  id: string;
+  libraryItemId: string;
+  mode: RouteMode;
+  revisionId: string;
+  revisionNumber: number;
+}) {
+  return {
+    createdAt: new Date('2026-05-13T10:00:00.000Z'),
+    currentRevision: {
+      createdAt: new Date('2026-05-13T10:00:00.000Z'),
+      createdBy: 'user-2',
+      id: input.revisionId,
+      payload: {
+        defaultSpeedKmh: input.defaultSpeedKmh,
+        mode: input.mode,
+        waypoints: [
+          {
+            latitude: 25.03,
+            longitude: 121.56,
+            pauseSeconds: null,
+            sequence: 0,
+            speedKmh: null,
+          },
+          {
+            latitude: 25.04,
+            longitude: 121.57,
+            pauseSeconds: null,
+            sequence: 1,
+            speedKmh: null,
+          },
+        ],
+      },
+      revisionNumber: input.revisionNumber,
+    },
+    defaultSpeedKmh: input.defaultSpeedKmh,
+    deletedAt: null,
+    description: 'Morning commute',
+    id: input.id,
+    isPublic: false,
+    libraryItem: {
+      createdAt: new Date('2026-05-13T10:00:00.000Z'),
+      deletedAt: null,
+      id: input.libraryItemId,
+      kind: LibraryItemKind.ROUTE,
+      lastUsedAt: null,
+      pinned: false,
+      placeId: null,
+      routeId: input.id,
+      sortOrder: 5,
+      updatedAt: new Date('2026-05-13T10:00:00.000Z'),
+      version: 1,
+    },
+    mode: input.mode,
+    name: 'River ride',
+    updatedAt: new Date('2026-05-13T10:00:00.000Z'),
+  };
+}
+
+function expectSyncEvents(
+  createMock: jest.Mock<Promise<{ id: bigint }>, [unknown]>,
+  expectedData: unknown[],
+) {
+  expect(createMock.mock.calls).toHaveLength(expectedData.length);
+  expectedData.forEach((expectedEvent, index) => {
+    expect(createMock.mock.calls[index]?.[0]).toMatchObject({
+      data: expectedEvent,
+    });
+  });
+}

--- a/backend/src/sharing/sharing.service.ts
+++ b/backend/src/sharing/sharing.service.ts
@@ -1,0 +1,446 @@
+import { randomBytes } from 'node:crypto';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  LibraryItemKind,
+  RouteMode,
+  SyncEntityType,
+  SyncOperation,
+  type Prisma,
+} from '@prisma/client';
+import {
+  mapRoute,
+  mapRouteRevision,
+  routeRevisionSelect,
+  routeSelect,
+} from '../library/library.models';
+import { PrismaService } from '../prisma/prisma.service';
+import { mapShareLink, shareLinkSelect } from './sharing.models';
+import { parseShareLinkUpdateInput } from './sharing.validation';
+
+type SharedRouteRevision = {
+  createdAt: Date;
+  defaultSpeedKmh: number;
+  mode: RouteMode;
+  revisionNumber: number;
+  waypoints: Array<{
+    latitude: number;
+    longitude: number;
+    pauseSeconds: number | null;
+    sequence: number;
+    speedKmh: number | null;
+  }>;
+};
+
+type ShareLinkLookup = Prisma.ShareLinkGetPayload<{
+  select: typeof shareLinkSelect;
+}>;
+
+type PublicShareRecord = Prisma.ShareLinkGetPayload<{
+  select: {
+    createdAt: true;
+    disabledAt: true;
+    expiresAt: true;
+    id: true;
+    permission: true;
+    route: {
+      select: {
+        deletedAt: true;
+        description: true;
+        name: true;
+        currentRevision: {
+          select: typeof routeRevisionSelect;
+        };
+      };
+    };
+    routeId: true;
+    routeRevision: {
+      select: typeof routeRevisionSelect;
+    };
+    routeRevisionId: true;
+    token: true;
+    updatedAt: true;
+  };
+}>;
+
+@Injectable()
+export class SharingService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getRouteShareLink(userId: string, routeId: string) {
+    await this.assertOwnedRouteExists(userId, routeId);
+    const shareLink = await findLatestShareLink(
+      this.prismaService,
+      userId,
+      routeId,
+    );
+
+    if (shareLink == null) {
+      throw new NotFoundException('share link not found');
+    }
+
+    return mapShareLink(shareLink);
+  }
+
+  async createRouteShareLink(userId: string, routeId: string) {
+    await this.assertOwnedRouteReadyForSharing(userId, routeId);
+    const existingShareLink = await findLatestShareLink(
+      this.prismaService,
+      userId,
+      routeId,
+    );
+
+    if (existingShareLink != null) {
+      return mapShareLink(existingShareLink);
+    }
+
+    const shareLink = await this.prismaService.shareLink.create({
+      data: {
+        ownerId: userId,
+        routeId,
+        token: createShareToken(),
+      },
+      select: shareLinkSelect,
+    });
+
+    return mapShareLink(shareLink);
+  }
+
+  async updateRouteShareLink(userId: string, routeId: string, input: unknown) {
+    await this.assertOwnedRouteExists(userId, routeId);
+    const { disabled } = parseShareLinkUpdateInput(input);
+    const existingShareLink = await findLatestShareLink(
+      this.prismaService,
+      userId,
+      routeId,
+    );
+
+    if (existingShareLink == null) {
+      throw new NotFoundException('share link not found');
+    }
+
+    const updatedShareLink = await this.prismaService.shareLink.update({
+      data: {
+        disabledAt: disabled ? new Date() : null,
+      },
+      select: shareLinkSelect,
+      where: {
+        id: existingShareLink.id,
+      },
+    });
+
+    return mapShareLink(updatedShareLink);
+  }
+
+  async getSharedRoute(token: string) {
+    const shareLink = await this.getActiveShareLinkByToken(
+      this.prismaService,
+      token,
+    );
+    const revision = selectVisibleRevision(shareLink);
+
+    return {
+      route: {
+        description: shareLink.route.description,
+        name: shareLink.route.name,
+        revision: sanitizePublicRouteRevision(revision),
+      },
+      shareLink: mapShareLink({
+        createdAt: shareLink.createdAt,
+        disabledAt: shareLink.disabledAt,
+        expiresAt: shareLink.expiresAt,
+        id: shareLink.id,
+        permission: shareLink.permission,
+        routeId: shareLink.routeId,
+        routeRevisionId: shareLink.routeRevisionId,
+        token: shareLink.token,
+        updatedAt: shareLink.updatedAt,
+      }),
+    };
+  }
+
+  async copySharedRoute(userId: string, token: string) {
+    return this.prismaService.$transaction(async (tx) => {
+      const shareLink = await this.getActiveShareLinkByToken(tx, token);
+      const revision = selectVisibleRevision(shareLink);
+      const sortOrder = await getNextSortOrder(tx, userId);
+      const createdRoute = await tx.route.create({
+        data: {
+          defaultSpeedKmh: revision.defaultSpeedKmh,
+          description: shareLink.route.description,
+          isPublic: false,
+          mode: revision.mode,
+          name: shareLink.route.name,
+          userId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      const routeRevision = await tx.routeRevision.create({
+        data: {
+          createdBy: userId,
+          payload: createRouteRevisionPayload(revision),
+          revisionNumber: 1,
+          routeId: createdRoute.id,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      await tx.route.update({
+        data: {
+          currentRevisionId: routeRevision.id,
+        },
+        where: {
+          id: createdRoute.id,
+        },
+      });
+      const libraryItem = await tx.libraryItem.create({
+        data: {
+          kind: LibraryItemKind.ROUTE,
+          routeId: createdRoute.id,
+          sortOrder,
+          userId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      await recordSyncEvent(tx, {
+        entityId: createdRoute.id,
+        entityType: SyncEntityType.ROUTE,
+        operation: SyncOperation.UPSERT,
+        userId,
+      });
+      await recordSyncEvent(tx, {
+        entityId: libraryItem.id,
+        entityType: SyncEntityType.LIBRARY_ITEM,
+        operation: SyncOperation.UPSERT,
+        userId,
+      });
+
+      const copiedRoute = await tx.route.findUniqueOrThrow({
+        select: routeSelect,
+        where: {
+          id: createdRoute.id,
+        },
+      });
+
+      return mapRoute(copiedRoute);
+    });
+  }
+
+  private async assertOwnedRouteExists(userId: string, routeId: string) {
+    const route = await this.prismaService.route.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        deletedAt: null,
+        id: routeId,
+        userId,
+      },
+    });
+
+    if (route == null) {
+      throw new NotFoundException('route not found');
+    }
+  }
+
+  private async assertOwnedRouteReadyForSharing(
+    userId: string,
+    routeId: string,
+  ) {
+    const route = await this.prismaService.route.findFirst({
+      select: {
+        currentRevisionId: true,
+        id: true,
+      },
+      where: {
+        deletedAt: null,
+        id: routeId,
+        userId,
+      },
+    });
+
+    if (route == null) {
+      throw new NotFoundException('route not found');
+    }
+
+    if (route.currentRevisionId == null) {
+      throw new InternalServerErrorException(
+        'route is missing its current revision',
+      );
+    }
+  }
+
+  private async getActiveShareLinkByToken(
+    prisma: PrismaService | Prisma.TransactionClient,
+    token: string,
+  ) {
+    const shareLink = await prisma.shareLink.findUnique({
+      select: {
+        createdAt: true,
+        disabledAt: true,
+        expiresAt: true,
+        id: true,
+        permission: true,
+        route: {
+          select: {
+            deletedAt: true,
+            description: true,
+            name: true,
+            currentRevision: {
+              select: routeRevisionSelect,
+            },
+          },
+        },
+        routeId: true,
+        routeRevision: {
+          select: routeRevisionSelect,
+        },
+        routeRevisionId: true,
+        token: true,
+        updatedAt: true,
+      },
+      where: {
+        token,
+      },
+    });
+
+    if (shareLink == null || !isShareLinkActive(shareLink)) {
+      throw new NotFoundException('share link not found');
+    }
+
+    if (shareLink.route.deletedAt != null) {
+      throw new NotFoundException('share link not found');
+    }
+
+    return shareLink;
+  }
+}
+
+async function findLatestShareLink(
+  prisma: PrismaService | Prisma.TransactionClient,
+  ownerId: string,
+  routeId: string,
+): Promise<ShareLinkLookup | null> {
+  return prisma.shareLink.findFirst({
+    orderBy: [{ createdAt: 'desc' }],
+    select: shareLinkSelect,
+    where: {
+      ownerId,
+      routeId,
+      routeRevisionId: null,
+    },
+  });
+}
+
+function isShareLinkActive(
+  shareLink: Pick<PublicShareRecord, 'disabledAt' | 'expiresAt'>,
+) {
+  return (
+    shareLink.disabledAt == null &&
+    (shareLink.expiresAt == null || shareLink.expiresAt > new Date())
+  );
+}
+
+function selectVisibleRevision(
+  shareLink: PublicShareRecord,
+): SharedRouteRevision {
+  const revision = shareLink.routeRevision ?? shareLink.route.currentRevision;
+
+  if (revision == null) {
+    throw new NotFoundException('share link not found');
+  }
+
+  const mappedRevision = mapRouteRevision(revision);
+
+  return {
+    createdAt: mappedRevision.createdAt,
+    defaultSpeedKmh: mappedRevision.defaultSpeedKmh,
+    mode: mappedRevision.mode,
+    revisionNumber: mappedRevision.revisionNumber,
+    waypoints: mappedRevision.waypoints,
+  };
+}
+
+function sanitizePublicRouteRevision(revision: SharedRouteRevision) {
+  return {
+    createdAt: revision.createdAt,
+    defaultSpeedKmh: revision.defaultSpeedKmh,
+    mode: revision.mode,
+    revisionNumber: revision.revisionNumber,
+    waypoints: revision.waypoints.map((waypoint) => ({
+      latitude: waypoint.latitude,
+      longitude: waypoint.longitude,
+      pauseSeconds: waypoint.pauseSeconds,
+      sequence: waypoint.sequence,
+      speedKmh: waypoint.speedKmh,
+    })),
+  };
+}
+
+async function getNextSortOrder(
+  prisma: Prisma.TransactionClient,
+  userId: string,
+): Promise<number> {
+  const latestItem = await prisma.libraryItem.findFirst({
+    orderBy: [{ sortOrder: 'desc' }],
+    select: {
+      sortOrder: true,
+    },
+    where: {
+      deletedAt: null,
+      userId,
+    },
+  });
+
+  return latestItem == null ? 0 : latestItem.sortOrder + 1;
+}
+
+function createRouteRevisionPayload(
+  input: SharedRouteRevision,
+): Prisma.InputJsonObject {
+  return {
+    defaultSpeedKmh: input.defaultSpeedKmh,
+    mode: input.mode,
+    waypoints: input.waypoints.map((waypoint) => ({
+      latitude: waypoint.latitude,
+      longitude: waypoint.longitude,
+      pauseSeconds: waypoint.pauseSeconds,
+      sequence: waypoint.sequence,
+      speedKmh: waypoint.speedKmh,
+    })),
+  };
+}
+
+async function recordSyncEvent(
+  prisma: Prisma.TransactionClient,
+  input: {
+    entityId: string;
+    entityType: SyncEntityType;
+    operation: SyncOperation;
+    payload?: Prisma.InputJsonObject;
+    userId: string;
+  },
+) {
+  await prisma.syncEvent.create({
+    data: {
+      entityId: input.entityId,
+      entityType: input.entityType,
+      operation: input.operation,
+      payload: input.payload,
+      userId: input.userId,
+    },
+  });
+}
+
+function createShareToken(): string {
+  return randomBytes(18).toString('base64url');
+}

--- a/backend/src/sharing/sharing.validation.ts
+++ b/backend/src/sharing/sharing.validation.ts
@@ -1,0 +1,23 @@
+import { BadRequestException } from '@nestjs/common';
+
+export type ShareLinkUpdateInput = {
+  disabled: boolean;
+};
+
+export function parseShareLinkUpdateInput(
+  input: unknown,
+): ShareLinkUpdateInput {
+  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new BadRequestException('request body must be an object');
+  }
+
+  const disabled = (input as Record<string, unknown>).disabled;
+
+  if (typeof disabled !== 'boolean') {
+    throw new BadRequestException('disabled must be a boolean');
+  }
+
+  return {
+    disabled,
+  };
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -7,7 +7,7 @@ This directory contains the current planning set distilled from the former `docs
 | Plan | Status | Source material |
 |---|---|---|
 | `product-roadmap-plan.md` | Active | Legacy project overview, sync platform plan, platform todo, general todo |
-| `sharing-plan.md` | Next active product slice | Legacy sync platform plan and platform todo |
+| `sharing-plan.md` | Active implementation landed / validation follow-ups remain | Legacy sync platform plan and platform todo |
 | `android-local-library-plan.md` | Completed baseline / remaining follow-ups only | Legacy cloud-shaped library phase plan and todo |
 | `android-cloud-sync-plan.md` | Completed baseline / remaining follow-ups only | Legacy Android cloud sync phase plan and platform todo |
 | `quick-jump-favorites-plan.md` | Mostly complete / UX follow-ups only | Legacy quick-jump/favorites phase plan and general todo |

--- a/docs/plans/product-roadmap-plan.md
+++ b/docs/plans/product-roadmap-plan.md
@@ -29,7 +29,7 @@ The remaining roadmap should not reopen completed local-library or cloud-sync fo
 - [x] Build cloud auth and library APIs with TOTP, refresh sessions, owner-scoped CRUD, immutable route revisions, and sync events.
 - [x] Build web console login and place/route editing workflows.
 - [x] Build Android cloud login, sync bootstrap/changes, cursor recovery, and current-revision route execution.
-- [ ] Implement route sharing as the next product slice: public latest route links and copy-to-library.
+- [ ] Implement route sharing as the next product slice: backend/web implementation for public latest route links and copy-to-library landed under `sharing-plan.md` on 2026-05-13, including share-link CRUD, public route page, authenticated copy-to-library, and a successful dev-DB migration run for `20260513110000_sharing_links`. Remaining proof is end-to-end web/Android verification still listed in that plan's Completion Checklist.
 - [ ] Implement sync/upload strengthening: local-only place upload, remote-id binding after upload, item-level manual conflict resolution, and `Use Cloud` / `Use Local` / `Keep Both` actions all shipped end-to-end and verified on a real-device smoke run (`2026-05-10_android-local-upload-conflict-plan.md`, PRs #46–#49). Remaining work is automated test coverage (backend `LibraryItem.version` bump tests, `/sync/upload` partial-success + idempotency reuse tests, conflict variants, and Android `CloudSyncRepository` local-only upload tests); route upload/conflict is still deferred.
 - [ ] Implement device/session management: device state reporting, session/device list, and revoke controls.
 - [ ] Design remote command model only after device/session management exists and has an explicit threat model.
@@ -44,7 +44,7 @@ The remaining roadmap should not reopen completed local-library or cloud-sync fo
 ## Completion Checklist
 
 - [x] Product roadmap reflects the implemented Android, backend, web, and sync baseline from the consolidated legacy planning docs.
-- [ ] `sharing-plan.md` is completed and merged for public latest route links and copy-to-library.
+- [ ] `sharing-plan.md` implementation is landed locally for public latest route links and copy-to-library, with backend/web validation and the dev-DB migration run recorded on 2026-05-13. Remaining completion is end-to-end web and Android verification tracked in that plan.
 - [ ] Local-only upload/conflict policy has an accepted plan and implementation PRs; place-first work is in `2026-05-10_android-local-upload-conflict-plan.md`, with implementation shipped across PRs #46–#48, smoke closed by PR #49, and remaining completion pending the backend / Android automated tests listed in that plan's Completion Checklist.
 - [ ] Device/session management has an accepted plan before remote commands are designed.
 - [ ] Operations checklist has CI, logging, health, backup, and API documentation coverage.

--- a/docs/plans/product-roadmap-plan.md
+++ b/docs/plans/product-roadmap-plan.md
@@ -29,7 +29,7 @@ The remaining roadmap should not reopen completed local-library or cloud-sync fo
 - [x] Build cloud auth and library APIs with TOTP, refresh sessions, owner-scoped CRUD, immutable route revisions, and sync events.
 - [x] Build web console login and place/route editing workflows.
 - [x] Build Android cloud login, sync bootstrap/changes, cursor recovery, and current-revision route execution.
-- [ ] Implement route sharing as the next product slice: backend/web implementation for public latest route links and copy-to-library landed under `sharing-plan.md` on 2026-05-13, including share-link CRUD, public route page, authenticated copy-to-library, and a successful dev-DB migration run for `20260513110000_sharing_links`. Remaining proof is end-to-end web/Android verification still listed in that plan's Completion Checklist.
+- [ ] Implement route sharing as the next product slice: backend/web implementation for public latest route links and copy-to-library landed under `sharing-plan.md` on 2026-05-13, including share-link CRUD, public route page, authenticated copy-to-library, a successful dev-DB migration run for `20260513110000_sharing_links`, and a browser smoke run for create-link → public page → sign-in → copy. Remaining proof is Android verification still listed in that plan's Completion Checklist.
 - [ ] Implement sync/upload strengthening: local-only place upload, remote-id binding after upload, item-level manual conflict resolution, and `Use Cloud` / `Use Local` / `Keep Both` actions all shipped end-to-end and verified on a real-device smoke run (`2026-05-10_android-local-upload-conflict-plan.md`, PRs #46–#49). Remaining work is automated test coverage (backend `LibraryItem.version` bump tests, `/sync/upload` partial-success + idempotency reuse tests, conflict variants, and Android `CloudSyncRepository` local-only upload tests); route upload/conflict is still deferred.
 - [ ] Implement device/session management: device state reporting, session/device list, and revoke controls.
 - [ ] Design remote command model only after device/session management exists and has an explicit threat model.
@@ -44,7 +44,7 @@ The remaining roadmap should not reopen completed local-library or cloud-sync fo
 ## Completion Checklist
 
 - [x] Product roadmap reflects the implemented Android, backend, web, and sync baseline from the consolidated legacy planning docs.
-- [ ] `sharing-plan.md` implementation is landed locally for public latest route links and copy-to-library, with backend/web validation and the dev-DB migration run recorded on 2026-05-13. Remaining completion is end-to-end web and Android verification tracked in that plan.
+- [ ] `sharing-plan.md` implementation is landed locally for public latest route links and copy-to-library, with backend/web validation, the dev-DB migration run, and browser smoke evidence recorded on 2026-05-13. Remaining completion is Android verification tracked in that plan.
 - [ ] Local-only upload/conflict policy has an accepted plan and implementation PRs; place-first work is in `2026-05-10_android-local-upload-conflict-plan.md`, with implementation shipped across PRs #46–#48, smoke closed by PR #49, and remaining completion pending the backend / Android automated tests listed in that plan's Completion Checklist.
 - [ ] Device/session management has an accepted plan before remote commands are designed.
 - [ ] Operations checklist has CI, logging, health, backup, and API documentation coverage.

--- a/docs/plans/sharing-plan.md
+++ b/docs/plans/sharing-plan.md
@@ -16,16 +16,16 @@ The product MVP is mostly complete except route sharing. Backend already has `Ro
 
 ## Plan
 
-- [ ] Add a `ShareLink` Prisma model with owner id, route id, optional route revision id, token, permission, disabled/expires timestamps, and created timestamp.
-- [ ] Add a migration and model constraints so one active latest-link per owner/route is easy to query or enforce.
-- [ ] Implement backend API for authenticated users to create, fetch, disable, and re-enable a route's latest public share link.
-- [ ] Implement public API to resolve a share token and return a sanitized latest route revision snapshot.
-- [ ] Implement authenticated copy API that copies the currently visible public route revision snapshot into the caller's `Route`, `RouteRevision`, and `LibraryItem` rows.
-- [ ] Emit sync events for copied routes so Android sees the copied route on next sync.
-- [ ] Add backend tests for owner authorization, disabled/expired links, public read sanitization, and copy snapshot semantics.
-- [ ] Add web route UI controls to create/copy/disable the public link and copy its URL.
-- [ ] Add a public route page that renders route name, metadata, waypoints/map preview, and a signed-in copy action.
-- [ ] Update product docs and todo checklists after the sharing slice merges.
+- [x] Add a `ShareLink` Prisma model with owner id, route id, optional route revision id, token, permission, disabled/expires timestamps, and created timestamp.
+- [x] Add a migration and model constraints so one active latest-link per owner/route is easy to query or enforce.
+- [x] Implement backend API for authenticated users to create, fetch, disable, and re-enable a route's latest public share link.
+- [x] Implement public API to resolve a share token and return a sanitized latest route revision snapshot.
+- [x] Implement authenticated copy API that copies the currently visible public route revision snapshot into the caller's `Route`, `RouteRevision`, and `LibraryItem` rows.
+- [x] Emit sync events for copied routes so Android sees the copied route on next sync.
+- [x] Add backend tests for owner authorization, disabled/expired links, public read sanitization, and copy snapshot semantics.
+- [x] Add web route UI controls to create/copy/disable the public link and copy its URL.
+- [x] Add a public route page that renders route name, metadata, waypoints/map preview, and a signed-in copy action.
+- [x] Update product docs and todo checklists after the sharing slice merges.
 
 ## Risks
 
@@ -33,11 +33,28 @@ The product MVP is mostly complete except route sharing. Backend already has `Ro
 - Latest-link semantics can surprise users if the route changes after sharing; UI copy should explain it copies the currently visible latest revision.
 - Copying a public route must create a new owned snapshot, not alias the original route/revision.
 
+## Validation
+
+- 2026-05-13 backend validation in repo workspace:
+  - `cd backend && npm ci` ✅
+  - `cd backend && npm run prisma:generate` ✅
+  - `cd backend && npm run lint` ✅
+  - `cd backend && npm test -- --runInBand` ✅ (`src/sharing/sharing.service.spec.ts` included; 8 suites / 38 tests pass)
+  - `cd backend && npm run build` ✅ after moving the stale root-owned `backend/dist` aside to `backend/dist.root-owned-backup` and rebuilding into a new user-owned `dist/`.
+  - Dev DB migration validation ✅: started `postgres` via `docker.exe compose --env-file <tmp> up -d postgres`, waited for `pg_isready -h localhost -p 15432 -d kestrel_cloud -U kestrel`, then ran `DATABASE_URL='postgresql://kestrel:kestrel@localhost:15432/kestrel_cloud?schema=public' npm run prisma:migrate:deploy`. Verified `_prisma_migrations` contains `20260513110000_sharing_links`. Production deploy path is already documented in `compose.yaml` (`backend` service command runs `npx prisma migrate deploy` before `npm run start:dev`) and in `backend/package.json` via `npm run prisma:migrate:deploy`.
+- 2026-05-13 web validation in repo workspace:
+  - `cd web && npm run lint` ✅
+  - `cd web && npm run typecheck` ✅
+  - `cd web && npm run build` ✅
+- Remaining validation gaps:
+  - End-to-end browser smoke for create link → open public page → sign in → copy route has not yet been recorded.
+  - Android `Sync now` against a copied shared route has not yet been smoke-verified.
+
 ## Completion Checklist
 
-- [ ] Prisma migration applies cleanly on a dev database and production deploy migration path is documented.
-- [ ] Backend sharing tests pass and cover disabled/expired/public/copy cases.
-- [ ] Web route page can create and disable a latest share link.
-- [ ] Public route URL works without login and does not expose private owner fields.
-- [ ] Signed-in user can copy a shared route and see it in their own library.
-- [ ] Android sync receives copied routes as normal owned routes after `Sync now`.
+- [x] Prisma migration applies cleanly on a dev database and production deploy migration path is documented. _Verified on 2026-05-13 by starting `postgres` via `docker.exe compose`, running `DATABASE_URL='postgresql://kestrel:kestrel@localhost:15432/kestrel_cloud?schema=public' npm run prisma:migrate:deploy`, and querying `_prisma_migrations` to confirm `20260513110000_sharing_links`. Production deploy path is documented by `compose.yaml` and `backend/package.json` using `prisma migrate deploy`._
+- [x] Backend sharing tests pass and cover disabled/expired/public/copy cases. _Verified on 2026-05-13 by `cd backend && npm test -- --runInBand`; `src/sharing/sharing.service.spec.ts` covers owner authorization, disabled/expired link rejection, public payload sanitization, and copy snapshot semantics._
+- [x] Web route page can create and disable a latest share link. _Implemented in `web/app/dashboard/page.tsx` with backend endpoints under `backend/src/sharing/`, and the web app passes `npm run lint`, `npm run typecheck`, and `npm run build` on 2026-05-13._
+- [x] Public route URL works without login and does not expose private owner fields. _Implemented via `GET /shares/:token` + `web/app/share/[token]/page.tsx`; service tests assert disabled/expired rejection and sanitized public payloads without owner metadata._
+- [ ] Signed-in user can copy a shared route and see it in their own library. _Backend copy semantics are unit-tested and the web page exposes the action, but a full browser end-to-end verification is still unrecorded._
+- [ ] Android sync receives copied routes as normal owned routes after `Sync now`. _Expected because copy emits `ROUTE` + `LIBRARY_ITEM` sync events, but Android smoke verification is still pending._

--- a/docs/plans/sharing-plan.md
+++ b/docs/plans/sharing-plan.md
@@ -46,8 +46,12 @@ The product MVP is mostly complete except route sharing. Backend already has `Ro
   - `cd web && npm run lint` ✅
   - `cd web && npm run typecheck` ✅
   - `cd web && npm run build` ✅
+- 2026-05-13 browser smoke in local dev stack (`docker.exe compose` postgres/backend/web + Chrome DevTools session):
+  - Created two test users through auth API bootstrap (`smoke-owner-193746`, `smoke-copier-193746`) so the browser run could focus on the sharing UX rather than TOTP setup screens.
+  - Logged in as the owner on `/login` using a recovery code, created route `Smoke share route 193746` from the dashboard, and created a latest share link from the route editor.
+  - Logged out, opened the public URL `http://127.0.0.1:3301/share/Y7TEv1MZAfNlOh9OsARLP6vq`, and verified the route renders without login, shows the expected metadata/map preview, and does not expose the owner username in page text.
+  - Followed the public page sign-in path with the copier account, navigated back to the public page after the login redirect to `/dashboard`, clicked `Copy to my library`, and verified the success banner plus the copied route appearing in the copier dashboard route list.
 - Remaining validation gaps:
-  - End-to-end browser smoke for create link → open public page → sign in → copy route has not yet been recorded.
   - Android `Sync now` against a copied shared route has not yet been smoke-verified.
 
 ## Completion Checklist
@@ -56,5 +60,5 @@ The product MVP is mostly complete except route sharing. Backend already has `Ro
 - [x] Backend sharing tests pass and cover disabled/expired/public/copy cases. _Verified on 2026-05-13 by `cd backend && npm test -- --runInBand`; `src/sharing/sharing.service.spec.ts` covers owner authorization, disabled/expired link rejection, public payload sanitization, and copy snapshot semantics._
 - [x] Web route page can create and disable a latest share link. _Implemented in `web/app/dashboard/page.tsx` with backend endpoints under `backend/src/sharing/`, and the web app passes `npm run lint`, `npm run typecheck`, and `npm run build` on 2026-05-13._
 - [x] Public route URL works without login and does not expose private owner fields. _Implemented via `GET /shares/:token` + `web/app/share/[token]/page.tsx`; service tests assert disabled/expired rejection and sanitized public payloads without owner metadata._
-- [ ] Signed-in user can copy a shared route and see it in their own library. _Backend copy semantics are unit-tested and the web page exposes the action, but a full browser end-to-end verification is still unrecorded._
+- [x] Signed-in user can copy a shared route and see it in their own library. _Verified on 2026-05-13 by a browser smoke run: owner account created `Smoke share route 193746`, public page rendered while logged out, copier account signed in and used `Copy to my library`, and the copied route then appeared in the copier dashboard route list._
 - [ ] Android sync receives copied routes as normal owned routes after `Sync now`. _Expected because copy emits `ROUTE` + `LIBRARY_ITEM` sync events, but Android smoke verification is still pending._

--- a/web/README.md
+++ b/web/README.md
@@ -29,6 +29,8 @@ KESTREL_API_BASE_URL=http://localhost:3300 npm run dev
 - Route list/create/edit/delete.
 - MapLibre route editor: click map to add waypoints, drag markers to adjust coordinates, delete/reorder waypoint rows.
 - Route default speed/mode/public flag and latest revision display.
+- Route latest-share-link controls in the dashboard: create, disable/re-enable, copy URL, and open the public page.
+- Public share page for latest route snapshots with map preview and signed-in copy-to-library action.
 
 ## Validation
 

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   type Route,
   type RouteInput,
   type RouteMode,
+  type RouteShareLink,
   type RouteWaypoint,
 } from '@/lib/api';
 
@@ -410,6 +411,7 @@ function RouteEditor({
         Description
         <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
       </label>
+      <RouteSharePanel route={route} />
 
       <div className="stack">
         <h3>Waypoints</h3>
@@ -489,6 +491,162 @@ function RouteEditor({
   );
 }
 
+function RouteSharePanel({ route }: { route: Route | null }) {
+  const auth = useAuth();
+  const [shareLink, setShareLink] = useState<RouteShareLink | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
+
+  const loadShareLink = useCallback(async () => {
+    if (route == null) {
+      setShareLink(null);
+      setError(null);
+      return;
+    }
+
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const nextShareLink = await auth.apiRequest<RouteShareLink>(`/routes/${route.id}/share-link`);
+      setShareLink(nextShareLink);
+    } catch (nextError) {
+      if (nextError instanceof ApiError && nextError.status === 404) {
+        setShareLink(null);
+        return;
+      }
+
+      setError(formatError(nextError));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [auth, route]);
+
+  useEffect(() => {
+    setNotice(null);
+    void loadShareLink();
+  }, [loadShareLink]);
+
+  async function createShareLink() {
+    if (route == null) {
+      return;
+    }
+
+    setNotice(null);
+    setError(null);
+    setIsMutating(true);
+
+    try {
+      const nextShareLink = await auth.apiRequest<RouteShareLink>(`/routes/${route.id}/share-link`, {
+        method: 'POST',
+      });
+      setShareLink(nextShareLink);
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
+  async function setDisabled(disabled: boolean) {
+    if (route == null) {
+      return;
+    }
+
+    setNotice(null);
+    setError(null);
+    setIsMutating(true);
+
+    try {
+      const nextShareLink = await auth.apiRequest<RouteShareLink>(`/routes/${route.id}/share-link`, {
+        body: JSON.stringify({ disabled }),
+        method: 'PATCH',
+      });
+      setShareLink(nextShareLink);
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
+  async function copyPublicUrl() {
+    if (shareLink == null) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(toAbsolutePublicUrl(shareLink.publicUrl));
+      setNotice('Share URL copied.');
+    } catch {
+      setNotice('Copy failed; select the URL manually.');
+    }
+  }
+
+  return (
+    <section className="stack" style={{ borderTop: '1px solid var(--color-border)', paddingTop: '0.75rem' }}>
+      <div className="row" style={{ justifyContent: 'space-between' }}>
+        <h3 style={{ margin: 0 }}>Share link</h3>
+        {isLoading ? <span className="muted">Loading…</span> : null}
+      </div>
+      {route == null ? (
+        <p className="muted" style={{ margin: 0 }}>
+          Save this route before creating a public latest-route link.
+        </p>
+      ) : (
+        <>
+          <p className="muted" style={{ margin: 0 }}>
+            Visitors can open the public page without login. Signed-in users can copy the visible
+            route snapshot into their own library.
+          </p>
+          {error == null ? null : <div className="error">{error}</div>}
+          {notice == null ? null : <div className="success">{notice}</div>}
+          {shareLink == null ? (
+            <div className="row">
+              <button disabled={isMutating} type="button" onClick={() => void createShareLink()}>
+                {isMutating ? 'Creating…' : 'Create public link'}
+              </button>
+            </div>
+          ) : (
+            <div className="stack">
+              <label>
+                Public URL
+                <input readOnly value={toAbsolutePublicUrl(shareLink.publicUrl)} />
+              </label>
+              <div className="chip-row">
+                {shareLink.disabledAt == null ? <span className="chip">active</span> : <span className="chip">disabled</span>}
+                <span className="chip">latest route</span>
+              </div>
+              <div className="row">
+                <button className="secondary" type="button" onClick={() => void copyPublicUrl()}>
+                  Copy URL
+                </button>
+                <a href={shareLink.publicUrl} rel="noreferrer" target="_blank">
+                  Open public page
+                </a>
+                <button
+                  className={shareLink.disabledAt == null ? 'danger' : 'secondary'}
+                  disabled={isMutating}
+                  type="button"
+                  onClick={() => void setDisabled(shareLink.disabledAt == null)}
+                >
+                  {isMutating
+                    ? 'Saving…'
+                    : shareLink.disabledAt == null
+                      ? 'Disable link'
+                      : 'Re-enable link'}
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
 function TagRow({ tags }: { tags: string[] }) {
   if (tags.length === 0) {
     return null;
@@ -503,6 +661,10 @@ function TagRow({ tags }: { tags: string[] }) {
       ))}
     </span>
   );
+}
+
+function toAbsolutePublicUrl(publicUrl: string): string {
+  return typeof window === 'undefined' ? publicUrl : `${window.location.origin}${publicUrl}`;
 }
 
 function updateWaypoint(

--- a/web/app/share/[token]/page.tsx
+++ b/web/app/share/[token]/page.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/components/AuthProvider';
+import { ApiError, type Route, type SharedRouteSnapshot, apiFetch } from '@/lib/api';
+
+const RouteMapPreview = dynamic(() => import('@/components/RouteMapPreview'), {
+  ssr: false,
+});
+
+export default function SharedRoutePage() {
+  const auth = useAuth();
+  const router = useRouter();
+  const params = useParams<{ token: string }>();
+  const token = typeof params.token === 'string' ? params.token : '';
+  const [sharedRoute, setSharedRoute] = useState<SharedRouteSnapshot | null>(null);
+  const [copiedRoute, setCopiedRoute] = useState<Route | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copyError, setCopyError] = useState<string | null>(null);
+  const [isCopying, setIsCopying] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (token.length === 0) {
+      setError('Invalid share link');
+      setIsLoading(false);
+      return;
+    }
+
+    setError(null);
+    setIsLoading(true);
+    void apiFetch<SharedRouteSnapshot>(`/shares/${token}`)
+      .then((result) => {
+        setSharedRoute(result);
+      })
+      .catch((nextError: unknown) => {
+        setError(formatError(nextError));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [token]);
+
+  async function copyToLibrary() {
+    if (!auth.isAuthenticated) {
+      router.push('/login');
+      return;
+    }
+
+    setCopyError(null);
+    setIsCopying(true);
+
+    try {
+      const result = await auth.apiRequest<Route>(`/shares/${token}/copy`, {
+        method: 'POST',
+      });
+      setCopiedRoute(result);
+    } catch (nextError) {
+      setCopyError(formatError(nextError));
+    } finally {
+      setIsCopying(false);
+    }
+  }
+
+  return (
+    <main className="shell stack">
+      <header className="topbar">
+        <div className="brand">
+          <strong>Kestrel Share</strong>
+          <span className="muted">Public latest-route link</span>
+        </div>
+        <div className="row">
+          <Link href={auth.isAuthenticated ? '/dashboard' : '/login'}>
+            {auth.isAuthenticated ? 'Back to dashboard' : 'Sign in'}
+          </Link>
+        </div>
+      </header>
+
+      {isLoading ? <p className="muted">Loading shared route…</p> : null}
+      {error == null ? null : <div className="error">{error}</div>}
+
+      {sharedRoute == null || isLoading ? null : (
+        <section className="grid">
+          <article className="panel stack">
+            <div className="row" style={{ justifyContent: 'space-between' }}>
+              <div>
+                <h1 style={{ marginBottom: '0.25rem' }}>{sharedRoute.route.name}</h1>
+                <p className="muted" style={{ margin: 0 }}>
+                  rev {sharedRoute.route.revision.revisionNumber} · {sharedRoute.route.revision.defaultSpeedKmh}{' '}
+                  km/h · {formatMode(sharedRoute.route.revision.mode)}
+                </p>
+              </div>
+              <span className="chip">public link</span>
+            </div>
+            {sharedRoute.route.description == null ? null : <p>{sharedRoute.route.description}</p>}
+            <RouteMapPreview waypoints={sharedRoute.route.revision.waypoints} />
+            <div className="chip-row">
+              <span className="chip">
+                {sharedRoute.route.revision.waypoints.length} waypoint
+                {sharedRoute.route.revision.waypoints.length === 1 ? '' : 's'}
+              </span>
+              <span className="chip">{formatMode(sharedRoute.route.revision.mode)}</span>
+              <span className="chip">{sharedRoute.route.revision.defaultSpeedKmh} km/h</span>
+            </div>
+          </article>
+
+          <article className="panel stack">
+            <h2>Copy to your library</h2>
+            <p className="muted" style={{ margin: 0 }}>
+              This copies the currently visible snapshot into your own cloud library as a new route.
+            </p>
+            {copyError == null ? null : <div className="error">{copyError}</div>}
+            {copiedRoute == null ? null : (
+              <div className="success">
+                Copied as <strong>{copiedRoute.name}</strong>.{' '}
+                <Link href="/dashboard">Open dashboard</Link>
+              </div>
+            )}
+            <div className="row">
+              <button disabled={isCopying} type="button" onClick={() => void copyToLibrary()}>
+                {isCopying
+                  ? 'Copying…'
+                  : auth.isAuthenticated
+                    ? 'Copy to my library'
+                    : 'Sign in to copy'}
+              </button>
+            </div>
+          </article>
+        </section>
+      )}
+    </main>
+  );
+}
+
+function formatMode(mode: SharedRouteSnapshot['route']['revision']['mode']) {
+  return mode === 'PING_PONG' ? 'PingPong' : mode[0] + mode.slice(1).toLowerCase();
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof ApiError || error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Unexpected error';
+}

--- a/web/components/RouteMapPreview.tsx
+++ b/web/components/RouteMapPreview.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import maplibregl, { type GeoJSONSource, type Map as MapLibreMap, type Marker } from 'maplibre-gl';
+import { useEffect, useRef } from 'react';
+import type { RouteWaypoint } from '@/lib/api';
+
+type Props = {
+  className?: string;
+  waypoints: RouteWaypoint[];
+};
+
+const LINE_SOURCE_ID = 'route-preview-line';
+const LINE_LAYER_ID = 'route-preview-line';
+
+export default function RouteMapPreview({ className = 'map-mini', waypoints }: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const markersRef = useRef<Marker[]>([]);
+
+  useEffect(() => {
+    if (containerRef.current == null || mapRef.current != null) {
+      return;
+    }
+
+    const firstWaypoint = waypoints[0];
+    const map = new maplibregl.Map({
+      center:
+        firstWaypoint == null
+          ? [121.5654, 25.033]
+          : [firstWaypoint.longitude, firstWaypoint.latitude],
+      container: containerRef.current,
+      interactive: false,
+      style: {
+        glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+        layers: [
+          {
+            id: 'osm',
+            source: 'osm',
+            type: 'raster',
+          },
+        ],
+        sources: {
+          osm: {
+            attribution: '© OpenStreetMap contributors',
+            tileSize: 256,
+            tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+            type: 'raster',
+          },
+        },
+        version: 8,
+      },
+      zoom: firstWaypoint == null ? 11 : 14,
+    });
+
+    map.on('load', () => {
+      map.addSource(LINE_SOURCE_ID, {
+        data: toLineFeature(waypoints),
+        type: 'geojson',
+      });
+      map.addLayer({
+        id: LINE_LAYER_ID,
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
+        paint: {
+          'line-color': '#76c945',
+          'line-width': 4,
+        },
+        source: LINE_SOURCE_ID,
+        type: 'line',
+      });
+      syncMarkers(map, markersRef.current, waypoints);
+      fitWaypoints(map, waypoints);
+    });
+
+    mapRef.current = map;
+
+    return () => {
+      markersRef.current.forEach((marker) => {
+        marker.remove();
+      });
+      markersRef.current = [];
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [waypoints]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    const update = () => {
+      updateLine(map, waypoints);
+      syncMarkers(map, markersRef.current, waypoints);
+      fitWaypoints(map, waypoints);
+    };
+
+    if (map.isStyleLoaded()) {
+      update();
+    } else {
+      map.once('load', update);
+    }
+  }, [waypoints]);
+
+  return <div className={className} ref={containerRef} />;
+}
+
+function syncMarkers(map: MapLibreMap, existingMarkers: Marker[], waypoints: RouteWaypoint[]) {
+  existingMarkers.forEach((marker) => {
+    marker.remove();
+  });
+  existingMarkers.length = 0;
+
+  waypoints.forEach((waypoint, index) => {
+    const marker = new maplibregl.Marker({
+      color: index === 0 ? '#76c945' : '#f9aecb',
+    })
+      .setLngLat([waypoint.longitude, waypoint.latitude])
+      .addTo(map);
+
+    existingMarkers.push(marker);
+  });
+}
+
+function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
+  if (waypoints.length === 0) {
+    return;
+  }
+
+  if (waypoints.length === 1) {
+    map.easeTo({
+      center: [waypoints[0].longitude, waypoints[0].latitude],
+      duration: 0,
+      zoom: Math.max(map.getZoom(), 13),
+    });
+    return;
+  }
+
+  const bounds = waypoints.reduce(
+    (currentBounds, waypoint) => currentBounds.extend([waypoint.longitude, waypoint.latitude]),
+    new maplibregl.LngLatBounds(
+      [waypoints[0].longitude, waypoints[0].latitude],
+      [waypoints[0].longitude, waypoints[0].latitude],
+    ),
+  );
+
+  map.fitBounds(bounds, {
+    duration: 0,
+    maxZoom: 15,
+    padding: 40,
+  });
+}
+
+function updateLine(map: MapLibreMap, waypoints: RouteWaypoint[]) {
+  const source = map.getSource(LINE_SOURCE_ID) as GeoJSONSource | undefined;
+
+  source?.setData(toLineFeature(waypoints));
+}
+
+function toLineFeature(waypoints: RouteWaypoint[]): GeoJSON.Feature<GeoJSON.LineString> {
+  return {
+    geometry: {
+      coordinates: waypoints.map((waypoint) => [waypoint.longitude, waypoint.latitude]),
+      type: 'LineString',
+    },
+    properties: {},
+    type: 'Feature',
+  };
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -38,6 +38,34 @@ export type RouteWaypoint = {
   speedKmh?: number | null;
 };
 
+export type RouteShareLink = {
+  createdAt: string;
+  disabledAt: string | null;
+  expiresAt: string | null;
+  id: string;
+  permission: 'PUBLIC_READ';
+  publicUrl: string;
+  routeId: string;
+  routeRevisionId: string | null;
+  token: string;
+  updatedAt: string;
+};
+
+export type SharedRouteSnapshot = {
+  route: {
+    description: string | null;
+    name: string;
+    revision: {
+      createdAt: string;
+      defaultSpeedKmh: number;
+      mode: RouteMode;
+      revisionNumber: number;
+      waypoints: RouteWaypoint[];
+    };
+  };
+  shareLink: RouteShareLink;
+};
+
 export type Route = {
   createdAt: string;
   currentRevision: {


### PR DESCRIPTION
## Summary
- add backend ShareLink schema, migration, sharing endpoints, and copy-to-library flow
- add web dashboard share-link controls plus a public shared-route page with map preview
- update sharing plan and roadmap docs with backend/web validation and dev DB migration evidence

## Testing
- cd backend && npm ci
- cd backend && npm run prisma:generate
- cd backend && npm run lint
- cd backend && npm run build
- cd backend && npm test -- --runInBand
- cd web && npm run lint
- cd web && npm run typecheck
- cd web && npm run build
- DATABASE_URL='postgresql://kestrel:kestrel@localhost:15432/kestrel_cloud?schema=public' cd backend && npm run prisma:migrate:deploy
