### PR TITLE
ci: auto-tag releases after version merges

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,67 @@
+name: Tag release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'gradle.properties'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - 'web/package.json'
+      - 'web/package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require PAT token
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "Repository secret PAT_TOKEN is required to push tags that trigger release.yml" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Resolve shared version metadata
+        id: meta
+        run: |
+          scripts/resolve-release-metadata.sh --current
+
+      - name: Skip when release tag already exists
+        id: existing-tag
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          if git ls-remote --tags origin "refs/tags/${RELEASE_TAG}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${RELEASE_TAG} already exists; skipping"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push release tag
+        if: steps.existing-tag.outputs.exists == 'false'
+        env:
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "Release $RELEASE_VERSION"
+          git push origin "$RELEASE_TAG"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ A leading `changes` job uses `dorny/paths-filter` to gate each lane, so a PR tou
 
 - `just release` runs `:app:assembleRelease` and produces `app/build/outputs/apk/release/app-release-unsigned.apk`.
 - `.github/workflows/bump-version.yml` takes a `major` / `minor` / `patch` choice, calls `scripts/bump-version.py`, and bumps the shared Android/backend/web version plus Android `appVersionCode`, then opens a PR using repository secret `PAT_TOKEN` so the resulting PR can trigger downstream CI workflows.
+- `.github/workflows/tag-release.yml` watches version-file merges to `main`, resolves the shared Android/backend/web version, and pushes the matching `v*` tag with `PAT_TOKEN` if it does not already exist.
 - `.github/workflows/release.yml` calls `scripts/resolve-release-metadata.sh`, then publishes a GitHub Release when a matching `v*` tag is pushed (or when manually dispatched against an existing tag) and uploads the unsigned release APK as a release asset.
 
 ---

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,6 +1,7 @@
 ## GOTCHA
 
 - Android `:app:assembleRelease` currently produces `app/build/outputs/apk/release/app-release-unsigned.apk` because there is no signing config yet. Any workflow or release docs must call the artifact unsigned until keystore-based signing is added.
+- The auto-tag flow must push tags with `PAT_TOKEN`, not the default `GITHUB_TOKEN`, or the follow-up `push.tags` release workflow will not fire.
 - Backend Prisma schema edits are not visible to TypeScript/Nest until `cd backend && npm run prisma:generate` refreshes `node_modules/@prisma/client`; if `shareLink` or other new model types seem to be missing during `npm run typecheck`/`npm run build`, regenerate the client first.
 - Any command that can uninstall/reinstall the app, clear app data, or otherwise wipe app-private state on a phone (for example `connectedDebugAndroidTest`, `pm clear`, uninstall/reinstall flows, or similar instrumentation/install paths) must be called out explicitly before running. Treat favorites / prefs / mock state loss as destructive, operator-visible risk; do not suggest or run such commands on a primary device unless the user has clearly accepted the risk or taken an adb/run-as backup first.
 - During manual smoke guidance, give exactly one next test step at a time. Do not dump a multi-step checklist unless the user explicitly asks for the full list.

--- a/scripts/resolve-release-metadata.sh
+++ b/scripts/resolve-release-metadata.sh
@@ -1,21 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: $0 <release-tag>" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [<release-tag>|--current]" >&2
   exit 1
 fi
 
-release_tag="$1"
+release_tag="${1:---current}"
 properties_file="gradle.properties"
+backend_package_file="backend/package.json"
+web_package_file="web/package.json"
 
 if [ ! -f "$properties_file" ]; then
   echo "properties file not found: $properties_file" >&2
   exit 1
 fi
 
+if [ ! -f "$backend_package_file" ] || [ ! -f "$web_package_file" ]; then
+  echo "backend/package.json and web/package.json must exist" >&2
+  exit 1
+fi
+
 version_name="$(grep '^appVersionName=' "$properties_file" | cut -d= -f2-)"
 version_code="$(grep '^appVersionCode=' "$properties_file" | cut -d= -f2-)"
+backend_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$backend_package_file")"
+web_version="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$web_package_file")"
 expected_tag="v${version_name}"
 apk_name="kestrel-${version_name}-release-unsigned.apk"
 
@@ -24,18 +33,35 @@ if [ -z "$version_name" ] || [ -z "$version_code" ]; then
   exit 1
 fi
 
-if [ "$release_tag" != "$expected_tag" ]; then
-  echo "Tag $release_tag does not match gradle.properties appVersionName=$version_name" >&2
+if [ "$backend_version" != "$version_name" ]; then
+  echo "backend/package.json version $backend_version does not match appVersionName=$version_name" >&2
   exit 1
+fi
+
+if [ "$web_version" != "$version_name" ]; then
+  echo "web/package.json version $web_version does not match appVersionName=$version_name" >&2
+  exit 1
+fi
+
+if [ "$release_tag" != "--current" ] && [ "$release_tag" != "$expected_tag" ]; then
+  echo "Tag $release_tag does not match shared version $expected_tag" >&2
+  exit 1
+fi
+
+resolved_tag="$expected_tag"
+if [ "$release_tag" != "--current" ]; then
+  resolved_tag="$release_tag"
 fi
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   {
-    echo "tag=$release_tag"
+    echo "tag=$resolved_tag"
     echo "version_name=$version_name"
     echo "version_code=$version_code"
+    echo "backend_version=$backend_version"
+    echo "web_version=$web_version"
     echo "apk_name=$apk_name"
   } >> "$GITHUB_OUTPUT"
 fi
 
-echo "Resolved release metadata: tag=$release_tag version_name=$version_name version_code=$version_code"
+echo "Resolved release metadata: tag=$resolved_tag version_name=$version_name version_code=$version_code"


### PR DESCRIPTION
## Summary
- add a workflow that watches version-file merges on main and pushes the matching release tag with PAT_TOKEN
- teach the release metadata script to validate Android, backend, and web share the same version
- document the new auto-tag step in README and MEMORY

## Notes
- tag pushes created by GITHUB_TOKEN do not trigger downstream workflows, so this uses PAT_TOKEN
- workflow_dispatch is kept so the current main version can be tagged manually if it was bumped before this workflow existed

## Validation
- parsed .github/workflows/tag-release.yml and .github/workflows/release.yml as YAML
- ran scripts/resolve-release-metadata.sh --current against current main metadata
