### PR TITLE
fix(release): reset shared version to 0.0.1

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "1.0.1",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.0.1",
+      "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.1",
+  "version": "0.0.1",
   "description": "",
   "author": "",
   "private": true,

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.disallowKotlinSourceSets=false
-appVersionCode=2
-appVersionName=1.0.1
+appVersionCode=1
+appVersionName=0.0.1

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kestrel-web",
-  "version": "1.0.1",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kestrel-web",
-      "version": "1.0.1",
+      "version": "0.0.1",
       "dependencies": {
         "maplibre-gl": "^5.14.0",
         "next": "^16.0.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kestrel-web",
-  "version": "1.0.1",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3301",


### PR DESCRIPTION
## Summary
- reset Android, backend, and web shared version metadata to 0.0.1
- reset Android versionCode to 1 to match the rollback
- keep package-lock root versions in sync

## Verification
- ./scripts/resolve-release-metadata.sh --current