### PR TITLE
feat(web): add collapsible dashboard sidebar

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -13,6 +13,7 @@ export default function PlacesDashboardPage() {
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 
   const selectedPlace = useMemo(
     () => places.find((place) => place.id === selectedPlaceId) ?? null,
@@ -86,31 +87,48 @@ export default function PlacesDashboardPage() {
       )}
 
       <section className="dashboard-grid">
-        <aside className="grid">
+        <aside className={`dashboard-sidebar${isSidebarOpen ? '' : ' collapsed'}`}>
           <div className="card stack">
-            <div className="row" style={{ justifyContent: 'space-between' }}>
-              <h2>Places</h2>
-              <button className="secondary" type="button" onClick={() => setSelectedPlaceId(null)}>
-                New
-              </button>
-            </div>
-            {isLoading ? <p className="muted">Loading…</p> : null}
-            <div className="list">
-              {places.map((place) => (
+            <div className="dashboard-sidebar-header">
+              <h2 className="dashboard-sidebar-title">Places</h2>
+              <div className="row dashboard-sidebar-actions">
                 <button
-                  className={`list-item ${selectedPlaceId === place.id ? 'active' : ''}`}
-                  key={place.id}
+                  aria-expanded={isSidebarOpen}
+                  aria-label={isSidebarOpen ? 'Collapse places sidebar' : 'Expand places sidebar'}
+                  className="secondary dashboard-sidebar-toggle"
                   type="button"
-                  onClick={() => setSelectedPlaceId(place.id)}
+                  onClick={() => setIsSidebarOpen((current) => !current)}
                 >
-                  <strong>{place.name}</strong>
-                  <span className="muted">
-                    {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
-                  </span>
-                  <TagRow tags={place.tags} />
+                  {isSidebarOpen ? '‹' : '›'}
                 </button>
-              ))}
-              {places.length === 0 && !isLoading ? <p className="muted">No places yet.</p> : null}
+                <button
+                  className="secondary dashboard-sidebar-new"
+                  type="button"
+                  onClick={() => setSelectedPlaceId(null)}
+                >
+                  New
+                </button>
+              </div>
+            </div>
+            <div className="dashboard-sidebar-content">
+              {isLoading ? <p className="muted">Loading…</p> : null}
+              <div className="list">
+                {places.map((place) => (
+                  <button
+                    className={`list-item ${selectedPlaceId === place.id ? 'active' : ''}`}
+                    key={place.id}
+                    type="button"
+                    onClick={() => setSelectedPlaceId(place.id)}
+                  >
+                    <strong>{place.name}</strong>
+                    <span className="muted">
+                      {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
+                    </span>
+                    <TagRow tags={place.tags} />
+                  </button>
+                ))}
+                {places.length === 0 && !isLoading ? <p className="muted">No places yet.</p> : null}
+              </div>
             </div>
           </div>
         </aside>

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -13,6 +13,7 @@ export default function RoutesDashboardPage() {
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 
   const selectedRoute = useMemo(
     () => routes.find((route) => route.id === selectedRouteId) ?? null,
@@ -86,35 +87,52 @@ export default function RoutesDashboardPage() {
       )}
 
       <section className="dashboard-grid">
-        <aside className="grid">
+        <aside className={`dashboard-sidebar${isSidebarOpen ? '' : ' collapsed'}`}>
           <div className="card stack">
-            <div className="row" style={{ justifyContent: 'space-between' }}>
-              <h2>Routes</h2>
-              <button className="secondary" type="button" onClick={() => setSelectedRouteId(null)}>
-                New
-              </button>
-            </div>
-            {isLoading ? <p className="muted">Loading…</p> : null}
-            <div className="list">
-              {routes.map((route) => (
+            <div className="dashboard-sidebar-header">
+              <h2 className="dashboard-sidebar-title">Routes</h2>
+              <div className="row dashboard-sidebar-actions">
                 <button
-                  className={`list-item ${selectedRouteId === route.id ? 'active' : ''}`}
-                  key={route.id}
+                  aria-expanded={isSidebarOpen}
+                  aria-label={isSidebarOpen ? 'Collapse routes sidebar' : 'Expand routes sidebar'}
+                  className="secondary dashboard-sidebar-toggle"
                   type="button"
-                  onClick={() => setSelectedRouteId(route.id)}
+                  onClick={() => setIsSidebarOpen((current) => !current)}
                 >
-                  <strong>{route.name}</strong>
-                  <span className="muted">
-                    {route.currentRevision?.waypoints.length ?? 0} waypoints ·{' '}
-                    {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
-                  </span>
-                  <span className="chip-row">
-                    <span className="chip">rev {route.currentRevision?.revisionNumber ?? '—'}</span>
-                    {route.isPublic ? <span className="chip">public</span> : null}
-                  </span>
+                  {isSidebarOpen ? '‹' : '›'}
                 </button>
-              ))}
-              {routes.length === 0 && !isLoading ? <p className="muted">No routes yet.</p> : null}
+                <button
+                  className="secondary dashboard-sidebar-new"
+                  type="button"
+                  onClick={() => setSelectedRouteId(null)}
+                >
+                  New
+                </button>
+              </div>
+            </div>
+            <div className="dashboard-sidebar-content">
+              {isLoading ? <p className="muted">Loading…</p> : null}
+              <div className="list">
+                {routes.map((route) => (
+                  <button
+                    className={`list-item ${selectedRouteId === route.id ? 'active' : ''}`}
+                    key={route.id}
+                    type="button"
+                    onClick={() => setSelectedRouteId(route.id)}
+                  >
+                    <strong>{route.name}</strong>
+                    <span className="muted">
+                      {route.currentRevision?.waypoints.length ?? 0} waypoints ·{' '}
+                      {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
+                    </span>
+                    <span className="chip-row">
+                      <span className="chip">rev {route.currentRevision?.revisionNumber ?? '—'}</span>
+                      {route.isPublic ? <span className="chip">public</span> : null}
+                    </span>
+                  </button>
+                ))}
+                {routes.length === 0 && !isLoading ? <p className="muted">No routes yet.</p> : null}
+              </div>
             </div>
           </div>
         </aside>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -444,14 +444,20 @@ label {
   position: relative;
 }
 
-.dashboard-grid > aside {
+.dashboard-sidebar {
   left: 1rem;
   max-height: calc(100vh - 13rem);
   overflow: auto;
   position: absolute;
   top: 5.4rem;
+  transition: width var(--transition);
   width: min(22rem, calc(100% - 2rem));
   z-index: 5;
+}
+
+.dashboard-sidebar.collapsed {
+  overflow: visible;
+  width: 3.6rem;
 }
 
 .dashboard-grid > section {
@@ -487,14 +493,44 @@ label {
   font-size: 1.1rem;
 }
 
-.dashboard-grid > aside .card {
+.dashboard-sidebar .card {
   backdrop-filter: blur(16px);
   background: rgb(255 255 255 / 86%);
   box-shadow: var(--shadow-md);
 }
 
+.dashboard-sidebar.collapsed .card {
+  padding: 0.55rem;
+}
+
+.dashboard-sidebar-header {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+}
+
+.dashboard-sidebar-title {
+  margin: 0;
+}
+
+.dashboard-sidebar-actions {
+  flex-shrink: 0;
+}
+
+.dashboard-sidebar-toggle {
+  min-width: 2.4rem;
+  padding-inline: 0.8rem;
+}
+
+.dashboard-sidebar.collapsed .dashboard-sidebar-content,
+.dashboard-sidebar.collapsed .dashboard-sidebar-new,
+.dashboard-sidebar.collapsed .dashboard-sidebar-title {
+  display: none;
+}
+
 @media (prefers-color-scheme: dark) {
-  .dashboard-grid > aside .card {
+  .dashboard-sidebar .card {
     background: rgb(28 40 32 / 88%);
   }
 }
@@ -760,13 +796,27 @@ label {
     grid-template-columns: 1fr;
   }
 
-  .dashboard-grid > aside {
+  .dashboard-sidebar,
+  .dashboard-sidebar.collapsed {
     left: auto;
     max-height: none;
     overflow: visible;
     position: static;
     top: auto;
     width: auto;
+  }
+
+  .dashboard-sidebar.collapsed .card {
+    padding: 1.1rem;
+  }
+
+  .dashboard-sidebar.collapsed .dashboard-sidebar-content {
+    display: block;
+  }
+
+  .dashboard-sidebar.collapsed .dashboard-sidebar-new,
+  .dashboard-sidebar.collapsed .dashboard-sidebar-title {
+    display: revert;
   }
 
   .map {


### PR DESCRIPTION
## Summary
- add an expand/collapse control to the dashboard Places and Routes sidebars
- keep the sidebar floating over the larger map on desktop
- preserve the stacked sidebar layout on narrow screens

## Checks
- npm run lint (web; passes with existing Biome schema version info)
- npm run typecheck (web; blocked locally because next is not installed in web/node_modules)