### PR TITLE
feat(web): improve route editor flow

### DIFF
--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -5,10 +5,11 @@ import DashboardShell from '@/components/dashboard/DashboardShell';
 import RouteEditor from '@/components/dashboard/RouteEditor';
 import { useDashboardAuth } from '@/components/dashboard/useDashboardAuth';
 import { formatError, formatMode } from '@/components/dashboard/utils';
-import type { Route, RouteInput } from '@/lib/api';
+import type { Place, Route, RouteInput } from '@/lib/api';
 
 export default function RoutesDashboardPage() {
   const auth = useDashboardAuth();
+  const [places, setPlaces] = useState<Place[]>([]);
   const [routes, setRoutes] = useState<Route[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -25,8 +26,12 @@ export default function RoutesDashboardPage() {
     setIsLoading(true);
 
     try {
-      const nextRoutes = await auth.apiRequest<Route[]>('/routes');
+      const [nextRoutes, nextPlaces] = await Promise.all([
+        auth.apiRequest<Route[]>('/routes'),
+        auth.apiRequest<Place[]>('/places'),
+      ]);
       setRoutes(nextRoutes);
+      setPlaces(nextPlaces);
       setSelectedRouteId((current) => current ?? nextRoutes[0]?.id ?? null);
     } catch (nextError) {
       setError(formatError(nextError));
@@ -106,7 +111,7 @@ export default function RoutesDashboardPage() {
                   type="button"
                   onClick={() => setSelectedRouteId(null)}
                 >
-                  New
+                  New route
                 </button>
               </div>
             </div>
@@ -141,7 +146,9 @@ export default function RoutesDashboardPage() {
           <RouteEditor
             key={selectedRoute?.id ?? 'new-route'}
             onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
+            onNew={selectedRoute == null ? undefined : () => setSelectedRouteId(null)}
             onSave={(input) => void saveRoute(input)}
+            places={places}
             route={selectedRoute}
           />
         </section>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -438,26 +438,27 @@ label {
    ========================================================================== */
 
 .dashboard-grid {
+  align-items: start;
   display: grid;
   gap: 1rem;
-  grid-template-columns: minmax(0, 1fr);
-  position: relative;
+  grid-template-columns: minmax(18rem, 22rem) minmax(0, 1fr);
+}
+
+.dashboard-grid:has(.dashboard-sidebar.collapsed) {
+  grid-template-columns: 3.6rem minmax(0, 1fr);
 }
 
 .dashboard-sidebar {
-  left: 1rem;
-  max-height: calc(100vh - 13rem);
+  max-height: calc(100vh - 2rem);
   overflow: auto;
-  position: absolute;
-  top: 5.4rem;
+  position: sticky;
+  top: 1rem;
   transition: width var(--transition);
-  width: min(22rem, calc(100% - 2rem));
-  z-index: 5;
+  width: 100%;
 }
 
 .dashboard-sidebar.collapsed {
   overflow: visible;
-  width: 3.6rem;
 }
 
 .dashboard-grid > section {

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -7,6 +7,7 @@ import type { RouteWaypoint } from '@/lib/api';
 
 type Props = {
   className?: string;
+  focusTarget?: RouteWaypoint | null;
   onChange: (waypoints: RouteWaypoint[]) => void;
   waypoints: RouteWaypoint[];
 };
@@ -14,7 +15,12 @@ type Props = {
 const LINE_SOURCE_ID = 'route-line';
 const LINE_LAYER_ID = 'route-line';
 
-export default function RouteMapEditor({ className = 'map', onChange, waypoints }: Props) {
+export default function RouteMapEditor({
+  className = 'map',
+  focusTarget = null,
+  onChange,
+  waypoints,
+}: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
@@ -96,15 +102,27 @@ export default function RouteMapEditor({ className = 'map', onChange, waypoints 
     if (map.isStyleLoaded()) {
       updateLine(map, waypoints);
       syncMarkers(map, markersRef.current, waypoints, onChange);
-      fitWaypoints(map, waypoints);
     } else {
       map.once('load', () => {
         updateLine(map, waypoints);
         syncMarkers(map, markersRef.current, waypoints, onChange);
-        fitWaypoints(map, waypoints);
       });
     }
   }, [onChange, waypoints]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null || focusTarget == null) {
+      return;
+    }
+
+    map.easeTo({
+      center: [focusTarget.longitude, focusTarget.latitude],
+      duration: 350,
+      zoom: Math.max(map.getZoom(), 14),
+    });
+  }, [focusTarget]);
 
   return <div className={className} ref={containerRef} />;
 }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/dashboard/utils';
 import {
   ApiError,
+  type Place,
   type Route,
   type RouteInput,
   type RouteMode,
@@ -24,11 +25,15 @@ const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
 
 export default function RouteEditor({
   onDelete,
+  onNew,
   onSave,
+  places = [],
   route,
 }: {
   onDelete?: () => void;
+  onNew?: () => void;
   onSave: (input: RouteInput) => void;
+  places?: Place[];
   route: Route | null;
 }) {
   const [name, setName] = useState(route?.name ?? '');
@@ -40,11 +45,9 @@ export default function RouteEditor({
     route?.currentRevision?.waypoints.map((waypoint) => ({
       latitude: waypoint.latitude,
       longitude: waypoint.longitude,
-    })) ?? [
-      { latitude: 25.033, longitude: 121.5654 },
-      { latitude: 25.0375, longitude: 121.5637 },
-    ],
+    })) ?? [],
   );
+  const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -72,16 +75,54 @@ export default function RouteEditor({
     }
   }
 
+  function startFromPlace(placeId: string) {
+    const place = places.find((currentPlace) => currentPlace.id === placeId);
+
+    if (place == null) {
+      return;
+    }
+
+    const waypoint = {
+      latitude: place.latitude,
+      longitude: place.longitude,
+    };
+
+    setWaypoints([waypoint]);
+    setFocusTarget(waypoint);
+  }
+
   return (
     <form className="panel stack" onSubmit={submit}>
       <div className="row" style={{ justifyContent: 'space-between' }}>
         <h2>{route == null ? 'New route' : 'Route editor'}</h2>
-        {route?.currentRevision == null ? null : (
-          <span className="chip">latest revision {route.currentRevision.revisionNumber}</span>
-        )}
+        <div className="row">
+          {route?.currentRevision == null ? null : (
+            <span className="chip">latest revision {route.currentRevision.revisionNumber}</span>
+          )}
+          {onNew == null ? null : (
+            <button className="secondary" type="button" onClick={onNew}>
+              New route
+            </button>
+          )}
+        </div>
       </div>
       {error == null ? null : <div className="error">{error}</div>}
-      <RouteMapEditor waypoints={waypoints} onChange={setWaypoints} />
+      {route == null && waypoints.length === 0 && places.length > 0 ? (
+        <label>
+          Start from place
+          <select defaultValue="" onChange={(event) => startFromPlace(event.target.value)}>
+            <option disabled value="">
+              Select a saved place…
+            </option>
+            {places.map((place) => (
+              <option key={place.id} value={place.id}>
+                {place.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+      <RouteMapEditor focusTarget={focusTarget} waypoints={waypoints} onChange={setWaypoints} />
       <label>
         Name
         <input required value={name} onChange={(event) => setName(event.target.value)} />


### PR DESCRIPTION
## Summary
- start new routes with zero waypoints and expose a New route action from the editor
- let empty new routes choose a saved place as the first waypoint
- keep route map zoom stable when adding or editing waypoints
- move the dashboard sidebar into the layout column so it no longer overlays the map

## Checks
- npm run lint (web; passes with existing Biome schema version info)