### PR TITLE
feat(web): improve waypoint editing controls

### DIFF
--- a/docs/plans/2026-05-14_web-dashboard-ux-review-plan.md
+++ b/docs/plans/2026-05-14_web-dashboard-ux-review-plan.md
@@ -79,10 +79,10 @@
 
 ### Phase 3 — 改善 waypoint 操作
 
-- [ ] 在 waypoint row 顯示更語意化 label：`Start`、`Stop 2`、`End`，而不是只有 `#1`；用 route 有 2/3/多點的畫面驗證 label 正確。
-- [ ] 點選 waypoint row 時設定 selected waypoint，並在 map marker 上用顏色 / scale / popup 反映 selected 狀態；用手動點 row 與 marker 驗證雙向同步。
-- [ ] 將 `Add waypoint` 從「複製最後一點」改為更明確的兩種操作：`Add from map click` instruction 與 `Duplicate last waypoint` 次要 action；用新增點流程驗證不再產生意外重疊。
-- [ ] 加入 `Fit route` 按鈕，僅由使用者主動觸發地圖重新縮放；用 map zoom 手動測試確認新增 waypoint 不 auto-fit、按鈕才 fit。
+- [x] 在 waypoint row 顯示更語意化 label：`Start`、`Stop 2`、`End`，而不是只有 `#1`；已更新 `RouteEditor` 並用 `cd web && npm run lint` 驗證。
+- [x] 點選 waypoint row 時設定 selected waypoint，並在 map marker 上用顏色 / scale / popup 反映 selected 狀態；已加入 selected row / marker state 與 marker click callback，並用 `cd web && npm run lint` 驗證。
+- [x] 將 `Add waypoint` 從「複製最後一點」改為更明確的兩種操作：`Add from map click` instruction 與 `Duplicate last waypoint` 次要 action；已更新 route builder actions 並用 `cd web && npm run lint` 驗證。
+- [x] 加入 `Fit route` 按鈕，僅由使用者主動觸發地圖重新縮放；已用 `fitRequest` 觸發手動 fit，並用 `cd web && npm run lint` 驗證。
 
 ### Phase 4 — 讓 Favorites / Places 更像可用素材庫
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -853,6 +853,51 @@ label {
   z-index: 2;
 }
 
+.map-action-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.route-marker {
+  align-items: center;
+  background: var(--color-secondary);
+  border: 2px solid white;
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-sm);
+  color: var(--color-text);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 800;
+  height: 2rem;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0;
+  transition:
+    background var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.route-marker:first-letter {
+  text-transform: uppercase;
+}
+
+.route-marker:hover:not(:disabled) {
+  background: var(--color-secondary);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.route-marker.selected,
+.route-marker.selected:hover:not(:disabled) {
+  background: var(--color-primary);
+  box-shadow: 0 0 0 4px rgb(118 201 69 / 28%), var(--shadow-md);
+  transform: scale(1.16);
+}
+
 .map {
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-xs);
@@ -879,9 +924,17 @@ label {
 
 .waypoint-row {
   align-items: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: auto 1fr 1fr auto;
+  grid-template-columns: minmax(4.5rem, auto) 1fr 1fr auto;
+  padding: 0.35rem;
+}
+
+.waypoint-row.selected {
+  background: rgb(118 201 69 / 8%);
+  border-color: rgb(118 201 69 / 25%);
 }
 
 /* ==========================================================================

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -7,8 +7,11 @@ import type { RouteWaypoint } from '@/lib/api';
 
 type Props = {
   className?: string;
+  fitRequest?: number;
   focusTarget?: RouteWaypoint | null;
   onChange: (waypoints: RouteWaypoint[]) => void;
+  onSelectWaypoint?: (index: number) => void;
+  selectedWaypointIndex?: number | null;
   waypoints: RouteWaypoint[];
 };
 
@@ -17,20 +20,27 @@ const LINE_LAYER_ID = 'route-line';
 
 export default function RouteMapEditor({
   className = 'map',
+  fitRequest = 0,
   focusTarget = null,
   onChange,
+  onSelectWaypoint,
+  selectedWaypointIndex = null,
   waypoints,
 }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
   const onChangeRef = useRef(onChange);
+  const onSelectWaypointRef = useRef(onSelectWaypoint);
+  const selectedWaypointIndexRef = useRef(selectedWaypointIndex);
   const waypointsRef = useRef(waypoints);
 
   useEffect(() => {
     onChangeRef.current = onChange;
+    onSelectWaypointRef.current = onSelectWaypoint;
+    selectedWaypointIndexRef.current = selectedWaypointIndex;
     waypointsRef.current = waypoints;
-  }, [onChange, waypoints]);
+  }, [onChange, onSelectWaypoint, selectedWaypointIndex, waypoints]);
 
   useEffect(() => {
     if (containerRef.current == null || mapRef.current != null) {
@@ -67,7 +77,14 @@ export default function RouteMapEditor({
         source: LINE_SOURCE_ID,
         type: 'line',
       });
-      syncMarkers(map, markersRef.current, waypointsRef.current, onChangeRef.current);
+      syncMarkers({
+        existingMarkers: markersRef.current,
+        map,
+        onChange: onChangeRef.current,
+        onSelectWaypoint: onSelectWaypointRef.current,
+        selectedWaypointIndex: selectedWaypointIndexRef.current,
+        waypoints: waypointsRef.current,
+      });
       fitWaypoints(map, waypointsRef.current);
     });
     map.on('click', (event) => {
@@ -78,6 +95,7 @@ export default function RouteMapEditor({
           longitude: roundCoord(event.lngLat.lng),
         },
       ]);
+      onSelectWaypointRef.current?.(waypointsRef.current.length);
     });
 
     mapRef.current = map;
@@ -101,14 +119,28 @@ export default function RouteMapEditor({
 
     if (map.isStyleLoaded()) {
       updateLine(map, waypoints);
-      syncMarkers(map, markersRef.current, waypoints, onChange);
+      syncMarkers({
+        existingMarkers: markersRef.current,
+        map,
+        onChange,
+        onSelectWaypoint,
+        selectedWaypointIndex,
+        waypoints,
+      });
     } else {
       map.once('load', () => {
         updateLine(map, waypoints);
-        syncMarkers(map, markersRef.current, waypoints, onChange);
+        syncMarkers({
+          existingMarkers: markersRef.current,
+          map,
+          onChange,
+          onSelectWaypoint,
+          selectedWaypointIndex,
+          waypoints,
+        });
       });
     }
-  }, [onChange, waypoints]);
+  }, [onChange, onSelectWaypoint, selectedWaypointIndex, waypoints]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -124,15 +156,34 @@ export default function RouteMapEditor({
     });
   }, [focusTarget]);
 
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null || fitRequest === 0) {
+      return;
+    }
+
+    fitWaypoints(map, waypointsRef.current);
+  }, [fitRequest]);
+
   return <div className={className} ref={containerRef} />;
 }
 
-function syncMarkers(
-  map: MapLibreMap,
-  existingMarkers: Marker[],
-  waypoints: RouteWaypoint[],
-  onChange: (waypoints: RouteWaypoint[]) => void,
-) {
+function syncMarkers({
+  existingMarkers,
+  map,
+  onChange,
+  onSelectWaypoint,
+  selectedWaypointIndex,
+  waypoints,
+}: {
+  existingMarkers: Marker[];
+  map: MapLibreMap;
+  onChange: (waypoints: RouteWaypoint[]) => void;
+  onSelectWaypoint?: (index: number) => void;
+  selectedWaypointIndex: number | null;
+  waypoints: RouteWaypoint[];
+}) {
   existingMarkers.forEach((marker) => {
     marker.remove();
   });
@@ -140,12 +191,23 @@ function syncMarkers(
 
   waypoints.forEach((waypoint, index) => {
     const marker = new maplibregl.Marker({
-      color: index === 0 ? '#76c945' : '#f9aecb',
       draggable: true,
+      element: createMarkerElement({
+        index,
+        isSelected: selectedWaypointIndex === index,
+        waypointCount: waypoints.length,
+      }),
     })
       .setLngLat([waypoint.longitude, waypoint.latitude])
       .addTo(map);
 
+    marker.getElement().addEventListener('click', (event) => {
+      event.stopPropagation();
+      onSelectWaypoint?.(index);
+    });
+    marker.on('dragstart', () => {
+      onSelectWaypoint?.(index);
+    });
     marker.on('dragend', () => {
       const lngLat = marker.getLngLat();
       onChange(
@@ -163,6 +225,35 @@ function syncMarkers(
 
     existingMarkers.push(marker);
   });
+}
+
+function createMarkerElement({
+  index,
+  isSelected,
+  waypointCount,
+}: {
+  index: number;
+  isSelected: boolean;
+  waypointCount: number;
+}) {
+  const element = document.createElement('button');
+  element.className = `route-marker ${isSelected ? 'selected' : ''}`;
+  element.textContent = getWaypointShortLabel(index, waypointCount);
+  element.type = 'button';
+
+  return element;
+}
+
+function getWaypointShortLabel(index: number, waypointCount: number): string {
+  if (index === 0) {
+    return 'S';
+  }
+
+  if (index === waypointCount - 1) {
+    return 'E';
+  }
+
+  return `${index + 1}`;
 }
 
 function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -47,11 +47,19 @@ export default function RouteEditor({
       longitude: waypoint.longitude,
     })) ?? [],
   );
+  const [fitRequest, setFitRequest] = useState(0);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
+  const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
+
+  useEffect(() => {
+    if (selectedWaypointIndex != null && selectedWaypointIndex >= waypoints.length) {
+      setSelectedWaypointIndex(null);
+    }
+  }, [selectedWaypointIndex, waypoints.length]);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -91,6 +99,29 @@ export default function RouteEditor({
 
     setWaypoints([waypoint]);
     setFocusTarget(waypoint);
+    setSelectedWaypointIndex(0);
+  }
+
+  function duplicateLastWaypoint() {
+    const lastWaypoint = waypoints.at(-1);
+
+    if (lastWaypoint == null) {
+      return;
+    }
+
+    setWaypoints([...waypoints, lastWaypoint]);
+    setSelectedWaypointIndex(waypoints.length);
+  }
+
+  function removeWaypoint(index: number) {
+    setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index));
+    setSelectedWaypointIndex((currentIndex) => {
+      if (currentIndex == null || currentIndex === index) {
+        return null;
+      }
+
+      return currentIndex > index ? currentIndex - 1 : currentIndex;
+    });
   }
 
   function confirmDelete() {
@@ -138,16 +169,37 @@ export default function RouteEditor({
           </label>
         ) : null}
         <div className="map-builder">
-          <RouteMapEditor focusTarget={focusTarget} waypoints={waypoints} onChange={setWaypoints} />
+          <RouteMapEditor
+            fitRequest={fitRequest}
+            focusTarget={focusTarget}
+            selectedWaypointIndex={selectedWaypointIndex}
+            waypoints={waypoints}
+            onChange={setWaypoints}
+            onSelectWaypoint={setSelectedWaypointIndex}
+          />
           <div className="map-instruction">Click map to add waypoint · Drag markers to adjust</div>
+        </div>
+        <div className="map-action-row">
+          <button
+            className="secondary"
+            disabled={waypoints.length === 0}
+            type="button"
+            onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
+          >
+            Fit route
+          </button>
+          <span className="muted">Add from map click, then use rows for exact coordinates.</span>
         </div>
 
         <div className="stack">
           <h3>Waypoints</h3>
           {waypoints.map((waypoint, index) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: waypoint rows are edited by position until drag-and-drop adds stable row ids.
-            <div className="waypoint-row" key={`${index}-${waypoint.latitude}-${waypoint.longitude}`}>
-              <span className="chip">#{index + 1}</span>
+            <div
+              className={`waypoint-row ${selectedWaypointIndex === index ? 'selected' : ''}`}
+              key={getWaypointKey(waypoint, index)}
+              onPointerDown={() => setSelectedWaypointIndex(index)}
+            >
+              <span className="chip">{getWaypointLabel(index, waypoints.length)}</span>
               <input
                 inputMode="decimal"
                 value={waypoint.latitude}
@@ -179,13 +231,7 @@ export default function RouteEditor({
                 >
                   ↓
                 </button>
-                <button
-                  className="danger"
-                  type="button"
-                  onClick={() =>
-                    setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index))
-                  }
-                >
+                <button className="danger" type="button" onClick={() => removeWaypoint(index)}>
                   ×
                 </button>
               </div>
@@ -193,15 +239,11 @@ export default function RouteEditor({
           ))}
           <button
             className="secondary"
+            disabled={waypoints.length === 0}
             type="button"
-            onClick={() =>
-              setWaypoints([
-                ...waypoints,
-                waypoints.at(-1) ?? { latitude: 25.033, longitude: 121.5654 },
-              ])
-            }
+            onClick={duplicateLastWaypoint}
           >
-            Add waypoint
+            Duplicate last waypoint
           </button>
         </div>
       </section>
@@ -278,6 +320,22 @@ export default function RouteEditor({
       </footer>
     </form>
   );
+}
+
+function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
+  return `${waypoint.sequence ?? index}-${waypoint.latitude}-${waypoint.longitude}`;
+}
+
+function getWaypointLabel(index: number, waypointCount: number): string {
+  if (index === 0) {
+    return 'Start';
+  }
+
+  if (index === waypointCount - 1) {
+    return 'End';
+  }
+
+  return `Stop ${index + 1}`;
 }
 
 function getRouteBuilderHint(waypointCount: number, placeCount: number): string {


### PR DESCRIPTION
## Summary
- add semantic waypoint labels for Start, Stop, and End
- support selected waypoint state across rows and map markers
- replace generic waypoint add with map-click guidance and Duplicate last waypoint
- add a manual Fit route control so map zoom changes only when requested
- update the web dashboard UX plan Phase 3 checklist

## Checks
- npm run lint (web; passes with existing Biome schema version info)