### PR TITLE
feat(web): add favorite waypoint picker

### DIFF
--- a/docs/plans/2026-05-14_web-dashboard-ux-review-plan.md
+++ b/docs/plans/2026-05-14_web-dashboard-ux-review-plan.md
@@ -86,9 +86,9 @@
 
 ### Phase 4 — 讓 Favorites / Places 更像可用素材庫
 
-- [ ] 將 Routes editor 中的 `Start from place` 改成可搜尋 combobox 或 filtered list，顯示 place name、tags、座標摘要；用 20 筆 places 的手動資料驗證搜尋效率。
-- [ ] 統一 Web 文案：navigation 可保留 `Places`，但 route editor 內使用 `Favorite place` / `Saved place`，並在空狀態提供前往 Places 的 link；用全文搜尋 `Places` / `place` 文案驗證一致性。
-- [ ] 在 route editor 支援 `Add favorite as waypoint`（已有 waypoint 時），但以次要 action 呈現，避免和 0 點時 `Start from place` 混淆；用 0 點與已有點兩種狀態手動驗證文案不同。
+- [x] 將 Routes editor 中的 `Start from place` 改成可搜尋 combobox 或 filtered list，顯示 place name、tags、座標摘要；已加入 filtered favorite place list 並用 `cd web && npm run lint` 驗證。
+- [x] 統一 Web 文案：navigation 可保留 `Places`，但 route editor 內使用 `Favorite place` / `Saved place`，並在空狀態提供前往 Places 的 link；已在 RouteEditor 使用 favorite place 文案與 `/dashboard/places` link，並用 `cd web && npm run lint` 驗證。
+- [x] 在 route editor 支援 `Add favorite as waypoint`（已有 waypoint 時），但以次要 action 呈現，避免和 0 點時 `Start from place` 混淆；已依 0 點 / 已有點切換文案與 append 行為，並用 `cd web && npm run lint` 驗證。
 
 ### Phase 5 — 視覺系統與響應式細修
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -833,6 +833,41 @@ label {
   padding: 0.75rem 0.9rem;
 }
 
+.favorite-picker {
+  background: rgb(255 255 255 / 42%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.9rem;
+}
+
+.favorite-picker h3,
+.favorite-picker p {
+  margin: 0;
+}
+
+.favorite-place-list {
+  display: grid;
+  gap: 0.45rem;
+  max-height: 16rem;
+  overflow: auto;
+}
+
+.favorite-place-option {
+  background: rgb(255 255 255 / 58%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem 0.8rem;
+  text-align: left;
+}
+
+.favorite-place-option:hover:not(:disabled) {
+  background: rgb(118 201 69 / 10%);
+  transform: none;
+}
+
 .map-builder {
   position: relative;
 }
@@ -913,6 +948,8 @@ label {
 }
 
 @media (prefers-color-scheme: dark) {
+  .favorite-picker,
+  .favorite-place-option,
   .map-instruction {
     background: rgb(28 40 32 / 84%);
   }

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -82,9 +82,9 @@ export default function RouteMapEditor({
         map,
         onChange: onChangeRef.current,
         onSelectWaypoint: onSelectWaypointRef.current,
-        selectedWaypointIndex: selectedWaypointIndexRef.current,
         waypoints: waypointsRef.current,
       });
+      updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
       fitWaypoints(map, waypointsRef.current);
     });
     map.on('click', (event) => {
@@ -124,9 +124,9 @@ export default function RouteMapEditor({
         map,
         onChange,
         onSelectWaypoint,
-        selectedWaypointIndex,
         waypoints,
       });
+      updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
     } else {
       map.once('load', () => {
         updateLine(map, waypoints);
@@ -135,12 +135,16 @@ export default function RouteMapEditor({
           map,
           onChange,
           onSelectWaypoint,
-          selectedWaypointIndex,
           waypoints,
         });
+        updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
       });
     }
-  }, [onChange, onSelectWaypoint, selectedWaypointIndex, waypoints]);
+  }, [onChange, onSelectWaypoint, waypoints]);
+
+  useEffect(() => {
+    updateMarkerSelection(markersRef.current, selectedWaypointIndex);
+  }, [selectedWaypointIndex]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -174,14 +178,12 @@ function syncMarkers({
   map,
   onChange,
   onSelectWaypoint,
-  selectedWaypointIndex,
   waypoints,
 }: {
   existingMarkers: Marker[];
   map: MapLibreMap;
   onChange: (waypoints: RouteWaypoint[]) => void;
   onSelectWaypoint?: (index: number) => void;
-  selectedWaypointIndex: number | null;
   waypoints: RouteWaypoint[];
 }) {
   existingMarkers.forEach((marker) => {
@@ -194,7 +196,6 @@ function syncMarkers({
       draggable: true,
       element: createMarkerElement({
         index,
-        isSelected: selectedWaypointIndex === index,
         waypointCount: waypoints.length,
       }),
     })
@@ -229,19 +230,23 @@ function syncMarkers({
 
 function createMarkerElement({
   index,
-  isSelected,
   waypointCount,
 }: {
   index: number;
-  isSelected: boolean;
   waypointCount: number;
 }) {
   const element = document.createElement('button');
-  element.className = `route-marker ${isSelected ? 'selected' : ''}`;
+  element.className = 'route-marker';
   element.textContent = getWaypointShortLabel(index, waypointCount);
   element.type = 'button';
 
   return element;
+}
+
+function updateMarkerSelection(markers: Marker[], selectedWaypointIndex: number | null) {
+  markers.forEach((marker, index) => {
+    marker.getElement().classList.toggle('selected', selectedWaypointIndex === index);
+  });
 }
 
 function getWaypointShortLabel(index: number, waypointCount: number): string {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { type FormEvent, useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import {
   formatError,
@@ -54,6 +55,7 @@ export default function RouteEditor({
   const [isSaving, setIsSaving] = useState(false);
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
+  const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
 
   useEffect(() => {
     if (selectedWaypointIndex != null && selectedWaypointIndex >= waypoints.length) {
@@ -85,21 +87,16 @@ export default function RouteEditor({
     }
   }
 
-  function startFromPlace(placeId: string) {
-    const place = places.find((currentPlace) => currentPlace.id === placeId);
-
-    if (place == null) {
-      return;
-    }
-
+  function addFavoriteWaypoint(place: Place) {
     const waypoint = {
       latitude: place.latitude,
       longitude: place.longitude,
     };
+    const nextWaypoints = waypoints.length === 0 ? [waypoint] : [...waypoints, waypoint];
 
-    setWaypoints([waypoint]);
+    setWaypoints(nextWaypoints);
     setFocusTarget(waypoint);
-    setSelectedWaypointIndex(0);
+    setSelectedWaypointIndex(nextWaypoints.length - 1);
   }
 
   function duplicateLastWaypoint() {
@@ -153,21 +150,11 @@ export default function RouteEditor({
           <p className="muted">Build the route shape from favorites or direct map clicks.</p>
         </div>
         <div className="route-builder-hint">{routeBuilderHint}</div>
-        {route == null && waypoints.length === 0 && places.length > 0 ? (
-          <label>
-            Start from favorite place
-            <select defaultValue="" onChange={(event) => startFromPlace(event.target.value)}>
-              <option disabled value="">
-                Select a saved place…
-              </option>
-              {places.map((place) => (
-                <option key={place.id} value={place.id}>
-                  {place.name}
-                </option>
-              ))}
-            </select>
-          </label>
-        ) : null}
+        <FavoriteWaypointPicker
+          mode={favoritePickerMode}
+          places={places}
+          onSelect={addFavoriteWaypoint}
+        />
         <div className="map-builder">
           <RouteMapEditor
             fitRequest={fitRequest}
@@ -320,6 +307,88 @@ export default function RouteEditor({
       </footer>
     </form>
   );
+}
+
+function FavoriteWaypointPicker({
+  mode,
+  onSelect,
+  places,
+}: {
+  mode: 'append' | 'start';
+  onSelect: (place: Place) => void;
+  places: Place[];
+}) {
+  const [query, setQuery] = useState('');
+  const filteredPlaces = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (normalizedQuery.length === 0) {
+      return places;
+    }
+
+    return places.filter((place) => {
+      const haystack = [place.name, place.description ?? '', ...place.tags].join(' ').toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  }, [places, query]);
+
+  if (places.length === 0) {
+    return (
+      <div className="favorite-picker empty-state">
+        <p className="muted">No favorite places yet.</p>
+        <Link href="/dashboard/places">Create a favorite place first</Link>
+      </div>
+    );
+  }
+
+  return (
+    <section className="favorite-picker stack">
+      <div>
+        <h3>{mode === 'start' ? 'Start from favorite place' : 'Add favorite as waypoint'}</h3>
+        <p className="muted">
+          {mode === 'start'
+            ? 'Pick a saved place as the first waypoint, or click the map to start manually.'
+            : 'Append a saved place to the end of this route.'}
+        </p>
+      </div>
+      <label>
+        Search favorite places
+        <input
+          placeholder="Search by name, tag, or description…"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+      </label>
+      <div className="favorite-place-list">
+        {filteredPlaces.map((place) => (
+          <button
+            className="favorite-place-option"
+            key={place.id}
+            type="button"
+            onClick={() => onSelect(place)}
+          >
+            <strong>{place.name}</strong>
+            <span className="muted">{formatFavoritePlaceCoords(place)}</span>
+            {place.tags.length === 0 ? null : (
+              <span className="chip-row">
+                {place.tags.map((tag) => (
+                  <span className="chip" key={tag}>
+                    {tag}
+                  </span>
+                ))}
+              </span>
+            )}
+          </button>
+        ))}
+        {filteredPlaces.length === 0 ? <p className="muted">No favorite places match.</p> : null}
+      </div>
+    </section>
+  );
+}
+
+function formatFavoritePlaceCoords(place: Place): string {
+  return `${place.latitude.toFixed(6)}, ${place.longitude.toFixed(6)}`;
 }
 
 function getWaypointKey(waypoint: RouteWaypoint, index: number): string {


### PR DESCRIPTION
## Summary
- replace the route start select with a searchable favorite place picker
- show favorite place names, coordinates, and tags in route building
- support appending a favorite place as a waypoint after a route has started
- link users to create favorite places when none exist
- update the web dashboard UX plan Phase 4 checklist

## Checks
- npm run lint (web; passes with existing Biome schema version info)