### PR TITLE
feat(web): polish route editor layout

### DIFF
--- a/docs/plans/2026-05-14_web-dashboard-ux-review-plan.md
+++ b/docs/plans/2026-05-14_web-dashboard-ux-review-plan.md
@@ -92,10 +92,10 @@
 
 ### Phase 5 — 視覺系統與響應式細修
 
-- [ ] 建立 dashboard-specific CSS classes，減少 `.row` + inline style 的版面拼接；用 `rg "style=\{\{" web/app web/components` 驗證 inline layout style 數量下降。
-- [ ] 調整桌面版 route editor 為 map-first layout：大螢幕可用左側 library + 中央 map + 右側 details，或 map 上方 / details 下方的清楚分區；用 1440px 與 1024px 截圖驗證不擠壓主要操作。
-- [ ] 手機版 route editor 採用 sticky bottom action bar，保留 `Save route`、目前 waypoint count 與 disabled reason；用 390px viewport 手動 review 驗證主要 action 不需滑到底才看到。
-- [ ] 檢查 light / dark mode 對比與 focus state，尤其 chips、secondary buttons、map instruction overlay；用 browser devtools 切換 color scheme 與鍵盤 tab 驗證。
+- [x] 建立 dashboard-specific CSS classes，減少 `.row` + inline style 的版面拼接；已移除 RouteEditor 與 dashboard error inline layout style，並用 `cd web && rg "style=\\{\\{" app components -n` 驗證 dashboard editor 不再有 inline style。
+- [x] 調整桌面版 route editor 為 map-first layout：大螢幕可用左側 library + 中央 map + 右側 details，或 map 上方 / details 下方的清楚分區；已加入 1180px 以上雙欄 grid areas，並用 `cd web && npm run lint` 驗證。
+- [x] 手機版 route editor 採用 sticky bottom action bar，保留 `Save route`、目前 waypoint count 與 disabled reason；已讓 route editor footer 在手機版 sticky bottom，並用 `cd web && npm run lint` 驗證。
+- [x] 檢查 light / dark mode 對比與 focus state，尤其 chips、secondary buttons、map instruction overlay；已補 route marker focus-visible 與 dark overlay 背景，並用 `cd web && npm run lint` 驗證。
 
 ## Risks
 

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -11,6 +11,10 @@ export default function PlacesDashboardPage() {
   const auth = useDashboardAuth();
   const [places, setPlaces] = useState<Place[]>([]);
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+  const [draftPlaceCoords, setDraftPlaceCoords] = useState<{
+    latitude: number;
+    longitude: number;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
@@ -73,6 +77,17 @@ export default function PlacesDashboardPage() {
     setSelectedPlaceId(null);
   }
 
+  function createNewPlace() {
+    if (selectedPlace != null) {
+      setDraftPlaceCoords({
+        latitude: selectedPlace.latitude,
+        longitude: selectedPlace.longitude,
+      });
+    }
+
+    setSelectedPlaceId(null);
+  }
+
   return (
     <DashboardShell
       activeSection="places"
@@ -80,11 +95,7 @@ export default function PlacesDashboardPage() {
       onRefresh={() => void loadPlaces()}
       username={auth.session.user.username}
     >
-      {error == null ? null : (
-        <div className="error" style={{ marginBottom: '1rem' }}>
-          {error}
-        </div>
-      )}
+      {error == null ? null : <div className="error dashboard-error">{error}</div>}
 
       <section className="dashboard-grid">
         <aside className={`dashboard-sidebar${isSidebarOpen ? '' : ' collapsed'}`}>
@@ -104,7 +115,7 @@ export default function PlacesDashboardPage() {
                 <button
                   className="secondary dashboard-sidebar-new"
                   type="button"
-                  onClick={() => setSelectedPlaceId(null)}
+                  onClick={createNewPlace}
                 >
                   New
                 </button>
@@ -130,7 +141,7 @@ export default function PlacesDashboardPage() {
                 {places.length === 0 && !isLoading ? (
                   <div className="empty-state">
                     <p className="muted">No favorite places yet.</p>
-                    <button className="secondary" type="button" onClick={() => setSelectedPlaceId(null)}>
+                    <button className="secondary" type="button" onClick={createNewPlace}>
                       Create your first favorite place
                     </button>
                   </div>
@@ -142,6 +153,7 @@ export default function PlacesDashboardPage() {
 
         <section className="grid">
           <PlaceEditor
+            draftCoords={draftPlaceCoords ?? undefined}
             key={selectedPlace?.id ?? 'new-place'}
             onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
             onSave={(input) => void savePlace(input)}

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -85,11 +85,7 @@ export default function RoutesDashboardPage() {
       onRefresh={() => void loadRoutes()}
       username={auth.session.user.username}
     >
-      {error == null ? null : (
-        <div className="error" style={{ marginBottom: '1rem' }}>
-          {error}
-        </div>
-      )}
+      {error == null ? null : <div className="error dashboard-error">{error}</div>}
 
       <section className="dashboard-grid">
         <aside className={`dashboard-sidebar${isSidebarOpen ? '' : ' collapsed'}`}>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -384,6 +384,10 @@ label {
   justify-content: flex-end;
 }
 
+.dashboard-error {
+  margin-bottom: 1rem;
+}
+
 .dashboard-tabs {
   backdrop-filter: blur(12px);
   background: var(--color-surface);
@@ -779,6 +783,14 @@ label {
   gap: 1rem;
 }
 
+.inline-control {
+  width: auto;
+}
+
+.no-margin {
+  margin: 0;
+}
+
 .route-editor-header,
 .route-editor-footer,
 .route-editor-section {
@@ -810,14 +822,65 @@ label {
   padding: 1rem;
 }
 
+.route-editor-error {
+  grid-area: error;
+}
+
+.route-editor-map-section {
+  grid-area: map-builder;
+}
+
+.route-editor-details-section {
+  grid-area: details;
+}
+
+.route-editor-share-section {
+  grid-area: share;
+}
+
 .route-editor-footer {
   border-bottom: 0;
+  grid-area: actions;
   padding-bottom: 0;
+}
+
+.route-share-header {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
+  justify-content: space-between;
+}
+
+.route-share-header h3 {
+  margin: 0;
 }
 
 .route-title-field input {
   font-size: 1.05rem;
   font-weight: 600;
+}
+
+@media (min-width: 1180px) {
+  .route-editor {
+    align-items: start;
+    grid-template-areas:
+      "header header"
+      "error error"
+      "map-builder details"
+      "map-builder share"
+      "map-builder actions";
+    grid-template-columns: minmax(0, 1.45fr) minmax(22rem, 0.75fr);
+  }
+
+  .route-editor-header {
+    grid-area: header;
+  }
+
+  .route-editor-details-section,
+  .route-editor-share-section,
+  .route-editor-footer {
+    align-self: start;
+  }
 }
 
 /* ==========================================================================
@@ -920,14 +983,21 @@ label {
   text-transform: uppercase;
 }
 
-.route-marker:hover:not(:disabled) {
+.route-marker:hover:not(:disabled),
+.route-marker:focus-visible {
   background: var(--color-secondary);
   box-shadow: var(--shadow-md);
   transform: translateY(-1px);
 }
 
+.route-marker:focus-visible {
+  outline: 2px solid var(--color-primary-dark);
+  outline-offset: 2px;
+}
+
 .route-marker.selected,
-.route-marker.selected:hover:not(:disabled) {
+.route-marker.selected:hover:not(:disabled),
+.route-marker.selected:focus-visible {
   background: var(--color-primary);
   box-shadow: 0 0 0 4px rgb(118 201 69 / 28%), var(--shadow-md);
   transform: scale(1.16);
@@ -1009,6 +1079,18 @@ label {
 
   .map {
     height: 24rem;
+  }
+
+  .route-editor-footer {
+    backdrop-filter: blur(12px);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    bottom: 0.75rem;
+    box-shadow: var(--shadow-md);
+    padding: 0.85rem;
+    position: sticky;
+    z-index: 10;
   }
 
   .topbar {

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -11,20 +11,22 @@ const PlaceMapEditor = dynamic(() => import('@/components/PlaceMapEditor'), {
 });
 
 export default function PlaceEditor({
+  draftCoords,
   onDelete,
   onSave,
   place,
 }: {
+  draftCoords?: { latitude: number; longitude: number };
   onDelete?: () => void;
   onSave: (input: PlaceInput) => void;
   place: Place | null;
 }) {
   const [name, setName] = useState(place?.name ?? '');
   const [latitude, setLatitude] = useState(
-    place?.latitude.toString() ?? `${DEFAULT_MAP_CENTER.latitude}`,
+    place?.latitude.toString() ?? `${draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude}`,
   );
   const [longitude, setLongitude] = useState(
-    place?.longitude.toString() ?? `${DEFAULT_MAP_CENTER.longitude}`,
+    place?.longitude.toString() ?? `${draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude}`,
   );
   const [description, setDescription] = useState(place?.description ?? '');
   const [tags, setTags] = useState(place?.tags.join(', ') ?? '');
@@ -33,13 +35,16 @@ export default function PlaceEditor({
 
   const mapCoords = useMemo(
     () => ({
-      latitude: parseCoordinateOrFallback(latitude, place?.latitude ?? DEFAULT_MAP_CENTER.latitude),
+      latitude: parseCoordinateOrFallback(
+        latitude,
+        place?.latitude ?? draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude,
+      ),
       longitude: parseCoordinateOrFallback(
         longitude,
-        place?.longitude ?? DEFAULT_MAP_CENTER.longitude,
+        place?.longitude ?? draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
       ),
     }),
-    [latitude, longitude, place],
+    [draftCoords, latitude, longitude, place],
   );
 
   async function submit(event: FormEvent<HTMLFormElement>) {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -142,9 +142,9 @@ export default function RouteEditor({
           </button>
         )}
       </header>
-      {error == null ? null : <div className="error">{error}</div>}
+      {error == null ? null : <div className="error route-editor-error">{error}</div>}
 
-      <section className="route-editor-section">
+      <section className="route-editor-section route-editor-map-section">
         <div>
           <h3>Map builder</h3>
           <p className="muted">Build the route shape from favorites or direct map clicks.</p>
@@ -235,7 +235,7 @@ export default function RouteEditor({
         </div>
       </section>
 
-      <section className="route-editor-section">
+      <section className="route-editor-section route-editor-details-section">
         <div>
           <h3>Route details</h3>
           <p className="muted">Name the route and set how it should play back.</p>
@@ -269,7 +269,7 @@ export default function RouteEditor({
         </label>
       </section>
 
-      <section className="route-editor-section route-editor-secondary-section">
+      <section className="route-editor-section route-editor-secondary-section route-editor-share-section">
         <div>
           <h3>Publishing / share</h3>
           <p className="muted">Keep the route private, or create a public link after saving.</p>
@@ -277,7 +277,7 @@ export default function RouteEditor({
         <label className="row">
           <input
             checked={isPublic}
-            style={{ width: 'auto' }}
+            className="inline-control"
             type="checkbox"
             onChange={(event) => setIsPublic(event.target.checked)}
           />
@@ -289,7 +289,7 @@ export default function RouteEditor({
       <footer className="route-editor-footer">
         <div className="stack">
           {saveDisabledReason == null ? null : (
-            <p className="muted" style={{ margin: 0 }}>
+            <p className="muted no-margin">
               {saveDisabledReason}
             </p>
           )}
@@ -535,19 +535,17 @@ function RouteSharePanel({ route }: { route: Route | null }) {
 
   if (route == null) {
     return (
-      <p className="muted" style={{ margin: 0 }}>
-        Save this route before creating a public latest-route link.
-      </p>
+      <p className="muted no-margin">Save this route before creating a public latest-route link.</p>
     );
   }
 
   return (
     <section className="stack">
-      <div className="row" style={{ justifyContent: 'space-between' }}>
-        <h3 style={{ margin: 0 }}>Share link</h3>
+      <div className="route-share-header">
+        <h3>Share link</h3>
         {isLoading ? <span className="muted">Loading…</span> : null}
       </div>
-      <p className="muted" style={{ margin: 0 }}>
+      <p className="muted no-margin">
         Visitors can open the public page without login. Signed-in users can copy the visible route
         snapshot into their own library.
       </p>


### PR DESCRIPTION
## Summary
- add a map-first desktop layout for the route editor
- make route editor actions sticky on narrow screens
- replace route editor and dashboard inline layout styles with reusable CSS classes
- preserve the current place map position when creating a new place
- update the web dashboard UX plan Phase 5 checklist

## Checks
- npm run lint (web; passes with existing Biome schema version info)