### PR TITLE
fix(web): restore route map focus

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -826,21 +826,8 @@ label {
   grid-area: error;
 }
 
-.route-editor-map-section {
-  grid-area: map-builder;
-}
-
-.route-editor-details-section {
-  grid-area: details;
-}
-
-.route-editor-share-section {
-  grid-area: share;
-}
-
 .route-editor-footer {
   border-bottom: 0;
-  grid-area: actions;
   padding-bottom: 0;
 }
 
@@ -860,27 +847,48 @@ label {
   font-weight: 600;
 }
 
-@media (min-width: 1180px) {
-  .route-editor {
-    align-items: start;
-    grid-template-areas:
-      "header header"
-      "error error"
-      "map-builder details"
-      "map-builder share"
-      "map-builder actions";
-    grid-template-columns: minmax(0, 1.45fr) minmax(22rem, 0.75fr);
-  }
+.route-editor-collapsible {
+  background: rgb(255 255 255 / 38%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0;
+}
 
-  .route-editor-header {
-    grid-area: header;
-  }
+.route-editor-collapsible summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  list-style: none;
+  padding: 0.9rem 1rem;
+}
 
-  .route-editor-details-section,
-  .route-editor-share-section,
-  .route-editor-footer {
-    align-self: start;
-  }
+.route-editor-collapsible summary::-webkit-details-marker {
+  display: none;
+}
+
+.route-editor-collapsible summary::after {
+  color: var(--color-text-secondary);
+  content: "▾";
+  font-size: 0.85rem;
+  transition: transform var(--transition-fast);
+}
+
+.route-editor-collapsible:not([open]) summary::after {
+  transform: rotate(-90deg);
+}
+
+.route-editor-collapsible summary > span:first-child {
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.route-editor-collapsible-content {
+  border-top: 1px solid var(--color-border);
+  display: grid;
+  gap: 0.85rem;
+  padding: 0 1rem 1rem;
 }
 
 /* ==========================================================================
@@ -1020,7 +1028,8 @@ label {
 @media (prefers-color-scheme: dark) {
   .favorite-picker,
   .favorite-place-option,
-  .map-instruction {
+  .map-instruction,
+  .route-editor-collapsible {
     background: rgb(28 40 32 / 84%);
   }
 }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -235,56 +235,60 @@ export default function RouteEditor({
         </div>
       </section>
 
-      <section className="route-editor-section route-editor-details-section">
-        <div>
-          <h3>Route details</h3>
-          <p className="muted">Name the route and set how it should play back.</p>
-        </div>
-        <label className="route-title-field">
-          Name
-          <input required value={name} onChange={(event) => setName(event.target.value)} />
-        </label>
-        <div className="split">
-          <label>
-            Default speed (km/h)
-            <input
-              required
-              inputMode="decimal"
-              value={defaultSpeedKmh}
-              onChange={(event) => setDefaultSpeedKmh(event.target.value)}
-            />
+      <details className="route-editor-section route-editor-collapsible route-editor-details-section" open>
+        <summary>
+          <span>Route details</span>
+          <span className="muted">Name, speed, and playback</span>
+        </summary>
+        <div className="route-editor-collapsible-content">
+          <label className="route-title-field">
+            Name
+            <input required value={name} onChange={(event) => setName(event.target.value)} />
           </label>
+          <div className="split">
+            <label>
+              Default speed (km/h)
+              <input
+                required
+                inputMode="decimal"
+                value={defaultSpeedKmh}
+                onChange={(event) => setDefaultSpeedKmh(event.target.value)}
+              />
+            </label>
+            <label>
+              Playback mode
+              <select value={mode} onChange={(event) => setMode(event.target.value as RouteMode)}>
+                <option value="ONCE">Once</option>
+                <option value="LOOP">Loop</option>
+                <option value="PING_PONG">PingPong</option>
+              </select>
+            </label>
+          </div>
           <label>
-            Playback mode
-            <select value={mode} onChange={(event) => setMode(event.target.value as RouteMode)}>
-              <option value="ONCE">Once</option>
-              <option value="LOOP">Loop</option>
-              <option value="PING_PONG">PingPong</option>
-            </select>
+            Description
+            <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
           </label>
         </div>
-        <label>
-          Description
-          <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
-        </label>
-      </section>
+      </details>
 
-      <section className="route-editor-section route-editor-secondary-section route-editor-share-section">
-        <div>
-          <h3>Publishing / share</h3>
-          <p className="muted">Keep the route private, or create a public link after saving.</p>
+      <details className="route-editor-section route-editor-collapsible route-editor-secondary-section route-editor-share-section">
+        <summary>
+          <span>Publishing / share</span>
+          <span className="muted">Privacy and public link</span>
+        </summary>
+        <div className="route-editor-collapsible-content">
+          <label className="row">
+            <input
+              checked={isPublic}
+              className="inline-control"
+              type="checkbox"
+              onChange={(event) => setIsPublic(event.target.checked)}
+            />
+            Public route
+          </label>
+          <RouteSharePanel route={route} />
         </div>
-        <label className="row">
-          <input
-            checked={isPublic}
-            className="inline-control"
-            type="checkbox"
-            onChange={(event) => setIsPublic(event.target.checked)}
-          />
-          Public route
-        </label>
-        <RouteSharePanel route={route} />
-      </section>
+      </details>
 
       <footer className="route-editor-footer">
         <div className="stack">


### PR DESCRIPTION
## Summary
- remove the desktop two-column route editor layout that made the map feel too small
- restore the route map builder to full-width map-first layout
- move route details and publishing/share into collapsible sections below the map
- keep the sticky save footer behavior

## Checks
- npm run lint (web; passes with existing Biome schema version info)