### PR TITLE
chore: bump version to 0.0.4

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "author": "",
   "private": true,

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.disallowKotlinSourceSets=false
-appVersionCode=3
-appVersionName=0.0.3
+appVersionCode=4
+appVersionName=0.0.4

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kestrel-web",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kestrel-web",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "maplibre-gl": "^5.14.0",
         "next": "^16.0.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kestrel-web",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3301",


### PR DESCRIPTION
## Summary
- bump shared Android/backend/web version to `0.0.4` via `patch`
- bump Android `appVersionCode` to `4`

## Notes
- generated by `.github/workflows/bump-version.yml`
- requires repository secret `PAT_TOKEN` so the resulting PR can trigger downstream CI workflows