### PR TITLE
fix(android): repair cloud library item sync

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/cloud/CloudSyncRepository.kt
@@ -52,6 +52,25 @@ data class CloudPlaceConflict(
     val cloudLongitude: Double,
 )
 
+internal fun CloudSyncState.requiresBootstrapFor(
+    sessionUserId: String,
+    hasSyncedContentMissingLibraryItems: Boolean = false,
+): Boolean = cursor == null || userId != sessionUserId || hasSyncedContentMissingLibraryItems
+
+internal fun collectCloudLibraryItems(
+    places: List<CloudPlacePayload>,
+    routes: List<CloudRoutePayload>,
+    libraryItems: List<CloudLibraryItemPayload>,
+): List<CloudLibraryItemPayload> =
+    buildMap {
+        libraryItems.forEach { item -> put(item.id, item) }
+        places.mapNotNull(CloudPlacePayload::libraryItem).forEach { item -> putIfAbsent(item.id, item) }
+        routes
+            .filter { route -> route.currentRevision != null }
+            .mapNotNull(CloudRoutePayload::libraryItem)
+            .forEach { item -> putIfAbsent(item.id, item) }
+    }.values.toList()
+
 @Suppress("TooManyFunctions")
 class CloudSyncRepository internal constructor(
     private val database: KestrelDatabase,
@@ -129,11 +148,13 @@ class CloudSyncRepository internal constructor(
     }
 
     private suspend fun syncInternal() {
+        val session = requireSession()
         val state = loadSyncState()
-        if (state.cursor == null) {
+        val hasSyncedContentMissingLibraryItems = dao.countSyncedContentMissingLibraryItems() > 0
+        if (state.requiresBootstrapFor(session.userId, hasSyncedContentMissingLibraryItems)) {
             bootstrap()
         } else {
-            changes(state.cursor)
+            changes(checkNotNull(state.cursor))
         }
         uploadPendingPlaceChanges()
         loadSyncState().cursor?.let { changes(it) }
@@ -177,14 +198,13 @@ class CloudSyncRepository internal constructor(
             upsertRouteRows(routeRows)
 
             val libraryItemEntities =
-                response.libraryItems.map { item ->
-                    val localId = dao.findLibraryItemIdByRemoteId(item.id) ?: uuidFactory()
-                    item.toLibraryItemEntity(
-                        localId = localId,
-                        localPlaceId = resolveLocalPlaceId(item.placeId, resolvedPlaceIds),
-                        localRouteId = resolveLocalRouteId(item.routeId, resolvedRouteIds),
-                    )
-                }
+                buildLibraryItemEntities(
+                    places = response.places,
+                    routes = response.routes,
+                    libraryItems = response.libraryItems,
+                    resolvedPlaceIds = resolvedPlaceIds,
+                    resolvedRouteIds = resolvedRouteIds,
+                )
             if (libraryItemEntities.isNotEmpty()) {
                 dao.upsertLibraryItems(libraryItemEntities)
             }
@@ -237,14 +257,13 @@ class CloudSyncRepository internal constructor(
                 upsertRouteRows(routeRows)
 
                 val libraryItemEntities =
-                    response.libraryItems.map { item ->
-                        val localId = dao.findLibraryItemIdByRemoteId(item.id) ?: uuidFactory()
-                        item.toLibraryItemEntity(
-                            localId = localId,
-                            localPlaceId = resolveLocalPlaceId(item.placeId, resolvedPlaceIds),
-                            localRouteId = resolveLocalRouteId(item.routeId, resolvedRouteIds),
-                        )
-                    }
+                    buildLibraryItemEntities(
+                        places = response.places,
+                        routes = response.routes,
+                        libraryItems = response.libraryItems,
+                        resolvedPlaceIds = resolvedPlaceIds,
+                        resolvedRouteIds = resolvedRouteIds,
+                    )
                 if (libraryItemEntities.isNotEmpty()) {
                     dao.upsertLibraryItems(libraryItemEntities)
                 }
@@ -470,6 +489,21 @@ class CloudSyncRepository internal constructor(
     }
 
     private fun String.toCloudSyncUploadChangeTypeOrNull(): CloudSyncUploadChangeType? = runCatching { CloudSyncUploadChangeType.valueOf(this) }.getOrNull()
+
+    private suspend fun buildLibraryItemEntities(
+        places: List<CloudPlacePayload>,
+        routes: List<CloudRoutePayload>,
+        libraryItems: List<CloudLibraryItemPayload>,
+        resolvedPlaceIds: Map<String, String>,
+        resolvedRouteIds: Map<String, String>,
+    ) = collectCloudLibraryItems(places, routes, libraryItems).map { item ->
+        val localId = dao.findLibraryItemIdByRemoteId(item.id) ?: uuidFactory()
+        item.toLibraryItemEntity(
+            localId = localId,
+            localPlaceId = resolveLocalPlaceId(item.placeId, resolvedPlaceIds),
+            localRouteId = resolveLocalRouteId(item.routeId, resolvedRouteIds),
+        )
+    }
 
     private suspend fun upsertRouteRows(routeRows: List<CloudRouteSyncRows>) {
         if (routeRows.isEmpty()) {

--- a/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryDao.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/library/db/LibraryDao.kt
@@ -76,6 +76,28 @@ abstract class LibraryDao {
     @Query("SELECT * FROM sync_conflicts WHERE id = :conflictId LIMIT 1")
     abstract suspend fun getSyncConflict(conflictId: String): SyncConflictEntity?
 
+    @Query(
+        """
+        SELECT
+            (
+                SELECT COUNT(*)
+                FROM places
+                WHERE sync_status = 'Synced'
+                    AND NOT EXISTS (
+                        SELECT 1 FROM library_items WHERE library_items.place_id = places.id
+                    )
+            ) + (
+                SELECT COUNT(*)
+                FROM routes
+                WHERE sync_status = 'Synced'
+                    AND NOT EXISTS (
+                        SELECT 1 FROM library_items WHERE library_items.route_id = routes.id
+                    )
+            )
+        """,
+    )
+    abstract suspend fun countSyncedContentMissingLibraryItems(): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun upsertPlaces(places: List<PlaceEntity>)
 

--- a/app/src/test/java/dev/narumi/kestrel/core/cloud/CloudSyncRepositoryTest.kt
+++ b/app/src/test/java/dev/narumi/kestrel/core/cloud/CloudSyncRepositoryTest.kt
@@ -1,0 +1,125 @@
+package dev.narumi.kestrel.core.cloud
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CloudSyncRepositoryTest {
+    @Test
+    fun `sync requires bootstrap when cursor is missing`() {
+        val state = CloudSyncState(cursor = null, userId = "user-1")
+
+        assertTrue(state.requiresBootstrapFor("user-1"))
+    }
+
+    @Test
+    fun `sync requires bootstrap when stored user is missing`() {
+        val state = CloudSyncState(cursor = "42", userId = null)
+
+        assertTrue(state.requiresBootstrapFor("user-1"))
+    }
+
+    @Test
+    fun `sync requires bootstrap when stored user differs from session user`() {
+        val state = CloudSyncState(cursor = "42", userId = "user-1")
+
+        assertTrue(state.requiresBootstrapFor("user-2"))
+    }
+
+    @Test
+    fun `sync requires bootstrap when synced content is missing library items`() {
+        val state = CloudSyncState(cursor = "42", userId = "user-1")
+
+        assertTrue(state.requiresBootstrapFor("user-1", hasSyncedContentMissingLibraryItems = true))
+    }
+
+    @Test
+    fun `sync can use changes when cursor belongs to session user`() {
+        val state = CloudSyncState(cursor = "42", userId = "user-1")
+
+        assertFalse(state.requiresBootstrapFor("user-1"))
+    }
+
+    @Test
+    fun `collect library items includes embedded place and route items`() {
+        val explicitItem = cloudLibraryItem(id = "item-explicit", placeId = "place-explicit")
+        val embeddedPlaceItem = cloudLibraryItem(id = "item-place", placeId = "place-1")
+        val embeddedRouteItem =
+            cloudLibraryItem(
+                id = "item-route",
+                kind = CloudLibraryItemKind.ROUTE,
+                routeId = "route-1",
+            )
+
+        val items =
+            collectCloudLibraryItems(
+                places = listOf(cloudPlace(libraryItem = embeddedPlaceItem)),
+                routes = listOf(cloudRoute(libraryItem = embeddedRouteItem)),
+                libraryItems = listOf(explicitItem),
+            )
+
+        assertTrue(items.map(CloudLibraryItemPayload::id).containsAll(listOf("item-explicit", "item-place", "item-route")))
+    }
+
+    @Test
+    fun `collect library items keeps explicit item when embedded duplicate exists`() {
+        val explicitItem = cloudLibraryItem(id = "item-1", placeId = "place-explicit")
+        val embeddedItem = cloudLibraryItem(id = "item-1", placeId = "place-embedded")
+
+        val items =
+            collectCloudLibraryItems(
+                places = listOf(cloudPlace(libraryItem = embeddedItem)),
+                routes = emptyList(),
+                libraryItems = listOf(explicitItem),
+            )
+
+        assertFalse(items.single().placeId == "place-embedded")
+    }
+}
+
+private fun cloudLibraryItem(
+    id: String,
+    kind: CloudLibraryItemKind = CloudLibraryItemKind.PLACE,
+    placeId: String? = null,
+    routeId: String? = null,
+): CloudLibraryItemPayload =
+    CloudLibraryItemPayload(
+        createdAt = "2026-05-09T17:00:00Z",
+        id = id,
+        kind = kind,
+        placeId = placeId,
+        routeId = routeId,
+        sortOrder = 0,
+        updatedAt = "2026-05-09T17:00:00Z",
+    )
+
+private fun cloudPlace(libraryItem: CloudLibraryItemPayload?): CloudPlacePayload =
+    CloudPlacePayload(
+        createdAt = "2026-05-09T17:00:00Z",
+        id = "place-1",
+        libraryItem = libraryItem,
+        latitude = 25.033,
+        longitude = 121.565,
+        name = "Place",
+        updatedAt = "2026-05-09T17:00:00Z",
+    )
+
+private fun cloudRoute(libraryItem: CloudLibraryItemPayload?): CloudRoutePayload =
+    CloudRoutePayload(
+        createdAt = "2026-05-09T17:00:00Z",
+        currentRevision =
+            CloudRouteRevisionPayload(
+                createdAt = "2026-05-09T17:00:00Z",
+                createdBy = "user-1",
+                defaultSpeedKmh = 20.0,
+                id = "revision-1",
+                mode = CloudRouteMode.LOOP,
+                revisionNumber = 1,
+            ),
+        defaultSpeedKmh = 20.0,
+        id = "route-1",
+        libraryItem = libraryItem,
+        mode = CloudRouteMode.LOOP,
+        name = "Route",
+        updatedAt = "2026-05-09T17:00:00Z",
+    )

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -12,6 +12,8 @@
 - Next rewrites in `next.config.ts` bake the backend URL at `next build`; deploy images built without `KESTREL_API_BASE_URL` proxy to `localhost:3300`. Use the runtime `/api/backend/[...path]` route proxy instead.
 - Compose autofill attempts on Options cloud login were worse with 1Password: semantics `ContentType` prevented even password fill, while legacy `AutofillTree` / `AutofillNode` only filled OTP. A safer workaround is not rendering the OTP field until username/password are filled, so 1Password first sees a credential-only form.
 - `web/public/.well-known/assetlinks.json` currently contains the local Android debug signing fingerprint for `dev.narumi.kestrel` so credential-sharing can be tested before release signing exists. Replace/add the release certificate fingerprint when a release signing config is introduced.
+- Android cloud sync cursors are scoped to the signed-in backend user. If the saved cursor belongs to another user/backend and sync uses `/sync/changes` instead of bootstrap, the UI can show `Sync complete` with no Places/Routes imported.
+- Android library UI only shows rows with `library_items`; synced cloud `places`/`routes` can exist locally but stay invisible if their matching library item was not imported. Sync repair should re-bootstrap when synced content is missing library items and consume embedded `place.libraryItem` / `route.libraryItem` payloads.
 
 ## TASTE
 


### PR DESCRIPTION
## Summary
- re-bootstrap Android cloud sync when synced place/route rows are missing library items
- import embedded place/route library item payloads from sync responses
- add unit coverage for bootstrap decisions and embedded library item collection

## Verification
- just test
- ./gradlew spotlessCheck
- just lint
- just build
- manual device check: cloud Places/Routes are visible after Sync now