### PR TITLE
feat(web): restyle routes dashboard to Kestrel Cloud layout

### DIFF
--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -87,7 +87,7 @@ export default function RoutesDashboardPage() {
     >
       {error == null ? null : <div className="error dashboard-error">{error}</div>}
 
-      <section className="dashboard-grid">
+      <section className="dashboard-grid kc-workspace">
         <aside className={`dashboard-sidebar${isSidebarOpen ? '' : ' collapsed'}`}>
           <div className="card stack">
             <div className="dashboard-sidebar-header">
@@ -107,7 +107,7 @@ export default function RoutesDashboardPage() {
                   type="button"
                   onClick={() => setSelectedRouteId(null)}
                 >
-                  New route
+                  + New route
                 </button>
               </div>
             </div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1152,3 +1152,10 @@ label {
 button{border-radius:8px}
 .route-editor button[type='submit']{background:linear-gradient(180deg,#0e8c88,#087a78);color:#fff}
 .route-editor .danger{background:#fff;border:1px solid #f3b7b9;color:#e5484d}
+
+@media (max-width: 860px) {
+  .kc-workspace,
+  .kc-workspace:has(.dashboard-sidebar.collapsed) {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1131,3 +1131,24 @@ label {
     padding: 1rem;
   }
 }
+
+/* Kestrel Cloud routes redesign */
+.kc-shell{max-width:1440px;margin:0 auto;padding:16px 20px 28px;background:#f7fafc;color:#102a43}
+.kc-topbar{height:68px;background:#063846;border-radius:16px;display:flex;justify-content:space-between;align-items:center;padding:0 20px;color:#fff}
+.kc-brand{display:flex;gap:16px;align-items:center;font-weight:700}
+.kc-signed-in{font-size:14px;font-weight:500;opacity:.9}
+.kc-topbar-actions{display:flex;gap:10px}.kc-topbar-actions button.secondary{background:rgba(255,255,255,.06);color:#fff;border:1px solid rgba(255,255,255,.25);border-radius:8px;padding:9px 16px}
+.kc-tabs{display:flex;gap:12px;padding:14px 0 10px}.kc-tab{background:#fff;border:1px solid #e6edf3;border-radius:12px;padding:14px 18px;font-weight:600;color:#486581}.kc-tab.active{border:1.5px solid #0e8c88;color:#075e68;font-weight:700}
+.kc-workspace{display:grid;grid-template-columns:335px 1fr;gap:18px}
+.kc-sidebar .card{background:#fff;border:1px solid #e6edf3;border-radius:14px;padding:18px;box-shadow:0 4px 12px rgba(16,42,67,.04)}
+.dashboard-sidebar-title{font-size:20px}.dashboard-sidebar-new{width:100%}
+.list-item{border-radius:12px;border:1px solid #e6edf3}.list-item.active{background:linear-gradient(180deg,#f0fbfa,#fff);border:1.5px solid #159e9a;box-shadow:0 8px 24px rgba(8,122,120,.1)}
+.route-editor{background:#fff;border:1px solid #e6edf3;border-radius:16px;box-shadow:0 10px 30px rgba(16,42,67,.06);padding:28px}
+.route-editor-header h2{font-size:28px}.chip{border-radius:999px}
+.route-editor-section h3{font-size:18px}
+.map-builder{border-radius:14px;overflow:hidden}
+.route-editor-footer{position:sticky;bottom:0;background:#fff;padding-top:16px;border-top:1px solid #e6edf3}
+.route-editor-footer .row{justify-content:flex-end}
+button{border-radius:8px}
+.route-editor button[type='submit']{background:linear-gradient(180deg,#0e8c88,#087a78);color:#fff}
+.route-editor .danger{background:#fff;border:1px solid #f3b7b9;color:#e5484d}

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -18,37 +18,23 @@ const sections: Array<{ href: string; key: DashboardSection; label: string }> = 
   { href: '/dashboard/routes', key: 'routes', label: 'Routes' },
 ];
 
-export default function DashboardShell({
-  activeSection,
-  children,
-  onLogout,
-  onRefresh,
-  username,
-}: Props) {
+export default function DashboardShell({ activeSection, children, onLogout, onRefresh, username }: Props) {
   return (
-    <main className="shell">
-      <header className="topbar dashboard-topbar">
-        <div className="brand">
+    <main className="shell kc-shell">
+      <header className="kc-topbar">
+        <div className="kc-brand">
           <strong>Kestrel Cloud</strong>
-          <span className="muted">Signed in as {username}</span>
+          <span className="kc-signed-in">Signed in as {username}</span>
         </div>
-        <div className="row dashboard-actions">
-          <button className="secondary" type="button" onClick={onRefresh}>
-            Refresh
-          </button>
-          <button className="secondary" type="button" onClick={onLogout}>
-            Logout
-          </button>
+        <div className="kc-topbar-actions">
+          <button className="secondary" type="button" onClick={onRefresh}>Refresh</button>
+          <button className="secondary" type="button" onClick={onLogout}>Logout</button>
         </div>
       </header>
 
-      <nav aria-label="Dashboard sections" className="dashboard-tabs">
+      <nav aria-label="Dashboard sections" className="kc-tabs">
         {sections.map((section) => (
-          <Link
-            className={`dashboard-tab ${activeSection === section.key ? 'active' : ''}`}
-            href={section.href}
-            key={section.key}
-          >
+          <Link className={`kc-tab ${activeSection === section.key ? 'active' : ''}`} href={section.href} key={section.key}>
             {section.label}
           </Link>
         ))}

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -146,8 +146,8 @@ export default function RouteEditor({
 
       <section className="route-editor-section route-editor-map-section">
         <div>
-          <h3>Map builder</h3>
-          <p className="muted">Build the route shape from favorites or direct map clicks.</p>
+          <h3>Route editor</h3>
+          <p className="muted">Edit your route, manage waypoints, and configure playback settings.</p>
         </div>
         <div className="route-builder-hint">{routeBuilderHint}</div>
         <FavoriteWaypointPicker
@@ -230,7 +230,7 @@ export default function RouteEditor({
             type="button"
             onClick={duplicateLastWaypoint}
           >
-            Duplicate last waypoint
+            + Add waypoint
           </button>
         </div>
       </section>
@@ -268,7 +268,7 @@ export default function RouteEditor({
             </label>
           </div>
           <label>
-            Description
+            Description (optional)
             <textarea
               value={description}
               onChange={(event) => setDescription(event.target.value)}
@@ -280,7 +280,7 @@ export default function RouteEditor({
       <details className="route-editor-section route-editor-collapsible route-editor-secondary-section route-editor-share-section">
         <summary>
           <span>Publishing / share</span>
-          <span className="muted">Privacy and public link</span>
+          <span className="muted">Privacy and public link settings</span>
         </summary>
         <div className="route-editor-collapsible-content">
           <label className="row">
@@ -353,7 +353,7 @@ function FavoriteWaypointPicker({
   return (
     <section className="favorite-picker stack">
       <div>
-        <h3>{mode === 'start' ? 'Start from favorite place' : 'Add favorite as waypoint'}</h3>
+        <h3>{mode === 'start' ? 'Add from favorites' : 'Add from favorites'}</h3>
         <p className="muted">
           {mode === 'start'
             ? 'Pick a saved place as the first waypoint, or click the map to start manually.'
@@ -361,9 +361,9 @@ function FavoriteWaypointPicker({
         </p>
       </div>
       <label>
-        Search favorite places
+        Search favorites...
         <input
-          placeholder="Search by name, tag, or description…"
+          placeholder="Search favorites..."
           value={query}
           onChange={(event) => setQuery(event.target.value)}
         />


### PR DESCRIPTION
### Motivation
- Refresh the Routes dashboard to the Kestrel Cloud visual system (dark teal header, prominent tabs, two-column workspace) to improve hierarchy and map-first focus. 
- Align on-screen copy and controls with the route-editing UX spec so labels and affordances read more like a production SaaS route editor.

### Description
- Replace the topbar/tabs shell with Kestrel Cloud classes and markup in `web/components/dashboard/DashboardShell.tsx` to render the dark teal header, user status text, and updated tab styling. 
- Convert the routes workspace to a two-column layout and surface a more prominent `+ New route` action in `web/app/dashboard/routes/page.tsx` by adding the `kc-workspace` layout class and tweaking the sidebar button text. 
- Update the `RouteEditor` copy and small UI text to match the spec (section titles, publisher subtitle, favorites picker labels, waypoint action text) in `web/components/dashboard/RouteEditor.tsx` while preserving existing state and save/delete flows. 
- Add a dedicated Kestrel Cloud CSS override block to `web/app/globals.css` that introduces the teal palette, card/panel radii, active list styling, and primary/danger button styles used by the redesigned routes UI.

### Testing
- Ran the project linter with `cd web && npm run lint`, which completed and reported a single non-blocking CSS specificity warning from Biome. 
- No other automated tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a085e317d8c832699430c70c088f9b6)