### PR TITLE
feat(web): improve dashboard loading feedback and nav clarity

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -18,6 +18,7 @@ export default function PlacesDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [lastLoadedAt, setLastLoadedAt] = useState<Date | null>(null);
 
   const selectedPlace = useMemo(
     () => places.find((place) => place.id === selectedPlaceId) ?? null,
@@ -32,6 +33,7 @@ export default function PlacesDashboardPage() {
       const nextPlaces = await auth.apiRequest<Place[]>('/places');
       setPlaces(nextPlaces);
       setSelectedPlaceId((current) => current ?? nextPlaces[0]?.id ?? null);
+      setLastLoadedAt(new Date());
     } catch (nextError) {
       setError(formatError(nextError));
     } finally {
@@ -93,6 +95,8 @@ export default function PlacesDashboardPage() {
       activeSection="places"
       onLogout={auth.logout}
       onRefresh={() => void loadPlaces()}
+      isRefreshing={isLoading}
+      lastUpdatedLabel={lastLoadedAt?.toLocaleTimeString() ?? null}
       username={auth.session.user.username}
     >
       {error == null ? null : <div className="error dashboard-error">{error}</div>}
@@ -122,7 +126,7 @@ export default function PlacesDashboardPage() {
               </div>
             </div>
             <div className="dashboard-sidebar-content">
-              {isLoading ? <p className="muted">Loading…</p> : null}
+              {isLoading ? <p className="muted">Loading places…</p> : null}
               <div className="list">
                 {places.map((place) => (
                   <button
@@ -151,7 +155,8 @@ export default function PlacesDashboardPage() {
           </div>
         </aside>
 
-        <section className="grid">
+        <section aria-busy={isLoading} className="grid">
+          {isLoading ? <div className="loading-shimmer" /> : null}
           <PlaceEditor
             draftCoords={draftPlaceCoords ?? undefined}
             key={selectedPlace?.id ?? 'new-place'}

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -15,6 +15,7 @@ export default function RoutesDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [lastLoadedAt, setLastLoadedAt] = useState<Date | null>(null);
 
   const selectedRoute = useMemo(
     () => routes.find((route) => route.id === selectedRouteId) ?? null,
@@ -33,6 +34,7 @@ export default function RoutesDashboardPage() {
       setRoutes(nextRoutes);
       setPlaces(nextPlaces);
       setSelectedRouteId((current) => current ?? nextRoutes[0]?.id ?? null);
+      setLastLoadedAt(new Date());
     } catch (nextError) {
       setError(formatError(nextError));
     } finally {
@@ -83,6 +85,8 @@ export default function RoutesDashboardPage() {
       activeSection="routes"
       onLogout={auth.logout}
       onRefresh={() => void loadRoutes()}
+      isRefreshing={isLoading}
+      lastUpdatedLabel={lastLoadedAt?.toLocaleTimeString() ?? null}
       username={auth.session.user.username}
     >
       {error == null ? null : <div className="error dashboard-error">{error}</div>}
@@ -112,7 +116,7 @@ export default function RoutesDashboardPage() {
               </div>
             </div>
             <div className="dashboard-sidebar-content">
-              {isLoading ? <p className="muted">Loading…</p> : null}
+              {isLoading ? <p className="muted">Loading routes…</p> : null}
               <div className="list">
                 {routes.map((route) => (
                   <button
@@ -151,7 +155,8 @@ export default function RoutesDashboardPage() {
           </div>
         </aside>
 
-        <section className="grid">
+        <section aria-busy={isLoading} className="grid">
+          {isLoading ? <div className="loading-shimmer" /> : null}
           <RouteEditor
             key={selectedRoute?.id ?? 'new-route'}
             onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -388,6 +388,10 @@ label {
   margin-bottom: 1rem;
 }
 
+.dashboard-last-updated {
+  margin: 0 0 0.75rem;
+}
+
 .dashboard-tabs {
   backdrop-filter: blur(12px);
   background: var(--color-surface);
@@ -467,6 +471,32 @@ label {
 
 .dashboard-grid > section {
   min-width: 0;
+  position: relative;
+}
+
+.loading-shimmer {
+  animation: dashboard-shimmer 1.1s linear infinite;
+  background: linear-gradient(
+    90deg,
+    rgb(255 255 255 / 5%) 0%,
+    rgb(255 255 255 / 30%) 45%,
+    rgb(255 255 255 / 5%) 100%
+  );
+  border-radius: var(--radius-lg);
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 2;
+}
+
+@keyframes dashboard-shimmer {
+  0% {
+    transform: translateX(-35%);
+  }
+
+  100% {
+    transform: translateX(35%);
+  }
 }
 
 /* ==========================================================================

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -482,6 +482,8 @@ label {
     rgb(255 255 255 / 30%) 45%,
     rgb(255 255 255 / 5%) 100%
   );
+  background-position: 100% 0;
+  background-size: 200% 100%;
   border-radius: var(--radius-lg);
   inset: 0;
   pointer-events: none;
@@ -491,11 +493,11 @@ label {
 
 @keyframes dashboard-shimmer {
   0% {
-    transform: translateX(-35%);
+    background-position: 100% 0;
   }
 
   100% {
-    transform: translateX(35%);
+    background-position: -100% 0;
   }
 }
 

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -8,6 +8,8 @@ type DashboardSection = 'places' | 'routes';
 type Props = {
   activeSection: DashboardSection;
   children: ReactNode;
+  isRefreshing?: boolean;
+  lastUpdatedLabel?: string | null;
   onLogout: () => void;
   onRefresh: () => void;
   username: string;
@@ -21,6 +23,8 @@ const sections: Array<{ href: string; key: DashboardSection; label: string }> = 
 export default function DashboardShell({
   activeSection,
   children,
+  isRefreshing = false,
+  lastUpdatedLabel = null,
   onLogout,
   onRefresh,
   username,
@@ -33,18 +37,28 @@ export default function DashboardShell({
           <span className="kc-signed-in">Signed in as {username}</span>
         </div>
         <div className="kc-topbar-actions">
-          <button className="secondary" type="button" onClick={onRefresh}>
-            Refresh
+          <button
+            aria-busy={isRefreshing}
+            className="secondary"
+            disabled={isRefreshing}
+            type="button"
+            onClick={onRefresh}
+          >
+            {isRefreshing ? 'Refreshing…' : 'Refresh'}
           </button>
           <button className="secondary" type="button" onClick={onLogout}>
             Logout
           </button>
         </div>
       </header>
+      {lastUpdatedLabel == null ? null : (
+        <p className="muted dashboard-last-updated">Updated {lastUpdatedLabel}</p>
+      )}
 
       <nav aria-label="Dashboard sections" className="kc-tabs">
         {sections.map((section) => (
           <Link
+            aria-current={activeSection === section.key ? 'page' : undefined}
             className={`kc-tab ${activeSection === section.key ? 'active' : ''}`}
             href={section.href}
             key={section.key}


### PR DESCRIPTION
### Motivation
- Users reported the web dashboard felt unclear during background loads and navigation, so loading feedback and section orientation needed improvement.
- The change aims to reduce duplicate actions and make fetch status and timing visible during common flows (Routes / Places). 

### Description
- Add `isRefreshing` / `lastUpdatedLabel` props to `DashboardShell` and disable the `Refresh` button while loading, including `aria-busy` and user-facing `Refreshing…` text. 
- Surface a lightweight `Updated <time>` line in the dashboard header and set `aria-current="page"` on the active section tab for clearer orientation. 
- In `web/app/dashboard/routes/page.tsx` and `web/app/dashboard/places/page.tsx` add `lastLoadedAt` state, pass `isRefreshing` and `lastUpdatedLabel` to the shell, make loading copy specific (`Loading routes…` / `Loading places…`), add `aria-busy` on the editor area, and render an in-context shimmer overlay while data is loading. 
- Add CSS for `.dashboard-last-updated`, `.loading-shimmer`, and `@keyframes dashboard-shimmer`, and make the editor section `position: relative` to host the shimmer overlay. 

### Testing
- Ran `cd web && npm exec -- biome ci .` which completed successfully and reported a single existing CSS specificity warning. 
- `just web-check` could not be executed in this environment because `just` is not available (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b15aa9bbc83269386e00adb8a9b5d)