### PR TITLE
style(web): refine dashboard typography hierarchy

### DIFF
--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -120,18 +120,17 @@ export default function RoutesDashboardPage() {
               <div className="list">
                 {routes.map((route) => (
                   <button
-                    className={`list-item route-list-item route-mode-${route.mode.toLowerCase().replace('_', '-')} ${selectedRouteId === route.id ? 'active' : ''}`}
+                    className={`list-item route-list-item ${selectedRouteId === route.id ? 'active' : ''}`}
                     key={route.id}
                     type="button"
                     onClick={() => setSelectedRouteId(route.id)}
                   >
-                    <strong>{route.name}</strong>
+                    <strong className="route-card-title">{route.name}</strong>
                     <span className="route-card-metrics">
-                      <span>⌁ {route.currentRevision?.waypoints.length ?? 0}</span>
-                      <span>↗ {route.defaultSpeedKmh} km/h</span>
-                      <span>⇄ {formatMode(route.mode)}</span>
+                      {formatRouteDistance(route)} · {route.defaultSpeedKmh}km/h ·{' '}
+                      {formatMode(route.mode)}
                     </span>
-                    <span className="chip-row">
+                    <span className="chip-row route-card-badges">
                       <span className="chip rev-chip">
                         rev {route.currentRevision?.revisionNumber ?? '—'}
                       </span>
@@ -180,4 +179,39 @@ function SidebarSkeleton() {
       <span className="skeleton-line short" />
     </div>
   );
+}
+
+function formatRouteDistance(route: Route): string {
+  const waypoints = route.currentRevision?.waypoints ?? [];
+  const distanceKm = waypoints.slice(1).reduce((totalDistance, waypoint, index) => {
+    const previousWaypoint = waypoints[index];
+
+    return totalDistance + getDistanceKm(previousWaypoint, waypoint);
+  }, 0);
+
+  if (distanceKm < 10) {
+    return `${distanceKm.toFixed(1)}km`;
+  }
+
+  return `${Math.round(distanceKm)}km`;
+}
+
+function getDistanceKm(
+  from: { latitude: number; longitude: number },
+  to: { latitude: number; longitude: number },
+): number {
+  const earthRadiusKm = 6371;
+  const deltaLatitude = toRadians(to.latitude - from.latitude);
+  const deltaLongitude = toRadians(to.longitude - from.longitude);
+  const fromLatitude = toRadians(from.latitude);
+  const toLatitude = toRadians(to.latitude);
+  const haversine =
+    Math.sin(deltaLatitude / 2) ** 2 +
+    Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.sin(deltaLongitude / 2) ** 2;
+
+  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -159,8 +159,7 @@ body {
 body {
   background: var(--color-bg);
   color: var(--color-text);
-  font-family:
-    -apple-system, BlinkMacSystemFont, "SF Pro", "Segoe UI", ui-sans-serif, system-ui, sans-serif;
+  font-family: Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   line-height: 1.5;
 }
@@ -209,12 +208,13 @@ textarea {
 button {
   background: var(--color-primary);
   border: 1.5px solid transparent;
-  border-radius: var(--radius-md);
+  border-radius: 8px;
   color: var(--color-primary-text);
   cursor: pointer;
   font-weight: 600;
   letter-spacing: 0.01em;
-  padding: 0.65rem 1.1rem;
+  min-height: 36px;
+  padding: 0 12px;
   transition:
     background var(--transition),
     box-shadow var(--transition),
@@ -423,7 +423,12 @@ label {
 }
 
 .dashboard-last-updated {
-  margin: 0 0 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1;
+  margin: 0;
+  white-space: nowrap;
 }
 
 .dashboard-tabs {
@@ -546,7 +551,7 @@ label {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-  padding: 1.1rem;
+  padding: 20px;
   transition: box-shadow var(--transition);
 }
 
@@ -1563,9 +1568,15 @@ label {
   width: 4px;
 }
 
-.route-mode-loop::before { background: var(--success); }
-.route-mode-ping-pong::before { background: var(--warning); }
-.list-item.route-list-item.active::before { background: var(--accent); }
+.route-mode-loop::before {
+  background: var(--success);
+}
+.route-mode-ping-pong::before {
+  background: var(--warning);
+}
+.list-item.route-list-item.active::before {
+  background: var(--accent);
+}
 
 .list-item.route-list-item:hover {
   box-shadow: 0 12px 28px rgb(42 37 32 / 10%);
@@ -1650,7 +1661,13 @@ label {
 
 .favorite-place-list {
   gap: 0;
-  mask-image: linear-gradient(to bottom, transparent, black 12px, black calc(100% - 20px), transparent);
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    black 12px,
+    black calc(100% - 20px),
+    transparent
+  );
 }
 
 .favorite-place-option {
@@ -1731,12 +1748,187 @@ button.is-loading {
   width: 76%;
 }
 
+/* Typography, spacing, and hierarchy refinement */
+.lucide-icon {
+  flex-shrink: 0;
+  height: 16px;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  width: 16px;
+}
+
+.favorite-place-icon {
+  color: var(--accent);
+  height: 14px;
+  width: 14px;
+}
+
+.muted,
+.route-editor .muted,
+.favorite-picker p {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.dashboard-sidebar .card {
+  padding: 20px;
+}
+
+.dashboard-sidebar .list {
+  gap: 8px;
+}
+
+.kc-topbar-actions {
+  margin-left: auto;
+}
+
+.kc-icon-button {
+  height: 36px;
+  width: 36px;
+}
+
+.kc-shell .dashboard-sidebar .dashboard-sidebar-new-card:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.route-editor {
+  gap: 32px;
+  padding: 20px;
+}
+
+.route-editor-header,
+.route-editor-section {
+  padding-bottom: 32px;
+}
+
+.route-editor-section {
+  gap: 12px;
+}
+
+.route-editor-header h2 {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.route-editor-section h3,
+.favorite-picker h3,
+.route-share-header h3 {
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.breadcrumb {
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.breadcrumb span {
+  color: var(--text-primary);
+}
+
+.list-item.route-list-item {
+  border-color: var(--border);
+  box-shadow: none;
+  gap: 4px;
+  padding: 12px 78px 12px 12px;
+  transition:
+    background 100ms ease,
+    border-color 100ms ease,
+    color 100ms ease;
+}
+
+.route-list-item::before {
+  display: none;
+}
+
+.route-card-title {
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.route-card-metrics {
+  color: var(--text-muted);
+  display: block;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.route-card-badges {
+  gap: 4px;
+  position: absolute;
+  right: 10px;
+  top: 10px;
+}
+
+.route-card-badges .rev-chip {
+  font-size: 10px;
+  letter-spacing: -0.01em;
+  padding: 1px 5px;
+}
+
+.list-item.route-list-item:hover:not(:disabled) {
+  background: var(--bg-subtle);
+  border-color: var(--border);
+  box-shadow: none;
+  transform: none;
+}
+
+.list-item.route-list-item.active,
+.list-item.route-list-item.active:hover:not(:disabled) {
+  background: var(--accent-soft);
+  border: 1px solid var(--accent);
+  box-shadow: none;
+}
+
+.rev-chip,
+.mono {
+  letter-spacing: -0.01em;
+}
+
+.route-editor button[type="submit"] {
+  background: var(--accent);
+  box-shadow: none;
+  color: #ffffff;
+}
+
+.route-editor button[type="submit"]:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: none;
+}
+
+.route-editor .danger {
+  background: transparent;
+  border: 1px solid var(--danger);
+  color: var(--danger);
+}
+
+.route-editor .danger:hover:not(:disabled) {
+  background: var(--danger-soft);
+  box-shadow: none;
+}
+
 @keyframes kc-loading {
-  to { background-position: -200% 0; }
+  to {
+    background-position: -200% 0;
+  }
 }
 
 @keyframes kc-skeleton {
-  to { background-position: -220% 0; }
+  to {
+    background-position: -220% 0;
+  }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -17,9 +17,9 @@ type Props = {
   username: string;
 };
 
-const sections: Array<{ href: string; icon: string; key: DashboardSection; label: string }> = [
-  { href: '/dashboard/places', icon: '⌖', key: 'places', label: 'Places' },
-  { href: '/dashboard/routes', icon: '⇄', key: 'routes', label: 'Routes' },
+const sections: Array<{ href: string; icon: ReactNode; key: DashboardSection; label: string }> = [
+  { href: '/dashboard/places', icon: <MapPinIcon />, key: 'places', label: 'Places' },
+  { href: '/dashboard/routes', icon: <RouteIcon />, key: 'routes', label: 'Routes' },
 ];
 
 export default function DashboardShell({
@@ -47,6 +47,9 @@ export default function DashboardShell({
           </div>
         </div>
         <div className="kc-topbar-actions">
+          {lastUpdatedLabel == null ? null : (
+            <span className="dashboard-last-updated">Updated {lastUpdatedLabel}</span>
+          )}
           <button
             aria-busy={isRefreshing}
             aria-label={refreshLabel}
@@ -56,7 +59,7 @@ export default function DashboardShell({
             type="button"
             onClick={onRefresh}
           >
-            {isRefreshing ? '…' : '↻'}
+            <RefreshCwIcon />
           </button>
           <div className="kc-user-menu">
             <button
@@ -69,15 +72,12 @@ export default function DashboardShell({
                 {username.slice(0, 1).toUpperCase()}
               </span>
               <span>{username}</span>
-              <span aria-hidden>⌄</span>
+              <ChevronDownIcon />
             </button>
             {isAccountOpen ? <AccountMenu onLogout={onLogout} /> : null}
           </div>
         </div>
       </header>
-      {lastUpdatedLabel == null ? null : (
-        <p className="muted dashboard-last-updated">Updated {lastUpdatedLabel}</p>
-      )}
 
       <nav aria-label="Dashboard sections" className="kc-tabs">
         {sections.map((section) => (
@@ -87,7 +87,7 @@ export default function DashboardShell({
             href={section.href}
             key={section.key}
           >
-            <span aria-hidden>{section.icon}</span>
+            {section.icon}
             {section.label}
           </Link>
         ))}
@@ -186,12 +186,45 @@ function KestrelIcon() {
         fill="currentColor"
         opacity="0.25"
       />
-      <path
-        d="M13.9 12.1 21 20"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="1.8"
-      />
+      <path d="M13.9 12.1 21 20" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+    </svg>
+  );
+}
+
+function MapPinIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M20 10c0 6-8 12-8 12S4 16 4 10a8 8 0 0 1 16 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
+  );
+}
+
+function RouteIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <circle cx="6" cy="19" r="3" />
+      <path d="M9 19h8.5a3.5 3.5 0 0 0 0-7h-11a3.5 3.5 0 0 1 0-7H15" />
+      <circle cx="18" cy="5" r="3" />
+    </svg>
+  );
+}
+
+function RefreshCwIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M3 12a9 9 0 0 1 15.5-6.2L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-15.5 6.2L3 16" />
+      <path d="M3 21v-5h5" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="m6 9 6 6 6-6" />
     </svg>
   );
 }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -134,10 +134,14 @@ export default function RouteEditor({
     <form className="panel route-editor" onSubmit={submit}>
       <header className="route-editor-header">
         <div className="stack">
-          <div className="breadcrumb">Routes / {route?.name ?? 'New route'}</div>
+          <div className="breadcrumb">
+            Routes / <span>{route?.name ?? 'New route'}</span>
+          </div>
           <h2>{route == null ? 'New route' : route.name}</h2>
           {route?.currentRevision == null ? null : (
-            <span className="chip rev-chip">latest revision {route.currentRevision.revisionNumber}</span>
+            <span className="chip rev-chip">
+              latest revision {route.currentRevision.revisionNumber}
+            </span>
           )}
         </div>
         {onNew == null ? null : (
@@ -156,7 +160,10 @@ export default function RouteEditor({
             Edit your route, manage waypoints, and configure playback settings.
           </p>
         </div>
-        <div className="route-builder-hint"><span aria-hidden>ⓘ</span>{routeBuilderHint}</div>
+        <div className="route-builder-hint">
+          <InfoIcon />
+          {routeBuilderHint}
+        </div>
         <FavoriteWaypointPicker
           mode={favoritePickerMode}
           places={places}
@@ -315,7 +322,11 @@ export default function RouteEditor({
             <p className="muted no-margin">{saveDisabledReason}</p>
           )}
           <div className="row">
-            <button className={isSaving ? 'is-loading' : ''} disabled={isSaving || saveDisabledReason != null} type="submit">
+            <button
+              className={isSaving ? 'is-loading' : ''}
+              disabled={isSaving || saveDisabledReason != null}
+              type="submit"
+            >
               {isSaving ? 'Saving…' : saveNotice == null ? 'Save route' : 'Saved ✓'}
             </button>
             {onDelete == null ? null : (
@@ -376,7 +387,7 @@ function FavoriteWaypointPicker({
       <label className="favorite-search">
         Search favorites
         <span className="favorite-search-box">
-          <span aria-hidden>⌕</span>
+          <SearchIcon />
           <input
             placeholder="Search favorites..."
             value={query}
@@ -394,7 +405,7 @@ function FavoriteWaypointPicker({
             onClick={() => onSelect(place)}
           >
             <span className="favorite-place-main">
-              <span aria-hidden>⌖</span>
+              <MapPinIcon />
               <strong>{place.name}</strong>
               <span className="favorite-add">+ Add</span>
             </span>
@@ -623,6 +634,39 @@ function RouteSharePanel({ route }: { route: Route | null }) {
         </div>
       )}
     </section>
+  );
+}
+
+function InfoIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="m21 21-4.3-4.3" />
+      <circle cx="11" cy="11" r="8" />
+    </svg>
+  );
+}
+
+function MapPinIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="lucide-icon favorite-place-icon"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <path d="M20 10c0 6-8 12-8 12S4 16 4 10a8 8 0 0 1 16 0Z" />
+      <circle cx="12" cy="10" r="3" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## Summary
- refine dashboard typography, helper text scale, and route editor spacing
- move the updated timestamp into the header and simplify route list hierarchy
- replace symbolic glyphs with Lucide-style inline SVG icons
- restyle route cards, badges, and primary/danger/new-route actions for a calmer crafted-tool feel

## Verification
- cd web && npm exec -- biome ci .
- cd web && npm run typecheck
- cd web && npm run build
- git diff --check