### PR TITLE
feat(web): add warm dashboard dark mode and personality details

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -72,11 +72,11 @@
   --radius-lg: 1rem;
   --radius-pill: 999px;
 
-  /* Shadows — soft, Apple-like */
-  --shadow-xs: 0 1px 3px rgb(0 0 0 / 6%), 0 1px 2px rgb(0 0 0 / 4%);
-  --shadow-sm: 0 2px 8px rgb(0 0 0 / 8%), 0 1px 3px rgb(0 0 0 / 4%);
-  --shadow-md: 0 4px 16px rgb(0 0 0 / 10%), 0 2px 6px rgb(0 0 0 / 6%);
-  --shadow-lg: 0 8px 32px rgb(0 0 0 / 12%), 0 4px 12px rgb(0 0 0 / 8%);
+  /* Shadows — restrained, notebook-like */
+  --shadow-xs: 0 1px 2px rgb(42 37 32 / 4%);
+  --shadow-sm: 0 1px 2px rgb(42 37 32 / 4%);
+  --shadow-md: 0 1px 2px rgb(42 37 32 / 4%);
+  --shadow-lg: 0 1px 2px rgb(42 37 32 / 4%);
 
   /* Focus ring */
   --focus-ring: 0 0 0 3px rgb(217 118 68 / 30%);
@@ -319,7 +319,8 @@ button:hover:not(:disabled) {
 
 button:active:not(:disabled) {
   box-shadow: none;
-  transform: translateY(0);
+  transform: scale(0.98);
+  transition-duration: 80ms;
 }
 
 button:focus-visible {
@@ -604,30 +605,7 @@ label {
 }
 
 .loading-shimmer {
-  animation: dashboard-shimmer 1.1s linear infinite;
-  background: linear-gradient(
-    90deg,
-    rgb(255 255 255 / 5%) 0%,
-    rgb(255 255 255 / 30%) 45%,
-    rgb(255 255 255 / 5%) 100%
-  );
-  background-position: 100% 0;
-  background-size: 200% 100%;
-  border-radius: var(--radius-lg);
-  inset: 0;
-  pointer-events: none;
-  position: absolute;
-  z-index: 2;
-}
-
-@keyframes dashboard-shimmer {
-  0% {
-    background-position: 100% 0;
-  }
-
-  100% {
-    background-position: -100% 0;
-  }
+  display: none;
 }
 
 /* ==========================================================================
@@ -1504,27 +1482,29 @@ label {
 .kc-brand strong {
   color: var(--text-primary);
   display: block;
-  font-size: 1rem;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
   line-height: 1.2;
 }
 
 .kc-logo,
 .kc-avatar {
   align-items: center;
-  background: var(--accent);
-  border: 1px solid var(--accent-hover);
-  border-radius: 12px;
-  color: #ffffff;
+  background: var(--bg-canvas);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--accent);
   display: inline-flex;
-  height: 38px;
+  height: 36px;
   justify-content: center;
-  width: 38px;
+  width: 36px;
 }
 
 .kc-signed-in {
   color: var(--text-muted);
   display: block;
-  font-size: 0.78rem;
+  font-size: 12px;
   font-weight: 500;
 }
 
@@ -1562,7 +1542,7 @@ label {
 }
 
 .kc-user-button {
-  border-radius: 999px;
+  border-radius: 10px;
   padding: 5px 10px 5px 5px;
 }
 
@@ -1576,6 +1556,7 @@ label {
 
 .kc-avatar {
   background: var(--accent);
+  border-color: var(--accent);
   color: white;
   font-size: 0.86rem;
   font-weight: 800;
@@ -1587,7 +1568,7 @@ label {
   background: var(--overlay-surface);
   border: 1px solid var(--kc-slate-200);
   border-radius: 16px;
-  box-shadow: 0 22px 60px rgb(42 37 32 / 18%);
+  box-shadow: var(--shadow-sm);
   color: var(--kc-slate-900);
   padding: 16px;
   position: absolute;
@@ -1677,8 +1658,8 @@ label {
 }
 
 .list-item.route-list-item:hover {
-  box-shadow: 0 12px 28px rgb(42 37 32 / 10%);
-  transform: translateY(-1px);
+  box-shadow: none;
+  transform: none;
 }
 
 .list-item.route-list-item.active {
@@ -1804,7 +1785,7 @@ label {
   border: 1px solid var(--kc-slate-200);
   border-radius: 16px;
   bottom: 12px;
-  box-shadow: 0 -8px 28px rgb(42 37 32 / 8%);
+  box-shadow: var(--shadow-sm);
   padding: 12px;
   position: sticky;
   z-index: 20;
@@ -1814,13 +1795,11 @@ button,
 .kc-tab,
 .list-item,
 .favorite-place-option {
-  transition: all 150ms ease;
+  transition: all 120ms ease-out;
 }
 
 button.is-loading {
-  background-image: linear-gradient(90deg, var(--accent-hover), var(--accent), var(--accent-hover));
-  background-size: 200% 100%;
-  animation: kc-loading 1s linear infinite;
+  background: var(--accent);
 }
 
 .skeleton-list {
@@ -1830,9 +1809,7 @@ button.is-loading {
 }
 
 .skeleton-line {
-  animation: kc-skeleton 1.2s ease-in-out infinite;
-  background: linear-gradient(90deg, var(--kc-slate-100), var(--bg-surface), var(--kc-slate-100));
-  background-size: 220% 100%;
+  background: var(--bg-subtle);
   border-radius: 12px;
   height: 52px;
 }
@@ -1988,6 +1965,9 @@ button.is-loading {
   background: var(--accent-soft);
   border: 1px solid var(--accent);
   box-shadow: none;
+  transition:
+    background-color 180ms ease-out,
+    border-color 180ms ease-out;
 }
 
 .rev-chip,
@@ -2017,15 +1997,96 @@ button.is-loading {
   box-shadow: none;
 }
 
-@keyframes kc-loading {
-  to {
-    background-position: -200% 0;
-  }
+.kc-icon-button.is-rotating .lucide-icon {
+  animation: refresh-rotate 240ms ease-out;
 }
 
-@keyframes kc-skeleton {
+.route-list-item.active .route-card-title::before {
+  background: var(--accent);
+  border-radius: 999px;
+  content: "";
+  height: 4px;
+  width: 4px;
+}
+
+.favorite-place-option {
+  cursor: default;
+}
+
+.favorite-place-option:hover {
+  background: var(--bg-subtle);
+}
+
+.favorite-add {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--accent);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  margin-left: auto;
+  min-height: 28px;
+  opacity: 0;
+  padding: 0 8px;
+}
+
+.favorite-place-option:hover .favorite-add,
+.favorite-add:focus-visible {
+  opacity: 1;
+}
+
+.favorite-add:hover:not(:disabled) {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  box-shadow: none;
+  color: var(--accent);
+  transform: none;
+}
+
+.coordinate-copy {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: flex-start;
+  min-height: 24px;
+  padding: 0;
+  position: relative;
+  text-align: left;
+  width: fit-content;
+}
+
+.coordinate-copy:hover:not(:disabled),
+.coordinate-copy:focus-visible {
+  background: transparent;
+  box-shadow: none;
+  color: var(--accent);
+  transform: none;
+}
+
+.coordinate-copy-tooltip {
+  background: var(--accent-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--accent);
+  font-family: Inter, Geist, ui-sans-serif, system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  left: calc(100% + 8px);
+  letter-spacing: 0;
+  padding: 2px 6px;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  white-space: nowrap;
+}
+
+@keyframes refresh-rotate {
   to {
-    background-position: -220% 0;
+    transform: rotate(360deg);
   }
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -23,6 +23,12 @@
   --danger: #b8483a;
   --danger-soft: #f7e4df;
 
+  --bg-canvas-end: #f5efe5;
+  --bg-header-end: #f5efe5;
+  --overlay-surface: rgb(255 255 255 / 96%);
+  --sticky-surface: rgb(255 255 255 / 82%);
+  --toolbar-bg: rgb(255 255 255 / 74%);
+
   /* Brand */
   --color-topbar: var(--bg-surface);
 
@@ -85,25 +91,31 @@
    ========================================================================== */
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    --bg-canvas: #1f1a15;
-    --bg-surface: #2a241e;
-    --bg-subtle: #342d26;
-    --border: #4a4036;
-    --border-strong: #5f5144;
+  :root:not([data-theme="light"]) {
+    --bg-canvas: #1a1714;
+    --bg-surface: #221e1a;
+    --bg-subtle: #2d2823;
+    --border: #3a332c;
+    --border-strong: #4a4138;
 
-    --text-primary: #f5efe7;
-    --text-secondary: #cdbfaf;
-    --text-muted: #a99a89;
+    --text-primary: #f2ede5;
+    --text-secondary: #a8998a;
+    --text-muted: #6b6157;
 
-    --accent: #e08a55;
-    --accent-hover: #f09a65;
-    --accent-soft: rgb(217 118 68 / 16%);
+    --accent: #e88a5c;
+    --accent-hover: #f0a07a;
+    --accent-soft: #3a2820;
 
-    --success: #a0ad5c;
-    --warning: #d5aa45;
-    --danger: #dc6a5c;
-    --danger-soft: rgb(184 72 58 / 18%);
+    --success: #a3b560;
+    --warning: #e0b358;
+    --danger: #d6685a;
+    --danger-soft: #3a2622;
+
+    --bg-canvas-end: #211c18;
+    --bg-header-end: var(--bg-subtle);
+    --overlay-surface: rgb(34 30 26 / 96%);
+    --sticky-surface: rgb(34 30 26 / 82%);
+    --toolbar-bg: rgb(34 30 26 / 74%);
 
     --color-primary: var(--accent);
     --color-primary-dark: var(--accent-hover);
@@ -127,17 +139,77 @@
     --color-danger-text: var(--danger);
 
     --color-success: var(--success);
-    --color-success-bg: rgb(122 140 63 / 16%);
-    --color-success-border: rgb(160 173 92 / 35%);
-    --color-success-text: #dbe6a0;
+    --color-success-bg: rgb(163 181 96 / 16%);
+    --color-success-border: rgb(163 181 96 / 35%);
+    --color-success-text: #d9e7a2;
 
-    --shadow-xs: 0 1px 3px rgb(0 0 0 / 25%);
-    --shadow-sm: 0 2px 8px rgb(0 0 0 / 35%);
-    --shadow-md: 0 4px 16px rgb(0 0 0 / 45%);
-    --shadow-lg: 0 8px 32px rgb(0 0 0 / 55%);
+    --shadow-xs: none;
+    --shadow-sm: none;
+    --shadow-md: none;
+    --shadow-lg: none;
 
-    --focus-ring: 0 0 0 3px rgb(224 138 85 / 35%);
+    --focus-ring: 0 0 0 3px rgb(232 138 92 / 35%);
   }
+}
+
+:root[data-theme="dark"] {
+  --bg-canvas: #1a1714;
+  --bg-surface: #221e1a;
+  --bg-subtle: #2d2823;
+  --border: #3a332c;
+  --border-strong: #4a4138;
+
+  --text-primary: #f2ede5;
+  --text-secondary: #a8998a;
+  --text-muted: #6b6157;
+
+  --accent: #e88a5c;
+  --accent-hover: #f0a07a;
+  --accent-soft: #3a2820;
+
+  --success: #a3b560;
+  --warning: #e0b358;
+  --danger: #d6685a;
+  --danger-soft: #3a2622;
+
+  --bg-canvas-end: #211c18;
+  --bg-header-end: var(--bg-subtle);
+  --overlay-surface: rgb(34 30 26 / 96%);
+  --sticky-surface: rgb(34 30 26 / 82%);
+  --toolbar-bg: rgb(34 30 26 / 74%);
+
+  --color-primary: var(--accent);
+  --color-primary-dark: var(--accent-hover);
+  --color-primary-text: #ffffff;
+
+  --color-secondary: var(--accent-soft);
+
+  --color-bg: var(--bg-canvas);
+  --color-surface-bg: var(--bg-canvas);
+  --color-surface: var(--bg-surface);
+
+  --color-text: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+
+  --color-border: var(--border);
+  --color-border-focus: var(--accent);
+
+  --color-danger: var(--danger);
+  --color-danger-bg: transparent;
+  --color-danger-border: var(--danger);
+  --color-danger-text: var(--danger);
+
+  --color-success: var(--success);
+  --color-success-bg: rgb(163 181 96 / 16%);
+  --color-success-border: rgb(163 181 96 / 35%);
+  --color-success-text: #d9e7a2;
+
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+
+  --focus-ring: 0 0 0 3px rgb(232 138 92 / 35%);
 }
 
 /* ==========================================================================
@@ -162,6 +234,24 @@ body {
   font-family: Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   line-height: 1.5;
+}
+
+body::before {
+  background: var(--accent);
+  content: "";
+  height: 3px;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 100;
+}
+
+.theme-transition-enabled,
+.theme-transition-enabled * {
+  transition-duration: 200ms;
+  transition-property: background-color, border-color, color;
+  transition-timing-function: ease;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -332,7 +422,7 @@ input[type="radio"] {
   input,
   select,
   textarea {
-    background: rgb(44 44 46 / 80%);
+    background: var(--bg-surface);
   }
 }
 
@@ -698,11 +788,11 @@ label {
 
 @media (prefers-color-scheme: dark) {
   .list-item {
-    background: rgb(44 44 46 / 60%);
+    background: var(--bg-surface);
   }
 
   .list-item:hover:not(:disabled) {
-    background: rgb(58 58 60 / 80%);
+    background: var(--bg-subtle);
   }
 
   .list-item.active {
@@ -1105,7 +1195,7 @@ label {
   .favorite-place-option,
   .map-instruction,
   .route-editor-collapsible {
-    background: rgb(44 44 46 / 84%);
+    background: var(--bg-surface);
   }
 }
 
@@ -1384,7 +1474,7 @@ label {
 }
 
 .kc-shell {
-  background: linear-gradient(180deg, var(--bg-canvas), #f5efe5);
+  background: linear-gradient(180deg, var(--bg-canvas), var(--bg-canvas-end));
   color: var(--kc-slate-900);
   font-family: Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
   max-width: 1440px;
@@ -1394,7 +1484,7 @@ label {
 
 .kc-topbar {
   align-items: center;
-  background: linear-gradient(180deg, var(--bg-surface), #f5efe5);
+  background: linear-gradient(180deg, var(--bg-surface), var(--bg-header-end));
   border: 1px solid var(--border);
   border-radius: 18px;
   box-shadow: 0 1px 2px rgb(42 37 32 / 4%);
@@ -1476,6 +1566,14 @@ label {
   padding: 5px 10px 5px 5px;
 }
 
+.kc-theme-toggle {
+  align-items: center;
+  display: inline-flex;
+  gap: 8px;
+  justify-content: center;
+  width: 100%;
+}
+
 .kc-avatar {
   background: var(--accent);
   color: white;
@@ -1486,7 +1584,7 @@ label {
 }
 
 .kc-account-popover {
-  background: rgb(255 255 255 / 96%);
+  background: var(--overlay-surface);
   border: 1px solid var(--kc-slate-200);
   border-radius: 16px;
   box-shadow: 0 22px 60px rgb(42 37 32 / 18%);
@@ -1500,7 +1598,7 @@ label {
 }
 
 .kc-tabs {
-  background: rgb(255 255 255 / 74%);
+  background: var(--toolbar-bg);
   border: 1px solid var(--kc-slate-200);
   border-radius: 16px;
   box-shadow: 0 1px 2px rgb(42 37 32 / 4%);
@@ -1702,7 +1800,7 @@ label {
 
 .route-editor-footer {
   backdrop-filter: blur(16px);
-  background: rgb(255 255 255 / 82%);
+  background: var(--sticky-surface);
   border: 1px solid var(--kc-slate-200);
   border-radius: 16px;
   bottom: 12px;
@@ -1933,7 +2031,7 @@ button.is-loading {
 
 @media (prefers-color-scheme: dark) {
   .kc-shell {
-    background: linear-gradient(180deg, var(--bg-canvas), #2a211a);
+    background: linear-gradient(180deg, var(--bg-canvas), var(--bg-canvas-end));
     color: var(--text-primary);
   }
 
@@ -1947,7 +2045,7 @@ button.is-loading {
   .route-editor,
   .favorite-picker,
   .favorite-search-box {
-    background: rgb(42 36 30 / 94%);
+    background: var(--overlay-surface);
     border-color: var(--border);
     color: var(--text-primary);
   }
@@ -1955,7 +2053,7 @@ button.is-loading {
   .kc-tab:hover,
   .favorite-place-option,
   .route-editor-footer {
-    background: rgb(52 45 38 / 88%);
+    background: var(--bg-subtle);
   }
 
   .kc-tab.active,

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,7 +1,9 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './globals.css';
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import { AuthProvider } from '@/components/AuthProvider';
+import { ThemeProvider } from '@/components/ThemeProvider';
 
 export const metadata: Metadata = {
   description: 'Web console for editing Kestrel cloud places and routes.',
@@ -10,10 +12,30 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" style={{ colorScheme: 'light dark' }}>
+    <html lang="en" suppressHydrationWarning style={{ colorScheme: 'light dark' }}>
       <body>
-        <AuthProvider>{children}</AuthProvider>
+        <Script id="kestrel-theme-init" strategy="beforeInteractive">
+          {themeInitScript}
+        </Script>
+        <ThemeProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );
 }
+
+const themeInitScript = `
+(() => {
+  try {
+    const storedTheme = window.localStorage.getItem('kestrel-theme');
+    const theme = storedTheme === 'dark' || storedTheme === 'light'
+      ? storedTheme
+      : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+  } catch {
+    // Keep CSS prefers-color-scheme fallback.
+  }
+})();
+`;

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -116,7 +116,7 @@ export default function LoginPage() {
     <main className="auth-page">
       <section className="card auth-card stack">
         <div className="brand">
-          <strong>🦅 Kestrel Cloud</strong>
+          <strong>Kestrel Cloud</strong>
           <span className="muted">Edit places and routes for Android sync.</span>
         </div>
 

--- a/web/components/ThemeProvider.tsx
+++ b/web/components/ThemeProvider.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type Theme = 'dark' | 'light';
+
+type ThemeContextValue = {
+  isHydrated: boolean;
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const STORAGE_KEY = 'kestrel-theme';
+const TRANSITION_CLASS = 'theme-transition-enabled';
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    function applyStoredOrSystemTheme() {
+      const storedTheme = readStoredTheme();
+      const nextTheme = storedTheme ?? getSystemTheme(mediaQuery);
+
+      applyTheme(nextTheme);
+      setTheme(nextTheme);
+    }
+
+    applyStoredOrSystemTheme();
+    setIsHydrated(true);
+
+    function handleSystemThemeChange() {
+      if (readStoredTheme() != null) {
+        return;
+      }
+
+      applyStoredOrSystemTheme();
+    }
+
+    mediaQuery.addEventListener('change', handleSystemThemeChange);
+
+    return () => mediaQuery.removeEventListener('change', handleSystemThemeChange);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((currentTheme) => {
+      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+      enableManualThemeTransition();
+      window.localStorage.setItem(STORAGE_KEY, nextTheme);
+      applyTheme(nextTheme);
+
+      return nextTheme;
+    });
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      isHydrated,
+      theme,
+      toggleTheme,
+    }),
+    [isHydrated, theme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (context == null) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+
+  return context;
+}
+
+function readStoredTheme(): Theme | null {
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+
+  return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+}
+
+function getSystemTheme(mediaQuery: MediaQueryList): Theme {
+  return mediaQuery.matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+function enableManualThemeTransition() {
+  document.documentElement.classList.add(TRANSITION_CLASS);
+  window.setTimeout(() => {
+    document.documentElement.classList.remove(TRANSITION_CLASS);
+  }, 220);
+}

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { type FormEvent, type ReactNode, useState } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import { formatError } from '@/components/dashboard/utils';
+import { useTheme } from '@/components/ThemeProvider';
 
 type DashboardSection = 'places' | 'routes';
 
@@ -100,6 +101,7 @@ export default function DashboardShell({
 
 function AccountMenu({ onLogout }: { onLogout: () => void }) {
   const auth = useAuth();
+  const { isHydrated, theme, toggleTheme } = useTheme();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [notice, setNotice] = useState<string | null>(null);
@@ -136,6 +138,15 @@ function AccountMenu({ onLogout }: { onLogout: () => void }) {
         </div>
         {error == null ? null : <div className="error">{error}</div>}
         {notice == null ? null : <div className="success">{notice}</div>}
+        <button
+          className="secondary kc-theme-toggle"
+          disabled={!isHydrated}
+          type="button"
+          onClick={toggleTheme}
+        >
+          {theme === 'dark' ? <SunIcon /> : <MoonIcon />}
+          {theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        </button>
         <form className="stack" onSubmit={submitPasswordChange}>
           <label>
             Current password
@@ -225,6 +236,30 @@ function ChevronDownIcon() {
   return (
     <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
       <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
     </svg>
   );
 }

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -33,7 +33,15 @@ export default function DashboardShell({
   username,
 }: Props) {
   const [isAccountOpen, setIsAccountOpen] = useState(false);
+  const [isRefreshAnimating, setIsRefreshAnimating] = useState(false);
   const refreshLabel = formatRefreshLabel(lastUpdatedLabel);
+
+  function handleRefresh() {
+    setIsRefreshAnimating(false);
+    window.requestAnimationFrame(() => setIsRefreshAnimating(true));
+    window.setTimeout(() => setIsRefreshAnimating(false), 240);
+    onRefresh();
+  }
 
   return (
     <main className="shell kc-shell">
@@ -54,11 +62,11 @@ export default function DashboardShell({
           <button
             aria-busy={isRefreshing}
             aria-label={refreshLabel}
-            className="secondary kc-icon-button"
+            className={`secondary kc-icon-button ${isRefreshAnimating ? 'is-rotating' : ''}`}
             disabled={isRefreshing}
             title={refreshLabel}
             type="button"
-            onClick={onRefresh}
+            onClick={handleRefresh}
           >
             <RefreshCwIcon />
           </button>
@@ -184,20 +192,15 @@ function AccountMenu({ onLogout }: { onLogout: () => void }) {
 
 function KestrelIcon() {
   return (
-    <svg aria-hidden="true" fill="none" height="24" viewBox="0 0 24 24" width="24">
+    <svg aria-hidden="true" fill="none" height="28" viewBox="0 0 28 28" width="28">
       <path
-        d="M3 13.2C8.4 4.7 15.7 3.1 21 4.1c-4.1 1.5-5.6 4.6-6.9 8.1"
+        d="M4 16.5C9.8 8.2 17.3 5.4 24 6.3c-4.8 1.7-8 5.2-9.9 10.8"
         stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeWidth="1.8"
+        strokeWidth="2"
       />
-      <path
-        d="M4.4 13.4c4.8-.5 8.2.5 10.8 3.2-4 .8-7.8-.1-10.8-3.2Z"
-        fill="currentColor"
-        opacity="0.25"
-      />
-      <path d="M13.9 12.1 21 20" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
+      <path d="M5.4 16.7c5.2-.4 9.1.9 12 4.1-4.7.8-8.6-.2-12-4.1Z" fill="currentColor" />
     </svg>
   );
 }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import {
   formatError,
@@ -156,9 +156,7 @@ export default function RouteEditor({
       <section className="route-editor-section route-editor-map-section">
         <div>
           <h3>Route editor</h3>
-          <p className="muted">
-            Edit your route, manage waypoints, and configure playback settings.
-          </p>
+          <p className="muted">Drag, drop, refine. Your route, your pace.</p>
         </div>
         <div className="route-builder-hint">
           <InfoIcon />
@@ -351,6 +349,8 @@ function FavoriteWaypointPicker({
   places: Place[];
 }) {
   const [query, setQuery] = useState('');
+  const [copiedPlaceId, setCopiedPlaceId] = useState<string | null>(null);
+  const copiedTimeoutRef = useRef<number | null>(null);
   const filteredPlaces = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
 
@@ -364,6 +364,31 @@ function FavoriteWaypointPicker({
       return haystack.includes(normalizedQuery);
     });
   }, [places, query]);
+
+  useEffect(
+    () => () => {
+      if (copiedTimeoutRef.current != null) {
+        window.clearTimeout(copiedTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  async function copyFavoriteCoords(place: Place) {
+    try {
+      await navigator.clipboard.writeText(formatFavoritePlaceCoords(place));
+      setCopiedPlaceId(place.id);
+      if (copiedTimeoutRef.current != null) {
+        window.clearTimeout(copiedTimeoutRef.current);
+      }
+      copiedTimeoutRef.current = window.setTimeout(() => {
+        setCopiedPlaceId((currentPlaceId) => (currentPlaceId === place.id ? null : currentPlaceId));
+        copiedTimeoutRef.current = null;
+      }, 1400);
+    } catch {
+      setCopiedPlaceId(null);
+    }
+  }
 
   if (places.length === 0) {
     return (
@@ -381,7 +406,7 @@ function FavoriteWaypointPicker({
         <p className="muted">
           {mode === 'start'
             ? 'Pick a saved place as the first waypoint, or click the map to start manually.'
-            : 'Append a saved place to the end of this route.'}
+            : 'Drop a favorite onto the tail of this route.'}
         </p>
       </div>
       <label className="favorite-search">
@@ -398,18 +423,25 @@ function FavoriteWaypointPicker({
       </label>
       <div className="favorite-place-list">
         {filteredPlaces.map((place) => (
-          <button
-            className="favorite-place-option"
-            key={place.id}
-            type="button"
-            onClick={() => onSelect(place)}
-          >
+          <div className="favorite-place-option" key={place.id}>
             <span className="favorite-place-main">
               <MapPinIcon />
               <strong>{place.name}</strong>
-              <span className="favorite-add">+ Add</span>
+              <button className="favorite-add" type="button" onClick={() => onSelect(place)}>
+                + Add
+              </button>
             </span>
-            <span className="muted mono">{formatFavoritePlaceCoords(place)}</span>
+            <button
+              aria-label={`Copy coordinates for ${place.name}`}
+              className="coordinate-copy muted mono"
+              type="button"
+              onClick={() => void copyFavoriteCoords(place)}
+            >
+              {formatFavoritePlaceCoords(place)}
+              {copiedPlaceId === place.id ? (
+                <span className="coordinate-copy-tooltip">copied</span>
+              ) : null}
+            </button>
             {place.tags.length === 0 ? null : (
               <span className="chip-row">
                 {place.tags.map((tag) => (
@@ -419,7 +451,7 @@ function FavoriteWaypointPicker({
                 ))}
               </span>
             )}
-          </button>
+          </div>
         ))}
         {filteredPlaces.length === 0 ? <p className="muted">No favorite places match.</p> : null}
       </div>
@@ -458,7 +490,7 @@ function getRouteBuilderHint(waypointCount: number, placeCount: number): string 
     return 'Add at least one more waypoint to save this route.';
   }
 
-  return 'Add more waypoints from the map, or drag markers to refine the route.';
+  return 'Tap the map to add a waypoint, or drag any pin to nudge the path.';
 }
 
 function getSaveDisabledReason(waypointCount: number): string | null {


### PR DESCRIPTION
## Summary
- add a ThemeProvider with system dark-mode detection and a user-menu sun/moon toggle
- persist manual theme choice in localStorage as `kestrel-theme`
- apply a warm dusk dark palette while preserving card borders and the accent hairline
- add Kestrel personality details: geometric wing mark, warmer helper copy, active route dot, coordinate copy affordance, and refresh rotation
- keep motion subtle and remove decorative loading shimmer

## Verification
- cd web && npm exec -- biome ci .
- cd web && npm run typecheck
- cd web && npm run build
- git diff --check