### PR TITLE
fix(web): guard theme storage access

### DIFF
--- a/web/components/ThemeProvider.tsx
+++ b/web/components/ThemeProvider.tsx
@@ -58,7 +58,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
 
       enableManualThemeTransition();
-      window.localStorage.setItem(STORAGE_KEY, nextTheme);
+      writeStoredTheme(nextTheme);
       applyTheme(nextTheme);
 
       return nextTheme;
@@ -88,9 +88,21 @@ export function useTheme() {
 }
 
 function readStoredTheme(): Theme | null {
-  const storedTheme = window.localStorage.getItem(STORAGE_KEY);
+  try {
+    const storedTheme = window.localStorage.getItem(STORAGE_KEY);
 
-  return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+    return storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredTheme(theme: Theme) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // A blocked or full Web Storage area should not break theme switching.
+  }
 }
 
 function getSystemTheme(mediaQuery: MediaQueryList): Theme {


### PR DESCRIPTION
## Summary
- wrap `localStorage` reads/writes in safe helpers for the dashboard theme preference
- keep theme toggling functional when Web Storage is blocked or throws

## Verification
- cd web && npm exec -- biome ci .
- cd web && npm run typecheck
- cd web && npm run build
- git diff --check

## Notes
- Follow-up for Codex feedback on merged PR #107.