### PR TITLE
style(web): refine dashboard visual hierarchy

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -117,10 +117,11 @@ export default function PlacesDashboardPage() {
                   {isSidebarOpen ? '‹' : '›'}
                 </button>
                 <button
-                  className="secondary dashboard-sidebar-new"
+                  className="secondary dashboard-sidebar-new button-icon-label"
                   type="button"
                   onClick={createNewPlace}
                 >
+                  <PlusIcon />
                   New
                 </button>
               </div>
@@ -136,7 +137,7 @@ export default function PlacesDashboardPage() {
                     onClick={() => setSelectedPlaceId(place.id)}
                   >
                     <strong>{place.name}</strong>
-                    <span className="muted">
+                    <span className="place-card-coordinates">
                       {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
                     </span>
                     <TagRow tags={place.tags} />
@@ -177,6 +178,15 @@ function SidebarSkeleton() {
       <span className="skeleton-line" />
       <span className="skeleton-line short" />
     </div>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
   );
 }
 

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -118,11 +118,12 @@ export default function RoutesDashboardPage() {
                   {isSidebarOpen ? '‹' : '›'}
                 </button>
                 <button
-                  className="secondary dashboard-sidebar-new dashboard-sidebar-new-card"
+                  className="secondary dashboard-sidebar-new dashboard-sidebar-new-card button-icon-label"
                   type="button"
                   onClick={() => selectRoute(null)}
                 >
-                  + New route
+                  <PlusIcon />
+                  New route
                 </button>
                 <button
                   aria-label="Close routes"
@@ -144,16 +145,18 @@ export default function RoutesDashboardPage() {
                     type="button"
                     onClick={() => selectRoute(route.id)}
                   >
-                    <strong className="route-card-title">{route.name}</strong>
-                    <span className="route-card-metrics">
-                      {formatRouteDistance(route)} · {route.defaultSpeedKmh}km/h ·{' '}
-                      {formatMode(route.mode)}
-                    </span>
-                    <span className="chip-row route-card-badges">
-                      <span className="chip rev-chip">
+                    <span className="route-card-title-row">
+                      <strong className="route-card-title">{route.name}</strong>
+                      <span className="route-card-rev">
                         rev {route.currentRevision?.revisionNumber ?? '—'}
                       </span>
-                      {route.isPublic ? <span className="chip">public</span> : null}
+                      {route.isPublic ? <span className="route-card-status">public</span> : null}
+                    </span>
+                    <span className="route-card-meta-row">
+                      <span className="route-card-metrics">
+                        {formatRouteDistance(route)} · {route.defaultSpeedKmh}km/h
+                      </span>
+                      <span className="route-mode-chip">{formatMode(route.mode)}</span>
                     </span>
                   </button>
                 ))}
@@ -185,7 +188,6 @@ export default function RoutesDashboardPage() {
           <RouteEditor
             key={selectedRoute?.id ?? 'new-route'}
             onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
-            onNew={selectedRoute == null ? undefined : () => selectRoute(null)}
             onSave={(input) => void saveRoute(input)}
             places={places}
             route={selectedRoute}
@@ -239,4 +241,13 @@ function getDistanceKm(
 
 function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180;
+}
+
+function PlusIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2517,3 +2517,341 @@ button.is-loading {
     max-width: calc(100% - 1.6rem);
   }
 }
+
+/* Dashboard hierarchy and consistency refinement */
+.kc-topbar {
+  background: var(--bg-subtle);
+  border: 0.5px solid var(--border);
+}
+
+.dashboard-last-updated {
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-left: auto;
+  text-align: right;
+}
+
+@media (min-width: 640px) {
+  .kc-topbar-actions button.secondary,
+  .kc-user-button.secondary {
+    background: var(--bg-surface);
+    border: 0.5px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    min-height: 32px;
+  }
+
+  .kc-icon-button {
+    height: 32px;
+    width: 32px;
+  }
+
+  .kc-user-button {
+    height: 32px;
+    padding: 0 8px 0 4px;
+  }
+
+  .kc-avatar {
+    font-size: 0.75rem;
+    height: 24px;
+    width: 24px;
+  }
+}
+
+.kc-tabs {
+  background: var(--bg-subtle);
+  border: 0;
+  border-radius: 10px;
+  box-shadow: none;
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+}
+
+.kc-tab {
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  min-height: 36px;
+  padding: 8px 12px;
+}
+
+.kc-tab:hover {
+  background: var(--bg-canvas);
+  border: 0;
+  color: var(--text-primary);
+}
+
+.kc-tab.active,
+.kc-tab.active:hover {
+  background: var(--bg-surface);
+  border: 0;
+  box-shadow: none;
+  color: var(--accent);
+}
+
+.kc-shell .card,
+.kc-shell .panel,
+.kc-shell .route-editor,
+.kc-shell .favorite-picker,
+.kc-shell .route-editor-collapsible {
+  border-radius: 12px;
+}
+
+.kc-shell button,
+.kc-shell .kc-user-button,
+.kc-shell .kc-icon-button,
+.kc-shell input:not([type="checkbox"]):not([type="radio"]),
+.kc-shell select,
+.kc-shell textarea {
+  border-radius: 8px;
+}
+
+.kc-shell label {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  gap: 6px;
+}
+
+.kc-shell input:not([type="checkbox"]):not([type="radio"]),
+.kc-shell select,
+.kc-shell textarea {
+  border: 0.5px solid var(--border);
+}
+
+.kc-shell input:not([type="checkbox"]):not([type="radio"]):focus,
+.kc-shell select:focus,
+.kc-shell textarea:focus {
+  border: 1px solid var(--accent);
+  box-shadow: none;
+  outline: 3px solid var(--accent-soft);
+  outline-offset: 0;
+}
+
+.kc-shell .chip,
+.kc-shell .rev-chip,
+.kc-shell .route-mode-chip,
+.kc-shell .route-card-rev,
+.kc-shell .route-card-status {
+  border-radius: 4px;
+}
+
+.button-icon-label {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  justify-content: center;
+}
+
+.button-icon-label .lucide-icon {
+  stroke-width: 1.5;
+}
+
+.dashboard-sidebar .list {
+  gap: 4px;
+}
+
+.dashboard-sidebar .list-item:not(.route-list-item) {
+  gap: 4px;
+  padding: 12px 14px;
+}
+
+.place-card-coordinates {
+  color: var(--text-muted);
+  font-family: "JetBrains Mono", "Geist Mono", ui-monospace, monospace;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.list-item.route-list-item {
+  gap: 8px;
+  padding: 12px;
+}
+
+.route-card-title-row,
+.route-card-meta-row {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.route-card-title-row {
+  justify-content: flex-start;
+}
+
+.route-card-meta-row {
+  justify-content: space-between;
+}
+
+.route-card-title {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kc-shell .route-card-rev,
+.kc-shell .route-card-status {
+  color: var(--text-muted);
+  flex: 0 0 auto;
+  font-family: "JetBrains Mono", "Geist Mono", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.kc-shell .route-card-status {
+  color: var(--text-secondary);
+}
+
+.route-card-metrics {
+  color: var(--text-muted);
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kc-shell .route-mode-chip {
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+  padding: 2px 6px;
+}
+
+.route-card-badges {
+  position: static;
+}
+
+.breadcrumb {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.breadcrumb span {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.place-editor-header {
+  border-bottom: 0.5px solid var(--border);
+  display: grid;
+  gap: 8px;
+  padding-bottom: 24px;
+}
+
+.place-editor-header h2 {
+  color: var(--text-primary);
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.place-editor .split,
+.route-editor-details-section .split {
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.map,
+.map-mini,
+.map-builder {
+  border-radius: 12px;
+}
+
+.map,
+.map-mini {
+  border: 0.5px solid var(--border);
+}
+
+.maplibregl-ctrl-attrib,
+.maplibregl-ctrl-attrib a {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.maplibregl-ctrl-attrib {
+  background: color-mix(in srgb, var(--bg-canvas) 80%, transparent);
+}
+
+.route-marker {
+  background: var(--accent);
+  border-color: var(--bg-surface);
+  border-radius: var(--radius-pill);
+  color: #ffffff;
+}
+
+.route-marker:hover:not(:disabled),
+.route-marker:focus-visible,
+.route-marker.selected,
+.route-marker.selected:hover:not(:disabled),
+.route-marker.selected:focus-visible {
+  background: var(--accent-hover);
+  color: #ffffff;
+}
+
+.route-editor-footer {
+  background: var(--bg-surface);
+  border: 0;
+  border-radius: 0 0 12px 12px;
+  border-top: 0.5px solid var(--border);
+  bottom: 0;
+  box-shadow: none;
+  margin: 0 -20px -20px;
+  padding: 12px 20px;
+}
+
+.route-editor-footer > .stack {
+  gap: 8px;
+}
+
+.route-editor-footer .row {
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+@media (max-width: 639px) {
+  .kc-tabs {
+    width: 100%;
+  }
+
+  .kc-tab {
+    height: 44px;
+    min-height: 44px;
+  }
+
+  .kc-avatar {
+    height: 32px;
+    width: 32px;
+  }
+
+  .mobile-route-sheet-trigger {
+    border-radius: var(--radius-pill);
+  }
+
+  .kc-workspace .list-item.route-list-item {
+    padding: 16px 14px 16px 12px;
+  }
+
+  .place-editor-header h2,
+  .route-editor-header h2 {
+    font-size: 22px;
+  }
+
+  .route-editor-footer {
+    border-radius: 12px 12px 0 0;
+    margin: 0 -14px -14px;
+    padding: 12px 14px calc(12px + env(safe-area-inset-bottom));
+  }
+}

--- a/web/components/PlaceMapEditor.tsx
+++ b/web/components/PlaceMapEditor.tsx
@@ -38,7 +38,7 @@ export default function PlaceMapEditor({
       zoom: 14,
     });
     const marker = new maplibregl.Marker({
-      color: '#76c945',
+      color: '#d97644',
       draggable: true,
     })
       .setLngLat([longitude, latitude])

--- a/web/components/PlaceMapPreview.tsx
+++ b/web/components/PlaceMapPreview.tsx
@@ -28,7 +28,7 @@ export default function PlaceMapPreview({ className = 'map-mini', latitude, long
       zoom: 14,
     });
     const marker = new maplibregl.Marker({
-      color: '#76c945',
+      color: '#d97644',
     })
       .setLngLat([longitude, latitude])
       .addTo(map);

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -71,7 +71,7 @@ export default function RouteMapEditor({
           'line-join': 'round',
         },
         paint: {
-          'line-color': '#76c945',
+          'line-color': '#d97644',
           'line-width': 4,
         },
         source: LINE_SOURCE_ID,

--- a/web/components/RouteMapPreview.tsx
+++ b/web/components/RouteMapPreview.tsx
@@ -47,7 +47,7 @@ export default function RouteMapPreview({ className = 'map-mini', waypoints }: P
           'line-join': 'round',
         },
         paint: {
-          'line-color': '#76c945',
+          'line-color': '#d97644',
           'line-width': 4,
         },
         source: LINE_SOURCE_ID,
@@ -100,7 +100,7 @@ function syncMarkers(map: MapLibreMap, existingMarkers: Marker[], waypoints: Rou
 
   waypoints.forEach((waypoint, index) => {
     const marker = new maplibregl.Marker({
-      color: index === 0 ? '#76c945' : '#f9aecb',
+      color: index === 0 ? '#d97644' : '#c5612f',
     })
       .setLngLat([waypoint.longitude, waypoint.latitude])
       .addTo(map);

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -77,8 +77,13 @@ export default function PlaceEditor({
   }
 
   return (
-    <form className="panel stack" onSubmit={submit}>
-      <h2>{place == null ? 'New place' : 'Edit place'}</h2>
+    <form className="panel stack place-editor" onSubmit={submit}>
+      <header className="place-editor-header">
+        <div className="breadcrumb">
+          Places / <span>{place?.name ?? 'New place'}</span>
+        </div>
+        <h2>{place == null ? 'New place' : place.name}</h2>
+      </header>
       {error == null ? null : <div className="error">{error}</div>}
       <PlaceMapEditor
         latitude={mapCoords.latitude}
@@ -121,16 +126,18 @@ export default function PlaceEditor({
         <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
       </label>
       <PlaceSharePanel place={place} />
-      <div className="row">
-        <button disabled={isSaving} type="submit">
-          {isSaving ? 'Saving…' : 'Save place'}
-        </button>
-        {onDelete == null ? null : (
-          <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>
-            Delete
+      <footer className="route-editor-footer place-editor-footer">
+        <div className="row">
+          {onDelete == null ? null : (
+            <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>
+              Delete
+            </button>
+          )}
+          <button disabled={isSaving} type="submit">
+            {isSaving ? 'Saving…' : 'Save place'}
           </button>
-        )}
-      </div>
+        </div>
+      </footer>
     </form>
   );
 }
@@ -253,7 +260,12 @@ function PlaceSharePanel({ place }: { place: Place | null }) {
       {notice == null ? null : <div className="success">{notice}</div>}
       {shareLink == null ? (
         <div className="row">
-          <button disabled={isMutating} type="button" onClick={() => void createShareLink()}>
+          <button
+            className="secondary"
+            disabled={isMutating}
+            type="button"
+            onClick={() => void createShareLink()}
+          >
             {isMutating ? 'Creating…' : 'Create public link'}
           </button>
         </div>

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -26,13 +26,11 @@ const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
 
 export default function RouteEditor({
   onDelete,
-  onNew,
   onSave,
   places = [],
   route,
 }: {
   onDelete?: () => void;
-  onNew?: () => void;
   onSave: (input: RouteInput) => void;
   places?: Place[];
   route: Route | null;
@@ -144,11 +142,6 @@ export default function RouteEditor({
             </span>
           )}
         </div>
-        {onNew == null ? null : (
-          <button className="secondary" type="button" onClick={onNew}>
-            New route
-          </button>
-        )}
       </header>
       {error == null ? null : <div className="error route-editor-error">{error}</div>}
       {saveNotice == null ? null : <div className="success route-editor-success">{saveNotice}</div>}
@@ -242,12 +235,13 @@ export default function RouteEditor({
               </div>
             ))}
             <button
-              className="secondary"
+              className="secondary button-icon-label"
               disabled={waypoints.length === 0}
               type="button"
               onClick={duplicateLastWaypoint}
             >
-              + Add waypoint
+              <PlusIcon />
+              Add waypoint
             </button>
           </div>
         </details>
@@ -320,6 +314,11 @@ export default function RouteEditor({
             <p className="muted no-margin">{saveDisabledReason}</p>
           )}
           <div className="row">
+            {onDelete == null ? null : (
+              <button className="danger" disabled={isSaving} type="button" onClick={confirmDelete}>
+                Delete route
+              </button>
+            )}
             <button
               className={isSaving ? 'is-loading' : ''}
               disabled={isSaving || saveDisabledReason != null}
@@ -327,11 +326,6 @@ export default function RouteEditor({
             >
               {isSaving ? 'Saving…' : saveNotice == null ? 'Save route' : 'Saved ✓'}
             </button>
-            {onDelete == null ? null : (
-              <button className="danger" disabled={isSaving} type="button" onClick={confirmDelete}>
-                Delete route
-              </button>
-            )}
           </div>
         </div>
       </footer>
@@ -427,8 +421,13 @@ function FavoriteWaypointPicker({
             <span className="favorite-place-main">
               <MapPinIcon />
               <strong>{place.name}</strong>
-              <button className="favorite-add" type="button" onClick={() => onSelect(place)}>
-                + Add
+              <button
+                className="favorite-add button-icon-label"
+                type="button"
+                onClick={() => onSelect(place)}
+              >
+                <PlusIcon />
+                Add
               </button>
             </span>
             <button
@@ -684,6 +683,15 @@ function SearchIcon() {
     <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
       <path d="m21 21-4.3-4.3" />
       <circle cx="11" cy="11" r="8" />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- add a warmer, more anchored header treatment and segmented Places/Routes tabs
- refine route cards with inline revision text and playback mode chips
- align Places and Routes editor breadcrumbs, sticky action bars, form fields, map containers, and button/icon treatment
- bring map markers/route lines into the Kestrel accent palette

## Verification
- cd web && npm exec -- biome ci .
- cd web && npm run typecheck
- cd web && npm run build
- git diff --check
- Chrome/CDP responsive spot-check at 1200px, 780px, and 375px for no page-level horizontal scroll