### PR TITLE
style(web): polish dashboard interactions

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -94,7 +94,7 @@ export default function PlacesDashboardPage() {
     <DashboardShell
       activeSection="places"
       isRefreshing={isLoading}
-      lastUpdatedLabel={lastLoadedAt?.toLocaleTimeString() ?? null}
+      lastUpdatedAt={lastLoadedAt}
       onLogout={auth.logout}
       onRefresh={() => void loadPlaces()}
       username={auth.session.user.username}

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -90,7 +90,7 @@ export default function RoutesDashboardPage() {
     <DashboardShell
       activeSection="routes"
       isRefreshing={isLoading}
-      lastUpdatedLabel={lastLoadedAt?.toLocaleTimeString() ?? null}
+      lastUpdatedAt={lastLoadedAt}
       onLogout={auth.logout}
       onRefresh={() => void loadRoutes()}
       username={auth.session.user.username}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3093,3 +3093,65 @@ button.is-loading {
     min-height: 44px;
   }
 }
+
+/* Header right-side and secondary action alignment */
+.kc-shell .kc-icon-button.secondary,
+.kc-shell .kc-user-button.secondary {
+  background: #ffffff;
+  border: 0.5px solid #e8e0d3;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  height: 32px;
+  min-height: 32px;
+}
+
+.kc-shell .kc-icon-button.secondary {
+  padding: 0;
+  width: 32px;
+}
+
+.kc-shell .kc-icon-button.secondary:hover:not(:disabled),
+.kc-shell .kc-user-button.secondary:hover:not(:disabled) {
+  background: var(--bg-subtle);
+  border-color: #e8e0d3;
+  box-shadow: none;
+  color: var(--text-primary);
+  transform: none;
+}
+
+.kc-shell .kc-user-button.secondary {
+  gap: 8px;
+  padding: 4px 10px 4px 4px;
+}
+
+.kc-shell .kc-user-button.secondary > span:not(.kc-avatar) {
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.kc-shell .kc-user-button.secondary .lucide-icon {
+  color: var(--text-muted);
+}
+
+.kc-shell .kc-user-button.secondary .kc-avatar {
+  height: 22px;
+  width: 22px;
+}
+
+.kc-shell .dashboard-sidebar .dashboard-sidebar-new,
+.kc-shell .dashboard-sidebar .dashboard-sidebar-new-card {
+  background: transparent;
+  border: 1px dashed #d6cbb8;
+  color: var(--text-secondary);
+}
+
+.kc-shell .dashboard-sidebar .dashboard-sidebar-new:hover:not(:disabled),
+.kc-shell .dashboard-sidebar .dashboard-sidebar-new-card:hover:not(:disabled) {
+  background: transparent;
+  border-color: var(--accent);
+  border-style: solid;
+  box-shadow: none;
+  color: var(--accent-hover);
+  transform: none;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3014,11 +3014,7 @@ button.is-loading {
 }
 
 .route-editor-collapsible .route-editor-collapsible-content {
-  max-height: 1800px;
-  overflow: hidden;
-  transition:
-    max-height 200ms ease-out,
-    padding 200ms ease-out;
+  transition: padding 200ms ease-out;
 }
 
 .route-editor-collapsible summary::after {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2855,3 +2855,241 @@ button.is-loading {
     padding: 12px 14px calc(12px + env(safe-area-inset-bottom));
   }
 }
+
+/* Final dashboard polish */
+.kc-shell {
+  padding-top: 0;
+}
+
+.kc-shell .kc-topbar {
+  background: var(--bg-header-end);
+  border: 0;
+  border-bottom: 0.5px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+  margin: 0 -20px;
+  padding: 14px 24px;
+}
+
+.kc-shell .kc-logo {
+  height: 44px;
+  width: 44px;
+}
+
+.kc-shell .kc-topbar-actions {
+  align-items: center;
+  gap: 8px;
+}
+
+.kc-shell .dashboard-last-updated {
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-left: 0;
+}
+
+.kc-shell .kc-topbar-actions button.secondary,
+.kc-shell .kc-user-button.secondary {
+  background: var(--bg-surface);
+  border: 0.5px solid var(--border);
+  border-radius: 8px;
+  min-height: 32px;
+}
+
+.kc-shell .kc-icon-button {
+  height: 32px;
+  width: 32px;
+}
+
+.kc-shell .kc-tabs.kc-tabs {
+  background: var(--bg-subtle);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  box-shadow: none;
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+}
+
+.kc-shell .kc-tab {
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  box-shadow: none;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  gap: 6px;
+  min-height: 34px;
+  padding: 7px 14px;
+}
+
+.kc-shell .kc-tab:hover {
+  background: rgb(255 255 255 / 50%);
+  border: 0;
+  color: var(--text-primary);
+}
+
+.kc-shell .kc-tab.active,
+.kc-shell .kc-tab.active:hover {
+  background: var(--bg-surface);
+  border: 0;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  color: var(--accent-hover);
+}
+
+.kc-shell .dashboard-sidebar-header {
+  gap: 10px;
+}
+
+.kc-shell .dashboard-sidebar-actions {
+  margin-left: auto;
+}
+
+.kc-shell .route-list-item .route-card-title::before {
+  background: var(--accent);
+  border-radius: 999px;
+  content: "";
+  flex: 0 0 auto;
+  height: 4px;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  width: 4px;
+}
+
+.kc-shell .route-list-item.active .route-card-title::before {
+  opacity: 1;
+}
+
+.kc-shell .route-card-rev {
+  align-self: center;
+  transform: translateY(0.5px);
+}
+
+.route-editor-waypoints-section .route-editor-collapsible-content {
+  gap: 8px;
+}
+
+.waypoint-row .chip {
+  background: #f5ebe0;
+  color: var(--accent-hover);
+}
+
+.waypoint-row .row-actions {
+  border: 0.5px solid var(--border);
+  border-radius: 6px;
+  display: inline-flex;
+  justify-self: end;
+  overflow: hidden;
+}
+
+.waypoint-row .row-actions button {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  border-right: 0.5px solid var(--border);
+  color: var(--text-muted);
+  min-height: 32px;
+  padding: 6px 10px;
+}
+
+.waypoint-row .row-actions button:last-child {
+  border-right: 0;
+}
+
+.waypoint-row .row-actions button:hover:not(:disabled) {
+  background: var(--bg-subtle);
+  box-shadow: none;
+  color: var(--text-secondary);
+  transform: none;
+}
+
+.waypoint-row .row-actions .danger {
+  border-color: transparent;
+  color: var(--text-muted);
+}
+
+.waypoint-row .row-actions .danger:hover:not(:disabled) {
+  border-color: transparent;
+  color: var(--danger);
+}
+
+.route-editor-collapsible .route-editor-collapsible-content {
+  max-height: 1800px;
+  overflow: hidden;
+  transition:
+    max-height 200ms ease-out,
+    padding 200ms ease-out;
+}
+
+.route-editor-collapsible summary::after {
+  content: "▼";
+  transform: none;
+  transition: transform 200ms ease;
+}
+
+.route-editor-collapsible[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.route-editor-collapsible:not([open]) summary::after {
+  transform: none;
+}
+
+.route-editor button[type="submit"].is-saved {
+  background: var(--success);
+}
+
+.place-card-coordinates,
+.coordinate-copy {
+  cursor: text;
+  user-select: text;
+}
+
+.map {
+  animation: map-load-pulse 600ms ease-out;
+  background: var(--bg-subtle);
+}
+
+@keyframes map-load-pulse {
+  0% {
+    background: var(--bg-subtle);
+  }
+
+  50% {
+    background: #f5ebe0;
+  }
+
+  100% {
+    background: var(--bg-subtle);
+  }
+}
+
+@media (max-width: 639px) {
+  .kc-shell {
+    padding-top: 0;
+  }
+
+  .kc-shell .kc-topbar {
+    margin: 0 -14px;
+    padding: 12px 14px;
+  }
+
+  .kc-shell .kc-logo {
+    height: 44px;
+    width: 44px;
+  }
+
+  .kc-shell .kc-tab {
+    height: 44px;
+    min-height: 44px;
+  }
+
+  .waypoint-row .row-actions {
+    justify-self: stretch;
+  }
+
+  .waypoint-row .row-actions button {
+    flex: 1;
+    min-height: 44px;
+  }
+}

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { type FormEvent, type ReactNode, useState } from 'react';
+import { type FormEvent, type ReactNode, useEffect, useState } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import { formatError } from '@/components/dashboard/utils';
 import { useTheme } from '@/components/ThemeProvider';
@@ -12,7 +12,7 @@ type Props = {
   activeSection: DashboardSection;
   children: ReactNode;
   isRefreshing?: boolean;
-  lastUpdatedLabel?: string | null;
+  lastUpdatedAt?: Date | null;
   onLogout: () => void;
   onRefresh: () => void;
   username: string;
@@ -27,13 +27,14 @@ export default function DashboardShell({
   activeSection,
   children,
   isRefreshing = false,
-  lastUpdatedLabel = null,
+  lastUpdatedAt = null,
   onLogout,
   onRefresh,
   username,
 }: Props) {
   const [isAccountOpen, setIsAccountOpen] = useState(false);
   const [isRefreshAnimating, setIsRefreshAnimating] = useState(false);
+  const lastUpdatedLabel = useRelativeUpdatedLabel(lastUpdatedAt);
   const refreshLabel = formatRefreshLabel(lastUpdatedLabel);
 
   function handleRefresh() {
@@ -192,7 +193,7 @@ function AccountMenu({ onLogout }: { onLogout: () => void }) {
 
 function KestrelIcon() {
   return (
-    <svg aria-hidden="true" fill="none" height="28" viewBox="0 0 28 28" width="28">
+    <svg aria-hidden="true" fill="none" height="36" viewBox="0 0 28 28" width="36">
       <path
         d="M4 16.5C9.8 8.2 17.3 5.4 24 6.3c-4.8 1.7-8 5.2-9.9 10.8"
         stroke="currentColor"
@@ -265,6 +266,51 @@ function SunIcon() {
       <path d="m19.07 4.93-1.41 1.41" />
     </svg>
   );
+}
+
+function useRelativeUpdatedLabel(lastUpdatedAt: Date | null): string | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (lastUpdatedAt == null) {
+      return;
+    }
+
+    setNow(Date.now());
+    const intervalId = window.setInterval(() => setNow(Date.now()), 30_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [lastUpdatedAt]);
+
+  if (lastUpdatedAt == null) {
+    return null;
+  }
+
+  return formatRelativeTime(lastUpdatedAt, now);
+}
+
+function formatRelativeTime(date: Date, now: number): string {
+  const elapsedSeconds = Math.max(0, Math.floor((now - date.getTime()) / 1000));
+
+  if (elapsedSeconds < 60) {
+    return 'Just now';
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes} minute${elapsedMinutes === 1 ? '' : 's'} ago`;
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+
+  if (elapsedHours < 24) {
+    return `${elapsedHours} hour${elapsedHours === 1 ? '' : 's'} ago`;
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+
+  return `${elapsedDays} day${elapsedDays === 1 ? '' : 's'} ago`;
 }
 
 function formatRefreshLabel(lastUpdatedLabel?: string | null): string {

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -292,25 +292,27 @@ function useRelativeUpdatedLabel(lastUpdatedAt: Date | null): string | null {
 function formatRelativeTime(date: Date, now: number): string {
   const elapsedSeconds = Math.max(0, Math.floor((now - date.getTime()) / 1000));
 
-  if (elapsedSeconds < 60) {
+  if (elapsedSeconds < 10) {
     return 'Just now';
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s ago`;
   }
 
   const elapsedMinutes = Math.floor(elapsedSeconds / 60);
 
   if (elapsedMinutes < 60) {
-    return `${elapsedMinutes} minute${elapsedMinutes === 1 ? '' : 's'} ago`;
+    return `${elapsedMinutes}m ago`;
   }
 
   const elapsedHours = Math.floor(elapsedMinutes / 60);
 
   if (elapsedHours < 24) {
-    return `${elapsedHours} hour${elapsedHours === 1 ? '' : 's'} ago`;
+    return `${elapsedHours}h ago`;
   }
 
-  const elapsedDays = Math.floor(elapsedHours / 24);
-
-  return `${elapsedDays} day${elapsedDays === 1 ? '' : 's'} ago`;
+  return new Intl.DateTimeFormat('en-US', { day: 'numeric', month: 'short' }).format(date);
 }
 
 function formatRefreshLabel(lastUpdatedLabel?: string | null): string {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -52,6 +52,7 @@ export default function RouteEditor({
   const [error, setError] = useState<string | null>(null);
   const [saveNotice, setSaveNotice] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const saveNoticeTimeoutRef = useRef<number | null>(null);
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
@@ -62,10 +63,22 @@ export default function RouteEditor({
     }
   }, [selectedWaypointIndex, waypoints.length]);
 
+  useEffect(
+    () => () => {
+      if (saveNoticeTimeoutRef.current != null) {
+        window.clearTimeout(saveNoticeTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
     setSaveNotice(null);
+    if (saveNoticeTimeoutRef.current != null) {
+      window.clearTimeout(saveNoticeTimeoutRef.current);
+    }
     setIsSaving(true);
 
     try {
@@ -81,6 +94,10 @@ export default function RouteEditor({
         })),
       });
       setSaveNotice('Saved.');
+      saveNoticeTimeoutRef.current = window.setTimeout(() => {
+        setSaveNotice(null);
+        saveNoticeTimeoutRef.current = null;
+      }, 1000);
     } catch (nextError) {
       setError(formatError(nextError));
     } finally {
@@ -144,7 +161,6 @@ export default function RouteEditor({
         </div>
       </header>
       {error == null ? null : <div className="error route-editor-error">{error}</div>}
-      {saveNotice == null ? null : <div className="success route-editor-success">{saveNotice}</div>}
 
       <section className="route-editor-section route-editor-map-section">
         <div>
@@ -175,6 +191,7 @@ export default function RouteEditor({
           <button
             className="secondary"
             disabled={waypoints.length === 0}
+            title="Auto-frame the map to show all waypoints"
             type="button"
             onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
           >
@@ -187,7 +204,8 @@ export default function RouteEditor({
 
         <details className="route-editor-collapsible route-editor-waypoints-section">
           <summary>
-            <span>Waypoints ({waypoints.length})</span>
+            <span>{formatWaypointCount(waypoints.length)}</span>
+            <span className="muted">{formatWaypointSummary(waypoints)}</span>
           </summary>
           <div className="route-editor-collapsible-content">
             {waypoints.map((waypoint, index) => (
@@ -211,7 +229,7 @@ export default function RouteEditor({
                     updateWaypoint(waypoints, setWaypoints, index, 'longitude', event.target.value)
                   }
                 />
-                <div className="row">
+                <div className="row-actions">
                   <button
                     className="secondary"
                     disabled={index === 0}
@@ -320,7 +338,7 @@ export default function RouteEditor({
               </button>
             )}
             <button
-              className={isSaving ? 'is-loading' : ''}
+              className={isSaving ? 'is-loading' : saveNotice == null ? '' : 'is-saved'}
               disabled={isSaving || saveDisabledReason != null}
               type="submit"
             >
@@ -400,7 +418,7 @@ function FavoriteWaypointPicker({
         <p className="muted">
           {mode === 'start'
             ? 'Pick a saved place as the first waypoint, or click the map to start manually.'
-            : 'Drop a favorite onto the tail of this route.'}
+            : 'Append a saved place. Drag, or click to add.'}
         </p>
       </div>
       <label className="favorite-search">
@@ -464,6 +482,33 @@ function formatFavoritePlaceCoords(place: Place): string {
 
 function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
   return `${waypoint.sequence ?? index}-${waypoint.latitude}-${waypoint.longitude}`;
+}
+
+function formatWaypointCount(waypointCount: number): string {
+  return `${waypointCount} waypoint${waypointCount === 1 ? '' : 's'}`;
+}
+
+function formatWaypointSummary(waypoints: RouteWaypoint[]): string {
+  const firstWaypoint = waypoints[0];
+  const lastWaypoint = waypoints.at(-1);
+
+  if (firstWaypoint == null || lastWaypoint == null) {
+    return 'Start by adding a point';
+  }
+
+  if (waypoints.length === 1) {
+    return `Starts at ${formatShortCoord(firstWaypoint.latitude)}, ${formatShortCoord(
+      firstWaypoint.longitude,
+    )}`;
+  }
+
+  return `Start at ${formatShortCoord(firstWaypoint.latitude)}, end at ${formatShortCoord(
+    lastWaypoint.latitude,
+  )}`;
+}
+
+function formatShortCoord(value: number | string): string {
+  return Number(value).toFixed(2);
 }
 
 function getWaypointLabel(index: number, waypointCount: number): string {


### PR DESCRIPTION
## Summary
- make the dashboard tabs a true segmented control and anchor the header with a warm flush treatment
- refine waypoint rows with grouped controls, lighter pills, summary copy, and reduced delete-button noise
- add relative refresh timestamps, route-card dot fade, Fit route tooltip, and transient Saved state
- tune accordion arrow motion, coordinate selection affordance, and subtle map load pulse

## Verification
- cd web && npm exec -- biome ci .
- cd web && npm run typecheck
- cd web && npm run build
- git diff --check
- Chrome/CDP spot-check for tab container, header, responsive layout, and no page-level horizontal scroll