### PR TITLE
feat(web): add cartographer dashboard

### DIFF
--- a/docs/plans/2026-05-20_web-cartographer-places-plan.md
+++ b/docs/plans/2026-05-20_web-cartographer-places-plan.md
@@ -1,0 +1,48 @@
+## Goal
+
+Rebuild the Places dashboard into a cartographer workspace: full-viewport map canvas with a floating field notebook for the place list and an index card for the selected place. Success means Places keeps existing create/edit/delete/share behavior while presenting the map as the main canvas.
+
+## Context
+
+The current Places page is `web/app/dashboard/places/page.tsx` and uses `PlaceEditor`, `PlaceMapEditor`, `PlaceMapPreview`, and `DashboardShell`. The prompt references `web/src/...`; implementation should use the repo’s existing `web/app`, `web/components`, and `web/lib` paths unless a deliberate migration is planned.
+
+## Non-Goals
+
+- Do not rebuild Routes in this step.
+- Do not change backend APIs, auth/session behavior, or place schema.
+- Do not introduce keyed map-provider dependencies or map-provider environment variables.
+- Do not remove existing save/delete/share functionality; restyle and relocate it only.
+
+## Architecture
+
+Add a `web/components/cartographer/` component group for stage-level UI, but keep data fetching and mutation ownership in `web/app/dashboard/places/page.tsx`. Map state should be lifted only as needed for marker selection, map panning, and custom zoom controls.
+
+## Plan
+
+- [ ] Create `web/components/cartographer/Stage.tsx`, `EdgeTape.tsx`, `CornerMark.tsx`, `FieldNotebook.tsx`, `IndexCard.tsx`, `StatusStrip.tsx`, `ScaleBar.tsx`, and `ZoomStack.tsx` with typed props and no API calls; verify exports with `rg -n "export .*Stage|FieldNotebook|IndexCard|ZoomStack" web/components/cartographer`.
+- [ ] Refactor `web/app/dashboard/places/page.tsx` return JSX into `kestrel-stage` with full-viewport map plus floating panels while keeping existing `loadPlaces`, `savePlace`, `deletePlace`, and `createNewPlace` logic; verify with `git diff web/app/dashboard/places/page.tsx`.
+- [ ] Adapt `PlaceMapEditor` or create a cartographer map canvas component that accepts places, selected place id, marker click callbacks, and imperative zoom/pan hooks without breaking the current map editor behavior; verify marker click selects a place in browser smoke.
+- [ ] Implement `FieldNotebook` Places mode: rust spine, serif title, mono count, Places/Routes text nav, active row rust bar, `+ New entry`, and page counter; verify with browser screenshot of `/dashboard/places`.
+- [ ] Implement `IndexCard` for selected places with push-pin, stamp, title, latitude/longitude fields, tags, share section, and Save/Delete actions wired to existing handlers; verify create/edit/delete/share flows manually.
+- [ ] Add custom place markers as DOM elements with active/hover styling and no default popup chrome; verify with browser smoke that marker clicks select the place and map pan/zoom still work.
+- [ ] Add responsive guardrails for this first pass: desktop cartographer layout only, and preserve a usable fallback for narrower screens if not fully responsive yet; verify at 1280px and 780px with Chrome/CDP screenshots or notes.
+- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+
+## Risks
+
+- Replacing the page shell can accidentally bypass `DashboardShell` auth/logout/theme affordances; ensure account controls still exist or are intentionally moved in a later plan.
+- Full-viewport absolute layout can trap content or create inaccessible panels if overflow is not planned.
+- Custom markers can drift from data state if MapLibre marker cleanup is incomplete.
+
+## Rollback / Recovery
+
+- Keep the old Places page diff isolated in one commit so it can be reverted without affecting map-style or token foundations.
+- If the cartographer map component destabilizes editing, temporarily keep `PlaceEditor` embedded inside `IndexCard` until smaller components are extracted.
+
+## Completion Checklist
+
+- [ ] `/dashboard/places` uses a full-viewport map stage with floating notebook and selected-place index card, verified by browser screenshot.
+- [ ] Existing place workflows are intact, verified by manual create, edit, delete confirmation, and share-link smoke tests.
+- [ ] Marker selection works both from notebook rows and map markers, verified by manual click tests.
+- [ ] No keyed map-provider dependency is introduced, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-cartographer-places-plan.md
+++ b/docs/plans/2026-05-20_web-cartographer-places-plan.md
@@ -19,14 +19,14 @@ Add a `web/components/cartographer/` component group for stage-level UI, but kee
 
 ## Plan
 
-- [ ] Create `web/components/cartographer/Stage.tsx`, `EdgeTape.tsx`, `CornerMark.tsx`, `FieldNotebook.tsx`, `IndexCard.tsx`, `StatusStrip.tsx`, `ScaleBar.tsx`, and `ZoomStack.tsx` with typed props and no API calls; verify exports with `rg -n "export .*Stage|FieldNotebook|IndexCard|ZoomStack" web/components/cartographer`.
-- [ ] Refactor `web/app/dashboard/places/page.tsx` return JSX into `kestrel-stage` with full-viewport map plus floating panels while keeping existing `loadPlaces`, `savePlace`, `deletePlace`, and `createNewPlace` logic; verify with `git diff web/app/dashboard/places/page.tsx`.
-- [ ] Adapt `PlaceMapEditor` or create a cartographer map canvas component that accepts places, selected place id, marker click callbacks, and imperative zoom/pan hooks without breaking the current map editor behavior; verify marker click selects a place in browser smoke.
-- [ ] Implement `FieldNotebook` Places mode: rust spine, serif title, mono count, Places/Routes text nav, active row rust bar, `+ New entry`, and page counter; verify with browser screenshot of `/dashboard/places`.
-- [ ] Implement `IndexCard` for selected places with push-pin, stamp, title, latitude/longitude fields, tags, share section, and Save/Delete actions wired to existing handlers; verify create/edit/delete/share flows manually.
-- [ ] Add custom place markers as DOM elements with active/hover styling and no default popup chrome; verify with browser smoke that marker clicks select the place and map pan/zoom still work.
-- [ ] Add responsive guardrails for this first pass: desktop cartographer layout only, and preserve a usable fallback for narrower screens if not fully responsive yet; verify at 1280px and 780px with Chrome/CDP screenshots or notes.
-- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Create `web/components/cartographer/Stage.tsx`, `EdgeTape.tsx`, `CornerMark.tsx`, `FieldNotebook.tsx`, `IndexCard.tsx`, `StatusStrip.tsx`, `ScaleBar.tsx`, and `ZoomStack.tsx` with typed props and no API calls; verify exports with `rg -n "export .*Stage|FieldNotebook|IndexCard|ZoomStack" web/components/cartographer`.
+- [x] Refactor `web/app/dashboard/places/page.tsx` return JSX into `kestrel-stage` with full-viewport map plus floating panels while keeping existing `loadPlaces`, `savePlace`, `deletePlace`, and `createNewPlace` logic; verify with `git diff web/app/dashboard/places/page.tsx`.
+- [x] Adapt `PlaceMapEditor` or create a cartographer map canvas component that accepts places, selected place id, marker click callbacks, and imperative zoom/pan hooks without breaking the current map editor behavior; verify marker click selects a place in browser smoke.
+- [x] Implement `FieldNotebook` Places mode: rust spine, serif title, mono count, Places/Routes text nav, active row rust bar, `+ New entry`, and page counter; verify with browser screenshot of `/dashboard/places`.
+- [x] Implement `IndexCard` for selected places with push-pin, stamp, title, latitude/longitude fields, tags, share section, and Save/Delete actions wired to existing handlers; verify create/edit/delete/share flows manually.
+- [x] Add custom place markers as DOM elements with active/hover styling and no default popup chrome; verify with browser smoke that marker clicks select the place and map pan/zoom still work.
+- [x] Add responsive guardrails for this first pass: desktop cartographer layout only, and preserve a usable fallback for narrower screens if not fully responsive yet; verify at 1280px and 780px with Chrome/CDP screenshots or notes.
+- [x] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
 
 ## Risks
 
@@ -41,8 +41,8 @@ Add a `web/components/cartographer/` component group for stage-level UI, but kee
 
 ## Completion Checklist
 
-- [ ] `/dashboard/places` uses a full-viewport map stage with floating notebook and selected-place index card, verified by browser screenshot.
-- [ ] Existing place workflows are intact, verified by manual create, edit, delete confirmation, and share-link smoke tests.
-- [ ] Marker selection works both from notebook rows and map markers, verified by manual click tests.
-- [ ] No keyed map-provider dependency is introduced, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
-- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] `/dashboard/places` uses a full-viewport map stage with floating notebook and selected-place index card, verified by browser screenshot.
+- [x] Existing place workflows are intact, verified by manual create, edit, delete confirmation, and share-link smoke tests.
+- [x] Marker selection works both from notebook rows and map markers, verified by manual click tests.
+- [x] No keyed map-provider dependency is introduced, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [x] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-cartographer-routes-chrome-plan.md
+++ b/docs/plans/2026-05-20_web-cartographer-routes-chrome-plan.md
@@ -19,15 +19,15 @@ Routes should reuse the `web/components/cartographer/` stage primitives. Route d
 
 ## Plan
 
-- [ ] Add `UserMark.tsx` and account-menu integration to `web/components/cartographer/` so logout/theme/password actions remain reachable after the old header is removed; verify manually that logout and theme toggle still work.
-- [ ] Remove the old dashboard top header and segmented tabs from cartographer Places/Routes pages while keeping navigation inside `FieldNotebook`; verify with `rg -n "kc-topbar|kc-tabs|DashboardShell" web/app/dashboard web/components/cartographer` and browser screenshots.
-- [ ] Rebuild `web/app/dashboard/routes/page.tsx` around `Stage`, `EdgeTape`, `CornerMark`, `FieldNotebook` in Routes mode, `StatusStrip`, `ScaleBar`, and `ZoomStack`; verify with screenshot of `/dashboard/routes`.
-- [ ] Implement a route `IndexCard` variant with draft/revision stamp, route metadata, waypoint count, mode, speed, distance, and action bar; verify selected route details match API data in browser smoke.
-- [ ] Preserve route editor functionality by embedding or adapting `RouteEditor`: waypoint add/remove/reorder, map click add, marker drag, save, delete confirmation, public/share link; verify with manual route edit smoke.
-- [ ] Add a stage-level keyboard shortcut module in `web/lib/keyboard.ts` or `web/components/cartographer/useKeyboardShortcuts.ts`: `g p`, `g r`, `n`, `/`, `Escape`, and `?`; verify shortcuts do not fire while typing in inputs/textareas/contenteditable.
-- [ ] Add a keyboard cheatsheet overlay with mono typography and paper-card styling; verify `?` opens/closes it and `Escape` closes it.
-- [ ] Delete or deprecate unused old dashboard chrome references after both Places and Routes are migrated; verify removed files/selectors are listed in the PR description.
-- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Add `UserMark.tsx` and account-menu integration to `web/components/cartographer/` so logout/theme/password actions remain reachable after the old header is removed; verify manually that logout and theme toggle still work.
+- [x] Remove the old dashboard top header and segmented tabs from cartographer Places/Routes pages while keeping navigation inside `FieldNotebook`; verify with `rg -n "kc-topbar|kc-tabs|DashboardShell" web/app/dashboard web/components/cartographer` and browser screenshots.
+- [x] Rebuild `web/app/dashboard/routes/page.tsx` around `Stage`, `EdgeTape`, `CornerMark`, `FieldNotebook` in Routes mode, `StatusStrip`, `ScaleBar`, and `ZoomStack`; verify with screenshot of `/dashboard/routes`.
+- [x] Implement a route `IndexCard` variant with draft/revision stamp, route metadata, waypoint count, mode, speed, distance, and action bar; verify selected route details match API data in browser smoke.
+- [x] Preserve route editor functionality by embedding or adapting `RouteEditor`: waypoint add/remove/reorder, map click add, marker drag, save, delete confirmation, public/share link; verify with manual route edit smoke.
+- [x] Add a stage-level keyboard shortcut module in `web/lib/keyboard.ts` or `web/components/cartographer/useKeyboardShortcuts.ts`: `g p`, `g r`, `n`, `/`, `Escape`, and `?`; verify shortcuts do not fire while typing in inputs/textareas/contenteditable.
+- [x] Add a keyboard cheatsheet overlay with mono typography and paper-card styling; verify `?` opens/closes it and `Escape` closes it.
+- [x] Delete or deprecate unused old dashboard chrome references after both Places and Routes are migrated; verify removed files/selectors are listed in the PR description.
+- [x] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
 
 ## Risks
 
@@ -42,9 +42,9 @@ Routes should reuse the `web/components/cartographer/` stage primitives. Route d
 
 ## Completion Checklist
 
-- [ ] Places and Routes both use cartographer stage chrome and no old dashboard top header/tab group, verified by screenshots and `rg -n "kc-topbar|kc-tabs" web/app/dashboard web/components/cartographer` review.
-- [ ] Route workflows still work, verified by manual tests for selecting a route, adding waypoints, dragging markers, saving, deleting with confirmation, and share-link actions.
-- [ ] Account/logout/theme/password actions are still reachable, verified by manual browser smoke.
-- [ ] Keyboard shortcuts work and do not fire while typing, verified by manual shortcut smoke.
-- [ ] No keyed map-provider dependency is introduced, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
-- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Places and Routes both use cartographer stage chrome and no old dashboard top header/tab group, verified by screenshots and `rg -n "kc-topbar|kc-tabs" web/app/dashboard web/components/cartographer` review.
+- [x] Route workflows still work, verified by manual tests for selecting a route, adding waypoints, dragging markers, saving, deleting with confirmation, and share-link actions.
+- [x] Account/logout/theme/password actions are still reachable, verified by manual browser smoke.
+- [x] Keyboard shortcuts work and do not fire while typing, verified by manual shortcut smoke.
+- [x] No keyed map-provider dependency is introduced, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [x] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-cartographer-routes-chrome-plan.md
+++ b/docs/plans/2026-05-20_web-cartographer-routes-chrome-plan.md
@@ -1,0 +1,50 @@
+## Goal
+
+Extend the cartographer workspace to the Routes page and replace the old dashboard header/tab chrome with field-notebook chrome. Success means Places and Routes share the same map-first stage, route editing still works, and no old segmented-control/top-header dashboard chrome remains in the cartographer dashboard.
+
+## Context
+
+This plan depends on the cartographer Places components being available. The current Routes page is `web/app/dashboard/routes/page.tsx`; route editing lives in `web/components/dashboard/RouteEditor.tsx` and map editing in `web/components/RouteMapEditor.tsx`.
+
+## Non-Goals
+
+- Do not change route API schemas or backend route behavior.
+- Do not add GPX/KML import/export or track recording.
+- Do not use a keyed hosted watercolor tile provider.
+- Do not rebuild login beyond optional visual alignment.
+
+## Architecture
+
+Routes should reuse the `web/components/cartographer/` stage primitives. Route data fetching and mutations remain in `web/app/dashboard/routes/page.tsx`; the existing `RouteEditor` can be embedded or split only where necessary to preserve waypoints, publishing, and save/delete behavior.
+
+## Plan
+
+- [ ] Add `UserMark.tsx` and account-menu integration to `web/components/cartographer/` so logout/theme/password actions remain reachable after the old header is removed; verify manually that logout and theme toggle still work.
+- [ ] Remove the old dashboard top header and segmented tabs from cartographer Places/Routes pages while keeping navigation inside `FieldNotebook`; verify with `rg -n "kc-topbar|kc-tabs|DashboardShell" web/app/dashboard web/components/cartographer` and browser screenshots.
+- [ ] Rebuild `web/app/dashboard/routes/page.tsx` around `Stage`, `EdgeTape`, `CornerMark`, `FieldNotebook` in Routes mode, `StatusStrip`, `ScaleBar`, and `ZoomStack`; verify with screenshot of `/dashboard/routes`.
+- [ ] Implement a route `IndexCard` variant with draft/revision stamp, route metadata, waypoint count, mode, speed, distance, and action bar; verify selected route details match API data in browser smoke.
+- [ ] Preserve route editor functionality by embedding or adapting `RouteEditor`: waypoint add/remove/reorder, map click add, marker drag, save, delete confirmation, public/share link; verify with manual route edit smoke.
+- [ ] Add a stage-level keyboard shortcut module in `web/lib/keyboard.ts` or `web/components/cartographer/useKeyboardShortcuts.ts`: `g p`, `g r`, `n`, `/`, `Escape`, and `?`; verify shortcuts do not fire while typing in inputs/textareas/contenteditable.
+- [ ] Add a keyboard cheatsheet overlay with mono typography and paper-card styling; verify `?` opens/closes it and `Escape` closes it.
+- [ ] Delete or deprecate unused old dashboard chrome references after both Places and Routes are migrated; verify removed files/selectors are listed in the PR description.
+- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+
+## Risks
+
+- Removing `DashboardShell` can accidentally drop auth/session controls if `UserMark` does not fully replace them.
+- RouteEditor is stateful and long; splitting too aggressively can create save/waypoint regressions.
+- Keyboard shortcuts can conflict with form editing unless input focus checks are comprehensive.
+
+## Rollback / Recovery
+
+- Keep the Routes chrome migration as a separate commit from keyboard shortcuts so shortcut regressions can be reverted independently.
+- If route editing regresses, temporarily mount the existing `RouteEditor` in a floating panel and defer deeper visual decomposition.
+
+## Completion Checklist
+
+- [ ] Places and Routes both use cartographer stage chrome and no old dashboard top header/tab group, verified by screenshots and `rg -n "kc-topbar|kc-tabs" web/app/dashboard web/components/cartographer` review.
+- [ ] Route workflows still work, verified by manual tests for selecting a route, adding waypoints, dragging markers, saving, deleting with confirmation, and share-link actions.
+- [ ] Account/logout/theme/password actions are still reachable, verified by manual browser smoke.
+- [ ] Keyboard shortcuts work and do not fire while typing, verified by manual shortcut smoke.
+- [ ] No keyed map-provider dependency is introduced, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-field-notebook-design-system-plan.md
+++ b/docs/plans/2026-05-20_web-field-notebook-design-system-plan.md
@@ -1,0 +1,41 @@
+## Goal
+
+Establish the “1920s explorer’s field notebook” visual foundation for the web dashboard while preserving current behavior. Success means the existing dashboard keeps working but uses paper/ink/rust tokens, field-notebook fonts, and subtle paper grain.
+
+## Context
+
+`docs/prompt.txt` targets a larger cartographer redesign. This plan is the design-token and font slice only. The repo uses `web/app/layout.tsx` and `web/app/globals.css`, not `web/src/app`.
+
+## Non-Goals
+
+- Do not rebuild Places or Routes layout in this step.
+- Do not change auth, API calls, map behavior, or dashboard data flow.
+- Do not add keyed map-provider dependencies or map-provider env vars.
+
+## Plan
+
+- [ ] Add `next/font/google` imports for Cormorant Garamond, JetBrains Mono, and Inter in `web/app/layout.tsx`; verify generated class variables are applied to the root `<html>` or body with `git diff web/app/layout.tsx` and `cd web && npm run typecheck`.
+- [ ] Replace the top-level color variables in `web/app/globals.css` with paper/ink/kestrel tokens while preserving existing aliases like `--bg-canvas`, `--bg-surface`, `--text-primary`, and `--accent`; verify existing selectors still compile with `cd web && npm run typecheck`.
+- [ ] Add `.font-serif`, `.font-mono`, and `.font-sans` utility classes to `web/app/globals.css`; verify with `rg -n "font-serif|font-mono|font-sans" web/app/globals.css`.
+- [ ] Add the paper-grain overlay without replacing the existing 3px top accent hairline; verify in `web/app/globals.css` that the grain uses a separate pseudo-element or non-conflicting selector and that the hairline still renders.
+- [ ] Review dark-mode token compatibility so existing warm dusk dark mode remains usable; verify by checking the `:root[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` token blocks.
+- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [ ] Browser-smoke login, Places, Routes, and shared pages for visual regressions and console errors; verify with explicit manual notes or screenshots.
+
+## Risks
+
+- The grain overlay can cover clickable UI if `pointer-events: none` or z-index is wrong.
+- Replacing aliases can unintentionally reduce contrast in dark mode.
+- Adding fonts changes layout metrics and may reveal spacing issues.
+
+## Rollback / Recovery
+
+- Revert the design-token commit to restore the previous terracotta/cream system.
+- If fonts fail to load or affect performance, keep CSS variables but remove the Google font imports in a follow-up commit.
+
+## Completion Checklist
+
+- [ ] The app uses paper/ink/kestrel tokens while old aliases still exist, verified by `rg -n "--paper-cream|--ink-black|--kestrel|--bg-canvas|--accent" web/app/globals.css`.
+- [ ] Font variables are wired into the app root, verified by `git diff web/app/layout.tsx` and visual browser smoke.
+- [ ] Existing pages render without layout rebuilds, verified by browser smoke of login, dashboard, Places, Routes, and share pages.
+- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-field-notebook-design-system-plan.md
+++ b/docs/plans/2026-05-20_web-field-notebook-design-system-plan.md
@@ -14,13 +14,13 @@ Establish the “1920s explorer’s field notebook” visual foundation for the 
 
 ## Plan
 
-- [ ] Add `next/font/google` imports for Cormorant Garamond, JetBrains Mono, and Inter in `web/app/layout.tsx`; verify generated class variables are applied to the root `<html>` or body with `git diff web/app/layout.tsx` and `cd web && npm run typecheck`.
-- [ ] Replace the top-level color variables in `web/app/globals.css` with paper/ink/kestrel tokens while preserving existing aliases like `--bg-canvas`, `--bg-surface`, `--text-primary`, and `--accent`; verify existing selectors still compile with `cd web && npm run typecheck`.
-- [ ] Add `.font-serif`, `.font-mono`, and `.font-sans` utility classes to `web/app/globals.css`; verify with `rg -n "font-serif|font-mono|font-sans" web/app/globals.css`.
-- [ ] Add the paper-grain overlay without replacing the existing 3px top accent hairline; verify in `web/app/globals.css` that the grain uses a separate pseudo-element or non-conflicting selector and that the hairline still renders.
-- [ ] Review dark-mode token compatibility so existing warm dusk dark mode remains usable; verify by checking the `:root[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` token blocks.
-- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
-- [ ] Browser-smoke login, Places, Routes, and shared pages for visual regressions and console errors; verify with explicit manual notes or screenshots.
+- [x] Add `next/font/google` imports for Cormorant Garamond, JetBrains Mono, and Inter in `web/app/layout.tsx`; verify generated class variables are applied to the root `<html>` or body with `git diff web/app/layout.tsx` and `cd web && npm run typecheck`.
+- [x] Replace the top-level color variables in `web/app/globals.css` with paper/ink/kestrel tokens while preserving existing aliases like `--bg-canvas`, `--bg-surface`, `--text-primary`, and `--accent`; verify existing selectors still compile with `cd web && npm run typecheck`.
+- [x] Add `.font-serif`, `.font-mono`, and `.font-sans` utility classes to `web/app/globals.css`; verify with `rg -n "font-serif|font-mono|font-sans" web/app/globals.css`.
+- [x] Add the paper-grain overlay without replacing the existing 3px top accent hairline; verify in `web/app/globals.css` that the grain uses a separate pseudo-element or non-conflicting selector and that the hairline still renders.
+- [x] Review dark-mode token compatibility so existing warm dusk dark mode remains usable; verify by checking the `:root[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` token blocks.
+- [x] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Browser-smoke login, Places, Routes, and shared pages for visual regressions and console errors; verify with explicit manual notes or screenshots.
 
 ## Risks
 
@@ -35,7 +35,7 @@ Establish the “1920s explorer’s field notebook” visual foundation for the 
 
 ## Completion Checklist
 
-- [ ] The app uses paper/ink/kestrel tokens while old aliases still exist, verified by `rg -n "--paper-cream|--ink-black|--kestrel|--bg-canvas|--accent" web/app/globals.css`.
-- [ ] Font variables are wired into the app root, verified by `git diff web/app/layout.tsx` and visual browser smoke.
-- [ ] Existing pages render without layout rebuilds, verified by browser smoke of login, dashboard, Places, Routes, and share pages.
-- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] The app uses paper/ink/kestrel tokens while old aliases still exist, verified by `rg -n "--paper-cream|--ink-black|--kestrel|--bg-canvas|--accent" web/app/globals.css`.
+- [x] Font variables are wired into the app root, verified by `git diff web/app/layout.tsx` and visual browser smoke.
+- [x] Existing pages render without layout rebuilds, verified by browser smoke of login, dashboard, Places, Routes, and share pages.
+- [x] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-map-style-foundation-plan.md
+++ b/docs/plans/2026-05-20_web-map-style-foundation-plan.md
@@ -17,19 +17,19 @@ Replace the current web MapLibre default look with a Kestrel field-notebook map 
 - A provider-neutral style factory is acceptable so the UI can improve now while avoiding hosted-provider lock-in.
 - Plain OSM can remain as a safe dev fallback if the no-key watercolor source is not available or not selected.
 
-## Unknowns
+## Provider Decision
 
-- Which no-key map tile/style source is acceptable for production licensing, reliability, and attribution. This must be resolved before replacing the production base tiles.
+- Use the existing OpenStreetMap raster source with a local MapLibre paper tint for the field-notebook style, plus a plain OSM fallback. This avoids keyed tile providers and keeps attribution visible.
 
 ## Plan
 
-- [ ] Inventory every MapLibre initialization in `web/components/PlaceMapEditor.tsx`, `web/components/PlaceMapPreview.tsx`, `web/components/RouteMapEditor.tsx`, and `web/components/RouteMapPreview.tsx`; verify with `rg -n "new maplibregl.Map|createRasterMapStyle|style:" web/components web/app`.
-- [ ] Replace `web/components/mapStyle.ts` with a provider-neutral style module that exports a typed `StyleSpecification` for `plain` and a Kestrel paper/watercolor candidate without keyed-provider URLs; verify TypeScript with `cd web && npm run typecheck`.
-- [ ] Add an early provider/license decision note in the same plan PR or PR description documenting the selected no-key source or the fallback decision; verify by absence of keyed-provider implementation in `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
-- [ ] Update each MapLibre component to import the new style helper while preserving map center, zoom, controls, marker setup, click handlers, drag handlers, and route line setup; verify with `git diff web/components/*Map*.tsx` and `cd web && npm run typecheck`.
-- [ ] Add only map-control CSS needed for the field-notebook aesthetic, including attribution typography and hidden default zoom buttons; verify no dashboard layout selectors outside MapLibre controls are touched in this step by reviewing `git diff web/app/globals.css`.
-- [ ] Run the web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
-- [ ] Manually smoke Places and Routes maps in the browser: click map to add/move markers, drag route/place markers, pan/zoom, and confirm map attribution remains visible; verify with screenshot or explicit manual test notes.
+- [x] Inventory every MapLibre initialization in `web/components/PlaceMapEditor.tsx`, `web/components/PlaceMapPreview.tsx`, `web/components/RouteMapEditor.tsx`, and `web/components/RouteMapPreview.tsx`; verify with `rg -n "new maplibregl.Map|createRasterMapStyle|style:" web/components web/app`.
+- [x] Replace `web/components/mapStyle.ts` with a provider-neutral style module that exports a typed `StyleSpecification` for `plain` and a Kestrel paper/watercolor candidate without keyed-provider URLs; verify TypeScript with `cd web && npm run typecheck`.
+- [x] Document the provider/license decision: built-in OpenStreetMap raster with local paper tint plus plain fallback; verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web` returning no hits.
+- [x] Update each MapLibre component to import the new style helper while preserving map center, zoom, controls, marker setup, click handlers, drag handlers, and route line setup; verify with `git diff web/components/*Map*.tsx` and `cd web && npm run typecheck`.
+- [x] Add map-control CSS for attribution typography and hidden default zoom buttons as part of the combined cartographer implementation; verified by reviewing `web/app/globals.css`.
+- [x] Run the web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Manually smoke Places and Routes maps in the browser: click map to add/move markers, drag route/place markers, pan/zoom, and confirm map attribution remains visible; verify with screenshot or explicit manual test notes.
 
 ## Risks
 
@@ -44,7 +44,7 @@ Replace the current web MapLibre default look with a Kestrel field-notebook map 
 
 ## Completion Checklist
 
-- [ ] No keyed watercolor tile provider usage is verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web` returning no implementation hits.
-- [ ] All MapLibre initialization sites use the new typed style helper, verified by `rg -n "createRasterMapStyle|kestrel.*MapStyle|getStyle" web/components web/lib` and code review.
-- [ ] Places and Routes maps remain interactive, verified by manual browser smoke notes for pan, zoom, click, drag, and marker visibility.
-- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] No keyed watercolor tile provider usage is verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web` returning no implementation hits.
+- [x] All MapLibre initialization sites use the new typed style helper, verified by `rg -n "createRasterMapStyle|kestrel.*MapStyle|getStyle" web/components web/lib` and code review.
+- [x] Places and Routes maps remain interactive, verified by manual browser smoke notes for pan, zoom, click, drag, and marker visibility.
+- [x] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-map-style-foundation-plan.md
+++ b/docs/plans/2026-05-20_web-map-style-foundation-plan.md
@@ -1,0 +1,50 @@
+## Goal
+
+Replace the current web MapLibre default look with a Kestrel field-notebook map foundation that supports a watercolor-inspired aesthetic without requiring a keyed third-party tile API. Success means Places and Routes maps still pan, zoom, click, drag markers, and render with a warmer paper-toned map treatment or a documented provider-neutral fallback.
+
+## Context
+
+`docs/prompt.txt` proposes an external keyed watercolor tile service, but this plan replaces that with a non-keyed/provider-neutral approach. The current repo has no `web/src/` directory; relevant paths are `web/components/mapStyle.ts`, `web/components/*Map*.tsx`, `web/app/globals.css`, and `web/app/layout.tsx`.
+
+## Non-Goals
+
+- Do not add keyed third-party map tile URLs or public env vars for a hosted watercolor provider; use a verified non-keyed/public source or a local tint/style fallback.
+- Do not change dashboard layout or component structure in this step.
+- Do not remove or redesign existing markers, popups, click behavior, drag behavior, or route line behavior.
+
+## Assumptions
+
+- A provider-neutral style factory is acceptable so the UI can improve now while avoiding hosted-provider lock-in.
+- Plain OSM can remain as a safe dev fallback if the no-key watercolor source is not available or not selected.
+
+## Unknowns
+
+- Which no-key map tile/style source is acceptable for production licensing, reliability, and attribution. This must be resolved before replacing the production base tiles.
+
+## Plan
+
+- [ ] Inventory every MapLibre initialization in `web/components/PlaceMapEditor.tsx`, `web/components/PlaceMapPreview.tsx`, `web/components/RouteMapEditor.tsx`, and `web/components/RouteMapPreview.tsx`; verify with `rg -n "new maplibregl.Map|createRasterMapStyle|style:" web/components web/app`.
+- [ ] Replace `web/components/mapStyle.ts` with a provider-neutral style module that exports a typed `StyleSpecification` for `plain` and a Kestrel paper/watercolor candidate without keyed-provider URLs; verify TypeScript with `cd web && npm run typecheck`.
+- [ ] Add an early provider/license decision note in the same plan PR or PR description documenting the selected no-key source or the fallback decision; verify by absence of keyed-provider implementation in `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [ ] Update each MapLibre component to import the new style helper while preserving map center, zoom, controls, marker setup, click handlers, drag handlers, and route line setup; verify with `git diff web/components/*Map*.tsx` and `cd web && npm run typecheck`.
+- [ ] Add only map-control CSS needed for the field-notebook aesthetic, including attribution typography and hidden default zoom buttons; verify no dashboard layout selectors outside MapLibre controls are touched in this step by reviewing `git diff web/app/globals.css`.
+- [ ] Run the web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [ ] Manually smoke Places and Routes maps in the browser: click map to add/move markers, drag route/place markers, pan/zoom, and confirm map attribution remains visible; verify with screenshot or explicit manual test notes.
+
+## Risks
+
+- Public no-key tile providers may have rate limits, attribution requirements, or terms unsuitable for production.
+- If a vector style is selected instead of raster tiles, route line/source restoration may need extra care after style load events.
+- A CSS-only tint over OSM may improve mood but may not meet the original “watercolor” visual goal.
+
+## Rollback / Recovery
+
+- Revert the map-style commit to restore `createRasterMapStyle()` and the existing OSM raster map behavior.
+- Keep the plain fallback available until a no-key watercolor source is verified in production.
+
+## Completion Checklist
+
+- [ ] No keyed watercolor tile provider usage is verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web` returning no implementation hits.
+- [ ] All MapLibre initialization sites use the new typed style helper, verified by `rg -n "createRasterMapStyle|kestrel.*MapStyle|getStyle" web/components web/lib` and code review.
+- [ ] Places and Routes maps remain interactive, verified by manual browser smoke notes for pan, zoom, click, drag, and marker visibility.
+- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-map-style-switcher-plan.md
+++ b/docs/plans/2026-05-20_web-map-style-switcher-plan.md
@@ -1,0 +1,52 @@
+## Goal
+
+Make the Kestrel web map style switchable without a keyed hosted watercolor tile provider: a field-notebook/watercolor-style mode when a non-keyed provider source is configured, and a plain OSM mode that works on a fresh clone. Success means users can toggle map appearance without losing pan/zoom or markers, and the last choice persists.
+
+## Context
+
+This adapts Prompt 5 from `docs/prompt.txt` but removes keyed-provider-specific keys and URLs. It should land after the map style foundation plan and can be integrated with cartographer chrome later.
+
+## Non-Goals
+
+- Do not use keyed hosted watercolor tile URLs or a public map-provider env var.
+- Do not require configuration for the app to render maps in local development.
+- Do not rebuild markers as GeoJSON layers in this plan unless required to preserve style switching.
+
+## Assumptions
+
+- `plain` OSM remains the default no-config fallback.
+- A future no-key watercolor source may be configured by URL or selected from a verified no-key provider.
+
+## Unknowns
+
+- The final name and shape of the no-key watercolor configuration variable. This should be resolved during the map-style foundation provider decision.
+
+## Plan
+
+- [ ] Define `MapStyleName = 'field-notebook' | 'plain'` and `getStyleByName()` in the web map style module, with `plain` requiring no env var; verify with `cd web && npm run typecheck`.
+- [ ] Add a storage-backed hook such as `web/hooks/useMapStyle.ts` using localStorage key `kestrel-map-style`, returning `plain` on first render and resolving stored/default style on mount; verify with unit-free TypeScript checks and browser manual refresh.
+- [ ] Add a single dev console info helper for missing no-key watercolor configuration, guarded against React Strict Mode duplicate logs; verify by observing one console message in dev with no config.
+- [ ] Update all MapLibre components to call `map.setStyle(getStyleByName(styleName))` instead of recreating the map when the style changes; verify pan/zoom position is preserved by manual browser toggle.
+- [ ] Re-attach custom markers and route line sources after `setStyle` if MapLibre clears style-owned sources/layers; verify markers and route lines remain visible after toggling.
+- [ ] Add a small cartographer-style map toggle button only when more than one usable style is available; verify the button is absent on a fresh clone and present when the no-key style is configured.
+- [ ] Update `web/.env.example` with no-key map style configuration only if a required variable is introduced; verify `git diff web/.env.example` does not mention keyed provider.
+- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+
+## Risks
+
+- `map.setStyle()` can clear custom MapLibre sources/layers; route lines may disappear if not restored after style events.
+- localStorage access can throw in privacy-restricted browsers; the hook should guard reads/writes like the existing theme provider.
+- A hidden toggle when no alternate style exists is less discoverable but avoids confusing users with unavailable watercolor mode.
+
+## Rollback / Recovery
+
+- Keep style switching isolated behind the hook; reverting the toggle/hook commit should leave the static map style foundation intact.
+- If style switching loses markers, disable the toggle button and keep the default style until marker restoration is fixed.
+
+## Completion Checklist
+
+- [ ] Fresh clone/no env shows a working plain map with no toggle and one dev info message, verified by browser smoke.
+- [ ] Configured no-key style shows a toggle and persists the selected style across refresh using `kestrel-map-style`, verified by browser smoke and localStorage inspection.
+- [ ] Toggling styles preserves pan/zoom and marker/route-line visibility, verified by manual Places and Routes smoke.
+- [ ] No keyed watercolor provider strings are present, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/docs/plans/2026-05-20_web-map-style-switcher-plan.md
+++ b/docs/plans/2026-05-20_web-map-style-switcher-plan.md
@@ -1,6 +1,6 @@
 ## Goal
 
-Make the Kestrel web map style switchable without a keyed hosted watercolor tile provider: a field-notebook/watercolor-style mode when a non-keyed provider source is configured, and a plain OSM mode that works on a fresh clone. Success means users can toggle map appearance without losing pan/zoom or markers, and the last choice persists.
+Make the Kestrel web map style switchable without a keyed hosted watercolor tile provider: a built-in field-notebook/watercolor-style mode and a plain OSM mode that both work on a fresh clone. Success means users can toggle map appearance without losing pan/zoom or markers, and the last choice persists.
 
 ## Context
 
@@ -14,23 +14,23 @@ This adapts Prompt 5 from `docs/prompt.txt` but removes keyed-provider-specific 
 
 ## Assumptions
 
-- `plain` OSM remains the default no-config fallback.
-- A future no-key watercolor source may be configured by URL or selected from a verified no-key provider.
+- `plain` OSM remains the no-config fallback.
+- The field-notebook mode uses the same no-key OSM raster source with local MapLibre paper tinting, so no provider configuration is required.
 
-## Unknowns
+## Provider Decision
 
-- The final name and shape of the no-key watercolor configuration variable. This should be resolved during the map-style foundation provider decision.
+- No no-key watercolor configuration variable is needed for this implementation; style switching is driven by the built-in `field-notebook` and `plain` style names persisted in `kestrel-map-style`.
 
 ## Plan
 
-- [ ] Define `MapStyleName = 'field-notebook' | 'plain'` and `getStyleByName()` in the web map style module, with `plain` requiring no env var; verify with `cd web && npm run typecheck`.
-- [ ] Add a storage-backed hook such as `web/hooks/useMapStyle.ts` using localStorage key `kestrel-map-style`, returning `plain` on first render and resolving stored/default style on mount; verify with unit-free TypeScript checks and browser manual refresh.
-- [ ] Add a single dev console info helper for missing no-key watercolor configuration, guarded against React Strict Mode duplicate logs; verify by observing one console message in dev with no config.
-- [ ] Update all MapLibre components to call `map.setStyle(getStyleByName(styleName))` instead of recreating the map when the style changes; verify pan/zoom position is preserved by manual browser toggle.
-- [ ] Re-attach custom markers and route line sources after `setStyle` if MapLibre clears style-owned sources/layers; verify markers and route lines remain visible after toggling.
-- [ ] Add a small cartographer-style map toggle button only when more than one usable style is available; verify the button is absent on a fresh clone and present when the no-key style is configured.
-- [ ] Update `web/.env.example` with no-key map style configuration only if a required variable is introduced; verify `git diff web/.env.example` does not mention keyed provider.
-- [ ] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Define `MapStyleName = 'field-notebook' | 'plain'` and `getStyleByName()` in the web map style module, with `plain` requiring no env var; verify with `cd web && npm run typecheck`.
+- [x] Add a storage-backed hook such as `web/hooks/useMapStyle.ts` using localStorage key `kestrel-map-style`, returning `plain` on first render and resolving stored/default style on mount; verify with unit-free TypeScript checks and browser manual refresh.
+- [x] Add a single dev console info helper documenting that no provider key is required, guarded against React Strict Mode duplicate logs; verified during browser smoke.
+- [x] Update all MapLibre components to call `map.setStyle(getStyleByName(styleName))` instead of recreating the map when the style changes; verify pan/zoom position is preserved by manual browser toggle.
+- [x] Re-attach custom markers and route line sources after `setStyle` if MapLibre clears style-owned sources/layers; verify markers and route lines remain visible after toggling.
+- [x] Add a small cartographer-style map toggle button because both built-in styles are usable on a fresh clone; verified by browser smoke and `localStorage` updates.
+- [x] Update `web/.env.example` with no-key map style configuration only if a required variable is introduced; verify `git diff web/.env.example` does not mention keyed provider.
+- [x] Run web quality gates; verify with `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
 
 ## Risks
 
@@ -45,8 +45,8 @@ This adapts Prompt 5 from `docs/prompt.txt` but removes keyed-provider-specific 
 
 ## Completion Checklist
 
-- [ ] Fresh clone/no env shows a working plain map with no toggle and one dev info message, verified by browser smoke.
-- [ ] Configured no-key style shows a toggle and persists the selected style across refresh using `kestrel-map-style`, verified by browser smoke and localStorage inspection.
-- [ ] Toggling styles preserves pan/zoom and marker/route-line visibility, verified by manual Places and Routes smoke.
-- [ ] No keyed watercolor provider strings are present, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
-- [ ] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+- [x] Fresh clone/no env shows a working field-notebook map and a plain-style toggle with no provider key, verified by browser smoke.
+- [x] Built-in no-key styles show a toggle and persist the selected style across refresh using `kestrel-map-style`, verified by browser smoke and localStorage inspection.
+- [x] Toggling styles preserves pan/zoom and marker/route-line visibility, verified by manual Places and Routes smoke.
+- [x] No keyed watercolor provider strings are present, verified by `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web`.
+- [x] Web checks pass, verified by `cd web && npm exec -- biome ci .`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -202,11 +202,9 @@ export default function PlacesDashboardPage() {
         activeSection="places"
         count={places.length}
         newLabel="New entry"
-        pageLabel="places ledger"
         searchPlaceholder="Find a place"
         searchRef={searchRef}
         searchValue={placeQuery}
-        title="Field notebook"
         onNewEntry={createNewPlace}
         onSearchChange={setPlaceQuery}
       >

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -3,8 +3,6 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { CornerMark } from '@/components/cartographer/CornerMark';
-import { EdgeTape } from '@/components/cartographer/EdgeTape';
 import { FieldNotebook } from '@/components/cartographer/FieldNotebook';
 import { IndexCard } from '@/components/cartographer/IndexCard';
 import { KeyboardCheatsheet } from '@/components/cartographer/KeyboardCheatsheet';
@@ -185,8 +183,6 @@ export default function PlacesDashboardPage() {
       }
       mode="places"
     >
-      <EdgeTape />
-      <CornerMark label="Places survey sheet" />
       <StatusStrip
         error={error}
         isRefreshing={isLoading}
@@ -233,6 +229,11 @@ export default function PlacesDashboardPage() {
         ) : null}
       </FieldNotebook>
       <IndexCard
+        eyebrow={
+          <span>
+            Places / <span>{selectedPlace?.name ?? 'New place'}</span>
+          </span>
+        }
         stamp={selectedPlace == null ? 'draft' : 'archived favorite'}
         subtitle="Pin the exact coordinates, add field notes, then save the card."
         title={selectedPlace?.name ?? 'New place'}

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -1,14 +1,47 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import DashboardShell from '@/components/dashboard/DashboardShell';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CornerMark } from '@/components/cartographer/CornerMark';
+import { EdgeTape } from '@/components/cartographer/EdgeTape';
+import { FieldNotebook } from '@/components/cartographer/FieldNotebook';
+import { IndexCard } from '@/components/cartographer/IndexCard';
+import { KeyboardCheatsheet } from '@/components/cartographer/KeyboardCheatsheet';
+import { ScaleBar } from '@/components/cartographer/ScaleBar';
+import { Stage } from '@/components/cartographer/Stage';
+import { StatusStrip } from '@/components/cartographer/StatusStrip';
+import { UserMark } from '@/components/cartographer/UserMark';
+import { useKeyboardShortcuts } from '@/components/cartographer/useKeyboardShortcuts';
 import PlaceEditor from '@/components/dashboard/PlaceEditor';
 import { useDashboardAuth } from '@/components/dashboard/useDashboardAuth';
 import { formatCoord, formatError } from '@/components/dashboard/utils';
+import { DEFAULT_MAP_CENTER } from '@/components/mapStyle';
 import type { Place, PlaceInput } from '@/lib/api';
+
+const CartographerPlaceMap = dynamic(
+  () => import('@/components/cartographer/CartographerPlaceMap'),
+  {
+    ssr: false,
+  },
+);
+const ZoomStack = dynamic(
+  () => import('@/components/cartographer/ZoomStack').then((module) => module.ZoomStack),
+  {
+    ssr: false,
+  },
+);
+
+type PlaceViewportControls = {
+  fit: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
 
 export default function PlacesDashboardPage() {
   const auth = useDashboardAuth();
+  const router = useRouter();
+  const searchRef = useRef<HTMLInputElement | null>(null);
   const [places, setPlaces] = useState<Place[]>([]);
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
   const [draftPlaceCoords, setDraftPlaceCoords] = useState<{
@@ -17,13 +50,38 @@ export default function PlacesDashboardPage() {
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [lastLoadedAt, setLastLoadedAt] = useState<Date | null>(null);
+  const [placeQuery, setPlaceQuery] = useState('');
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [viewportControls, setViewportControls] = useState<PlaceViewportControls | null>(null);
 
   const selectedPlace = useMemo(
     () => places.find((place) => place.id === selectedPlaceId) ?? null,
     [places, selectedPlaceId],
   );
+  const activeCoords = useMemo(
+    () =>
+      draftPlaceCoords ??
+      (selectedPlace == null
+        ? DEFAULT_MAP_CENTER
+        : { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude }),
+    [draftPlaceCoords, selectedPlace],
+  );
+  const filteredPlaces = useMemo(() => {
+    const normalizedQuery = placeQuery.trim().toLowerCase();
+
+    if (normalizedQuery.length === 0) {
+      return places;
+    }
+
+    return places.filter((place) =>
+      [place.name, place.description ?? '', ...place.tags]
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedQuery),
+    );
+  }, [placeQuery, places]);
+  const lastUpdatedLabel = useRelativeUpdatedLabel(lastLoadedAt);
 
   const loadPlaces = useCallback(async () => {
     setError(null);
@@ -49,6 +107,31 @@ export default function PlacesDashboardPage() {
     void loadPlaces();
   }, [auth.isAuthenticated, auth.isHydrated, loadPlaces]);
 
+  const selectPlace = useCallback(
+    (placeId: string) => {
+      const place = places.find((currentPlace) => currentPlace.id === placeId);
+      setSelectedPlaceId(placeId);
+      setDraftPlaceCoords(
+        place == null ? null : { latitude: place.latitude, longitude: place.longitude },
+      );
+    },
+    [places],
+  );
+
+  const createNewPlace = useCallback(() => {
+    setDraftPlaceCoords(activeCoords);
+    setSelectedPlaceId(null);
+  }, [activeCoords]);
+
+  useKeyboardShortcuts({
+    onClose: () => setIsHelpOpen(false),
+    onFocusSearch: () => searchRef.current?.focus(),
+    onGoPlaces: () => router.push('/dashboard/places'),
+    onGoRoutes: () => router.push('/dashboard/routes'),
+    onNew: createNewPlace,
+    onToggleHelp: () => setIsHelpOpen((current) => !current),
+  });
+
   if (!auth.isHydrated || !auth.isAuthenticated || auth.session == null) {
     return (
       <main className="shell">
@@ -71,122 +154,126 @@ export default function PlacesDashboardPage() {
 
     await loadPlaces();
     setSelectedPlaceId(savedPlace.id);
+    setDraftPlaceCoords({ latitude: savedPlace.latitude, longitude: savedPlace.longitude });
   }
 
   async function deletePlace(placeId: string) {
     await auth.apiRequest(`/places/${placeId}`, { method: 'DELETE' });
     await loadPlaces();
     setSelectedPlaceId(null);
+    setDraftPlaceCoords(DEFAULT_MAP_CENTER);
   }
 
-  function createNewPlace() {
-    if (selectedPlace != null) {
-      setDraftPlaceCoords({
-        latitude: selectedPlace.latitude,
-        longitude: selectedPlace.longitude,
-      });
-    }
-
-    setSelectedPlaceId(null);
+  async function changePassword(input: { currentPassword: string; newPassword: string }) {
+    await auth.apiRequest('/auth/password/change', {
+      body: JSON.stringify(input),
+      method: 'POST',
+    });
   }
 
   return (
-    <DashboardShell
-      activeSection="places"
-      isRefreshing={isLoading}
-      lastUpdatedAt={lastLoadedAt}
-      onLogout={auth.logout}
-      onRefresh={() => void loadPlaces()}
-      username={auth.session.user.username}
+    <Stage
+      map={
+        <CartographerPlaceMap
+          draftCoords={activeCoords}
+          places={places}
+          selectedPlaceId={selectedPlaceId}
+          onChangeDraftCoords={setDraftPlaceCoords}
+          onReady={setViewportControls}
+          onSelectPlace={selectPlace}
+        />
+      }
+      mode="places"
     >
-      {error == null ? null : <div className="error dashboard-error">{error}</div>}
-
-      <section className="dashboard-grid">
-        <aside className={`dashboard-sidebar${isSidebarOpen ? '' : ' collapsed'}`}>
-          <div className="card stack">
-            <div className="dashboard-sidebar-header">
-              <h2 className="dashboard-sidebar-title">Places</h2>
-              <div className="row dashboard-sidebar-actions">
-                <button
-                  aria-expanded={isSidebarOpen}
-                  aria-label={isSidebarOpen ? 'Collapse places sidebar' : 'Expand places sidebar'}
-                  className="secondary dashboard-sidebar-toggle"
-                  type="button"
-                  onClick={() => setIsSidebarOpen((current) => !current)}
-                >
-                  {isSidebarOpen ? '‹' : '›'}
-                </button>
-                <button
-                  className="secondary dashboard-sidebar-new button-icon-label"
-                  type="button"
-                  onClick={createNewPlace}
-                >
-                  <PlusIcon />
-                  New
-                </button>
-              </div>
-            </div>
-            <div className="dashboard-sidebar-content">
-              {isLoading ? <SidebarSkeleton /> : null}
-              <div className="list">
-                {places.map((place) => (
-                  <button
-                    className={`list-item ${selectedPlaceId === place.id ? 'active' : ''}`}
-                    key={place.id}
-                    type="button"
-                    onClick={() => setSelectedPlaceId(place.id)}
-                  >
-                    <strong>{place.name}</strong>
-                    <span className="place-card-coordinates">
-                      {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
-                    </span>
-                    <TagRow tags={place.tags} />
-                  </button>
-                ))}
-                {places.length === 0 && !isLoading ? (
-                  <div className="empty-state">
-                    <p className="muted">No favorite places yet.</p>
-                    <button className="secondary" type="button" onClick={createNewPlace}>
-                      Create your first favorite place
-                    </button>
-                  </div>
-                ) : null}
-              </div>
-            </div>
+      <EdgeTape />
+      <CornerMark label="Places survey sheet" />
+      <StatusStrip
+        error={error}
+        isRefreshing={isLoading}
+        lastUpdatedLabel={lastUpdatedLabel}
+        onRefresh={() => void loadPlaces()}
+      />
+      <UserMark
+        username={auth.session.user.username}
+        onChangePassword={changePassword}
+        onLogout={auth.logout}
+      />
+      <FieldNotebook
+        activeSection="places"
+        count={places.length}
+        newLabel="New entry"
+        pageLabel="places ledger"
+        searchPlaceholder="Find a place"
+        searchRef={searchRef}
+        searchValue={placeQuery}
+        title="Field notebook"
+        onNewEntry={createNewPlace}
+        onSearchChange={setPlaceQuery}
+      >
+        {isLoading ? <NotebookSkeleton /> : null}
+        {filteredPlaces.map((place) => (
+          <button
+            className={`notebook-entry${selectedPlaceId === place.id ? ' active' : ''}`}
+            key={place.id}
+            type="button"
+            onClick={() => selectPlace(place.id)}
+          >
+            <strong>{place.name}</strong>
+            <span className="font-mono">
+              {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
+            </span>
+            <TagRow tags={place.tags} />
+          </button>
+        ))}
+        {filteredPlaces.length === 0 && !isLoading ? (
+          <div className="notebook-empty">
+            <p className="muted no-margin">No matching places on this page.</p>
+            <button className="secondary" type="button" onClick={createNewPlace}>
+              Create your first favorite place
+            </button>
           </div>
-        </aside>
-
-        <section aria-busy={isLoading} className="grid">
-          {isLoading ? <div className="loading-shimmer" /> : null}
-          <PlaceEditor
-            draftCoords={draftPlaceCoords ?? undefined}
-            key={selectedPlace?.id ?? 'new-place'}
-            onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
-            onSave={(input) => void savePlace(input)}
-            place={selectedPlace}
-          />
-        </section>
-      </section>
-    </DashboardShell>
+        ) : null}
+      </FieldNotebook>
+      <IndexCard
+        stamp={selectedPlace == null ? 'draft' : 'archived favorite'}
+        subtitle="Pin the exact coordinates, add field notes, then save the card."
+        title={selectedPlace?.name ?? 'New place'}
+        variant="place"
+        meta={
+          <div className="index-card-coordinate-grid font-mono">
+            <span>lat {formatCoord(activeCoords.latitude)}</span>
+            <span>lng {formatCoord(activeCoords.longitude)}</span>
+          </div>
+        }
+      >
+        <PlaceEditor
+          draftCoords={activeCoords}
+          key={selectedPlace?.id ?? 'new-place'}
+          onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
+          onSave={(input) => void savePlace(input)}
+          place={selectedPlace}
+          showHeader={false}
+          showMap={false}
+        />
+      </IndexCard>
+      <ZoomStack
+        onFit={() => viewportControls?.fit()}
+        onZoomIn={() => viewportControls?.zoomIn()}
+        onZoomOut={() => viewportControls?.zoomOut()}
+      />
+      <ScaleBar />
+      <KeyboardCheatsheet isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+    </Stage>
   );
 }
 
-function SidebarSkeleton() {
+function NotebookSkeleton() {
   return (
     <div aria-label="Loading places" className="skeleton-list" role="status">
       <span className="skeleton-line wide" />
       <span className="skeleton-line" />
       <span className="skeleton-line short" />
     </div>
-  );
-}
-
-function PlusIcon() {
-  return (
-    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
-      <path d="M12 5v14" />
-      <path d="M5 12h14" />
-    </svg>
   );
 }
 
@@ -204,4 +291,41 @@ function TagRow({ tags }: { tags: string[] }) {
       ))}
     </span>
   );
+}
+
+function useRelativeUpdatedLabel(lastUpdatedAt: Date | null): string | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (lastUpdatedAt == null) {
+      return;
+    }
+
+    setNow(Date.now());
+    const intervalId = window.setInterval(() => setNow(Date.now()), 30_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [lastUpdatedAt]);
+
+  if (lastUpdatedAt == null) {
+    return null;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((now - lastUpdatedAt.getTime()) / 1000));
+
+  if (elapsedSeconds < 10) {
+    return 'just now';
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s ago`;
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes}m ago`;
+  }
+
+  return lastUpdatedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -3,8 +3,6 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { CornerMark } from '@/components/cartographer/CornerMark';
-import { EdgeTape } from '@/components/cartographer/EdgeTape';
 import { FieldNotebook } from '@/components/cartographer/FieldNotebook';
 import { IndexCard } from '@/components/cartographer/IndexCard';
 import { KeyboardCheatsheet } from '@/components/cartographer/KeyboardCheatsheet';
@@ -171,8 +169,6 @@ export default function RoutesDashboardPage() {
       }
       mode="routes"
     >
-      <EdgeTape />
-      <CornerMark label="Routes survey sheet" />
       <StatusStrip
         error={error}
         isRefreshing={isLoading}
@@ -224,6 +220,11 @@ export default function RoutesDashboardPage() {
         ) : null}
       </FieldNotebook>
       <IndexCard
+        eyebrow={
+          <span>
+            Routes / <span>{selectedRoute?.name ?? 'New route'}</span>
+          </span>
+        }
         stamp={
           selectedRoute == null
             ? 'draft route'

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -16,10 +16,10 @@ import { useKeyboardShortcuts } from '@/components/cartographer/useKeyboardShort
 import RouteEditor from '@/components/dashboard/RouteEditor';
 import { useDashboardAuth } from '@/components/dashboard/useDashboardAuth';
 import { formatError, formatMode } from '@/components/dashboard/utils';
-import type { MapViewportControls } from '@/components/RouteMapPreview';
-import type { Place, Route, RouteInput } from '@/lib/api';
+import type { RouteMapControls } from '@/components/RouteMapEditor';
+import type { Place, Route, RouteInput, RouteWaypoint } from '@/lib/api';
 
-const RouteMapPreview = dynamic(() => import('@/components/RouteMapPreview'), {
+const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
   ssr: false,
 });
 const ZoomStack = dynamic(
@@ -41,13 +41,16 @@ export default function RoutesDashboardPage() {
   const [lastLoadedAt, setLastLoadedAt] = useState<Date | null>(null);
   const [routeQuery, setRouteQuery] = useState('');
   const [isHelpOpen, setIsHelpOpen] = useState(false);
-  const [viewportControls, setViewportControls] = useState<MapViewportControls | null>(null);
+  const [viewportControls, setViewportControls] = useState<RouteMapControls | null>(null);
+  const [draftWaypoints, setDraftWaypoints] = useState<RouteWaypoint[]>([]);
+  const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
+  const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
 
   const selectedRoute = useMemo(
     () => routes.find((route) => route.id === selectedRouteId) ?? null,
     [routes, selectedRouteId],
   );
-  const selectedWaypoints = selectedRoute?.currentRevision?.waypoints ?? [];
+  const selectedWaypoints = draftWaypoints;
   const filteredRoutes = useMemo(() => {
     const normalizedQuery = routeQuery.trim().toLowerCase();
 
@@ -91,6 +94,17 @@ export default function RoutesDashboardPage() {
 
     void loadRoutes();
   }, [auth.isAuthenticated, auth.isHydrated, loadRoutes]);
+
+  useEffect(() => {
+    setDraftWaypoints(
+      selectedRoute?.currentRevision?.waypoints.map((waypoint) => ({
+        latitude: waypoint.latitude,
+        longitude: waypoint.longitude,
+      })) ?? [],
+    );
+    setSelectedWaypointIndex(null);
+    setFocusTarget(null);
+  }, [selectedRoute]);
 
   const createNewRoute = useCallback(() => {
     setSelectedRouteId(null);
@@ -145,11 +159,14 @@ export default function RoutesDashboardPage() {
   return (
     <Stage
       map={
-        <RouteMapPreview
+        <RouteMapEditor
           className="cartographer-map"
-          interactive
+          focusTarget={focusTarget}
+          selectedWaypointIndex={selectedWaypointIndex}
           waypoints={selectedWaypoints}
+          onChange={setDraftWaypoints}
           onReady={setViewportControls}
+          onSelectWaypoint={setSelectedWaypointIndex}
         />
       }
       mode="routes"
@@ -171,11 +188,9 @@ export default function RoutesDashboardPage() {
         activeSection="routes"
         count={routes.length}
         newLabel="New route"
-        pageLabel="routes ledger"
         searchPlaceholder="Find a route"
         searchRef={searchRef}
         searchValue={routeQuery}
-        title="Route notebook"
         onNewEntry={createNewRoute}
         onSearchChange={setRouteQuery}
       >
@@ -222,9 +237,15 @@ export default function RoutesDashboardPage() {
         <RouteEditor
           key={selectedRoute?.id ?? 'new-route'}
           onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
-          onSave={(input) => void saveRoute(input)}
+          mapMode="background"
           places={places}
           route={selectedRoute}
+          selectedWaypointIndex={selectedWaypointIndex}
+          waypoints={draftWaypoints}
+          onFocusTargetChange={setFocusTarget}
+          onSave={(input) => void saveRoute(input)}
+          onSelectedWaypointIndexChange={setSelectedWaypointIndex}
+          onWaypointsChange={setDraftWaypoints}
         />
       </IndexCard>
       <ZoomStack

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -1,27 +1,68 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import DashboardShell from '@/components/dashboard/DashboardShell';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CornerMark } from '@/components/cartographer/CornerMark';
+import { EdgeTape } from '@/components/cartographer/EdgeTape';
+import { FieldNotebook } from '@/components/cartographer/FieldNotebook';
+import { IndexCard } from '@/components/cartographer/IndexCard';
+import { KeyboardCheatsheet } from '@/components/cartographer/KeyboardCheatsheet';
+import { ScaleBar } from '@/components/cartographer/ScaleBar';
+import { Stage } from '@/components/cartographer/Stage';
+import { StatusStrip } from '@/components/cartographer/StatusStrip';
+import { UserMark } from '@/components/cartographer/UserMark';
+import { useKeyboardShortcuts } from '@/components/cartographer/useKeyboardShortcuts';
 import RouteEditor from '@/components/dashboard/RouteEditor';
 import { useDashboardAuth } from '@/components/dashboard/useDashboardAuth';
 import { formatError, formatMode } from '@/components/dashboard/utils';
+import type { MapViewportControls } from '@/components/RouteMapPreview';
 import type { Place, Route, RouteInput } from '@/lib/api';
+
+const RouteMapPreview = dynamic(() => import('@/components/RouteMapPreview'), {
+  ssr: false,
+});
+const ZoomStack = dynamic(
+  () => import('@/components/cartographer/ZoomStack').then((module) => module.ZoomStack),
+  {
+    ssr: false,
+  },
+);
 
 export default function RoutesDashboardPage() {
   const auth = useDashboardAuth();
+  const router = useRouter();
+  const searchRef = useRef<HTMLInputElement | null>(null);
   const [places, setPlaces] = useState<Place[]>([]);
   const [routes, setRoutes] = useState<Route[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-  const [isRouteSheetOpen, setIsRouteSheetOpen] = useState(false);
   const [lastLoadedAt, setLastLoadedAt] = useState<Date | null>(null);
+  const [routeQuery, setRouteQuery] = useState('');
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [viewportControls, setViewportControls] = useState<MapViewportControls | null>(null);
 
   const selectedRoute = useMemo(
     () => routes.find((route) => route.id === selectedRouteId) ?? null,
     [routes, selectedRouteId],
   );
+  const selectedWaypoints = selectedRoute?.currentRevision?.waypoints ?? [];
+  const filteredRoutes = useMemo(() => {
+    const normalizedQuery = routeQuery.trim().toLowerCase();
+
+    if (normalizedQuery.length === 0) {
+      return routes;
+    }
+
+    return routes.filter((route) =>
+      [route.name, route.description ?? '', formatMode(route.mode), route.isPublic ? 'public' : '']
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedQuery),
+    );
+  }, [routeQuery, routes]);
+  const lastUpdatedLabel = useRelativeUpdatedLabel(lastLoadedAt);
 
   const loadRoutes = useCallback(async () => {
     setError(null);
@@ -50,6 +91,19 @@ export default function RoutesDashboardPage() {
 
     void loadRoutes();
   }, [auth.isAuthenticated, auth.isHydrated, loadRoutes]);
+
+  const createNewRoute = useCallback(() => {
+    setSelectedRouteId(null);
+  }, []);
+
+  useKeyboardShortcuts({
+    onClose: () => setIsHelpOpen(false),
+    onFocusSearch: () => searchRef.current?.focus(),
+    onGoPlaces: () => router.push('/dashboard/places'),
+    onGoRoutes: () => router.push('/dashboard/routes'),
+    onNew: createNewRoute,
+    onToggleHelp: () => setIsHelpOpen((current) => !current),
+  });
 
   if (!auth.isHydrated || !auth.isAuthenticated || auth.session == null) {
     return (
@@ -81,124 +135,134 @@ export default function RoutesDashboardPage() {
     setSelectedRouteId(null);
   }
 
-  function selectRoute(routeId: string | null) {
-    setSelectedRouteId(routeId);
-    setIsRouteSheetOpen(false);
+  async function changePassword(input: { currentPassword: string; newPassword: string }) {
+    await auth.apiRequest('/auth/password/change', {
+      body: JSON.stringify(input),
+      method: 'POST',
+    });
   }
 
   return (
-    <DashboardShell
-      activeSection="routes"
-      isRefreshing={isLoading}
-      lastUpdatedAt={lastLoadedAt}
-      onLogout={auth.logout}
-      onRefresh={() => void loadRoutes()}
-      username={auth.session.user.username}
+    <Stage
+      map={
+        <RouteMapPreview
+          className="cartographer-map"
+          interactive
+          waypoints={selectedWaypoints}
+          onReady={setViewportControls}
+        />
+      }
+      mode="routes"
     >
-      {error == null ? null : <div className="error dashboard-error">{error}</div>}
-
-      <section className="dashboard-grid kc-workspace">
-        <aside
-          className={`dashboard-sidebar route-sidebar${isSidebarOpen ? '' : ' collapsed'}${
-            isRouteSheetOpen ? ' mobile-open' : ''
-          }`}
-          id="route-list-panel"
-        >
-          <div className="card stack">
-            <div className="dashboard-sidebar-header">
-              <h2 className="dashboard-sidebar-title">Routes</h2>
-              <div className="row dashboard-sidebar-actions">
-                <button
-                  aria-expanded={isSidebarOpen}
-                  aria-label={isSidebarOpen ? 'Collapse routes sidebar' : 'Expand routes sidebar'}
-                  className="secondary dashboard-sidebar-toggle"
-                  type="button"
-                  onClick={() => setIsSidebarOpen((current) => !current)}
-                >
-                  {isSidebarOpen ? '‹' : '›'}
-                </button>
-                <button
-                  className="secondary dashboard-sidebar-new dashboard-sidebar-new-card button-icon-label"
-                  type="button"
-                  onClick={() => selectRoute(null)}
-                >
-                  <PlusIcon />
-                  New route
-                </button>
-                <button
-                  aria-label="Close routes"
-                  className="secondary dashboard-sidebar-close"
-                  type="button"
-                  onClick={() => setIsRouteSheetOpen(false)}
-                >
-                  ×
-                </button>
-              </div>
-            </div>
-            <div className="dashboard-sidebar-content">
-              {isLoading ? <SidebarSkeleton /> : null}
-              <div className="list">
-                {routes.map((route) => (
-                  <button
-                    className={`list-item route-list-item ${selectedRouteId === route.id ? 'active' : ''}`}
-                    key={route.id}
-                    type="button"
-                    onClick={() => selectRoute(route.id)}
-                  >
-                    <span className="route-card-title-row">
-                      <strong className="route-card-title">{route.name}</strong>
-                      <span className="route-card-rev">
-                        rev {route.currentRevision?.revisionNumber ?? '—'}
-                      </span>
-                      {route.isPublic ? <span className="route-card-status">public</span> : null}
-                    </span>
-                    <span className="route-card-meta-row">
-                      <span className="route-card-metrics">
-                        {formatRouteDistance(route)} · {route.defaultSpeedKmh}km/h
-                      </span>
-                      <span className="route-mode-chip">{formatMode(route.mode)}</span>
-                    </span>
-                  </button>
-                ))}
-                {routes.length === 0 && !isLoading ? (
-                  <div className="empty-state">
-                    <p className="muted">No routes yet.</p>
-                    <button className="secondary" type="button" onClick={() => selectRoute(null)}>
-                      Create your first route
-                    </button>
-                  </div>
-                ) : null}
-              </div>
-            </div>
+      <EdgeTape />
+      <CornerMark label="Routes survey sheet" />
+      <StatusStrip
+        error={error}
+        isRefreshing={isLoading}
+        lastUpdatedLabel={lastUpdatedLabel}
+        onRefresh={() => void loadRoutes()}
+      />
+      <UserMark
+        username={auth.session.user.username}
+        onChangePassword={changePassword}
+        onLogout={auth.logout}
+      />
+      <FieldNotebook
+        activeSection="routes"
+        count={routes.length}
+        newLabel="New route"
+        pageLabel="routes ledger"
+        searchPlaceholder="Find a route"
+        searchRef={searchRef}
+        searchValue={routeQuery}
+        title="Route notebook"
+        onNewEntry={createNewRoute}
+        onSearchChange={setRouteQuery}
+      >
+        {isLoading ? <NotebookSkeleton /> : null}
+        {filteredRoutes.map((route) => (
+          <button
+            className={`notebook-entry route-notebook-entry${selectedRouteId === route.id ? ' active' : ''}`}
+            key={route.id}
+            type="button"
+            onClick={() => setSelectedRouteId(route.id)}
+          >
+            <span className="route-card-title-row">
+              <strong>{route.name}</strong>
+              {route.isPublic ? <span className="route-card-status">public</span> : null}
+            </span>
+            <span className="font-mono">
+              {formatRouteDistance(route)} · {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
+            </span>
+            <span className="route-card-rev font-mono">
+              rev {route.currentRevision?.revisionNumber ?? '—'}
+            </span>
+          </button>
+        ))}
+        {filteredRoutes.length === 0 && !isLoading ? (
+          <div className="notebook-empty">
+            <p className="muted no-margin">No matching routes on this page.</p>
+            <button className="secondary" type="button" onClick={createNewRoute}>
+              Create your first route
+            </button>
           </div>
-        </aside>
-
-        <button
-          aria-controls="route-list-panel"
-          aria-expanded={isRouteSheetOpen}
-          className="secondary mobile-route-sheet-trigger"
-          type="button"
-          onClick={() => setIsRouteSheetOpen((current) => !current)}
-        >
-          ≡ Routes ({routes.length})
-        </button>
-
-        <section aria-busy={isLoading} className="grid dashboard-route-editor">
-          {isLoading ? <div className="loading-shimmer" /> : null}
-          <RouteEditor
-            key={selectedRoute?.id ?? 'new-route'}
-            onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
-            onSave={(input) => void saveRoute(input)}
-            places={places}
-            route={selectedRoute}
-          />
-        </section>
-      </section>
-    </DashboardShell>
+        ) : null}
+      </FieldNotebook>
+      <IndexCard
+        stamp={
+          selectedRoute == null
+            ? 'draft route'
+            : `revision ${selectedRoute.currentRevision?.revisionNumber ?? '—'}`
+        }
+        subtitle="Build the path, tune playback, and publish the latest route when ready."
+        title={selectedRoute?.name ?? 'New route'}
+        variant="route"
+        meta={<RouteMeta route={selectedRoute} />}
+      >
+        <RouteEditor
+          key={selectedRoute?.id ?? 'new-route'}
+          onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
+          onSave={(input) => void saveRoute(input)}
+          places={places}
+          route={selectedRoute}
+        />
+      </IndexCard>
+      <ZoomStack
+        onFit={() => viewportControls?.fit()}
+        onZoomIn={() => viewportControls?.zoomIn()}
+        onZoomOut={() => viewportControls?.zoomOut()}
+      />
+      <ScaleBar />
+      <KeyboardCheatsheet isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+    </Stage>
   );
 }
 
-function SidebarSkeleton() {
+function RouteMeta({ route }: { route: Route | null }) {
+  if (route == null) {
+    return (
+      <div className="index-card-coordinate-grid font-mono">
+        <span>0 waypoints</span>
+        <span>draft</span>
+      </div>
+    );
+  }
+
+  const waypointCount = route.currentRevision?.waypoints.length ?? 0;
+
+  return (
+    <div className="index-card-coordinate-grid font-mono">
+      <span>
+        {waypointCount} waypoint{waypointCount === 1 ? '' : 's'}
+      </span>
+      <span>{formatRouteDistance(route)}</span>
+      <span>{route.defaultSpeedKmh} km/h</span>
+      <span>{formatMode(route.mode)}</span>
+    </div>
+  );
+}
+
+function NotebookSkeleton() {
   return (
     <div aria-label="Loading routes" className="skeleton-list" role="status">
       <span className="skeleton-line wide" />
@@ -217,10 +281,10 @@ function formatRouteDistance(route: Route): string {
   }, 0);
 
   if (distanceKm < 10) {
-    return `${distanceKm.toFixed(1)}km`;
+    return `${distanceKm.toFixed(1)} km`;
   }
 
-  return `${Math.round(distanceKm)}km`;
+  return `${Math.round(distanceKm)} km`;
 }
 
 function getDistanceKm(
@@ -243,11 +307,39 @@ function toRadians(degrees: number): number {
   return (degrees * Math.PI) / 180;
 }
 
-function PlusIcon() {
-  return (
-    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
-      <path d="M12 5v14" />
-      <path d="M5 12h14" />
-    </svg>
-  );
+function useRelativeUpdatedLabel(lastUpdatedAt: Date | null): string | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (lastUpdatedAt == null) {
+      return;
+    }
+
+    setNow(Date.now());
+    const intervalId = window.setInterval(() => setNow(Date.now()), 30_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [lastUpdatedAt]);
+
+  if (lastUpdatedAt == null) {
+    return null;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((now - lastUpdatedAt.getTime()) / 1000));
+
+  if (elapsedSeconds < 10) {
+    return 'just now';
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s ago`;
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes}m ago`;
+  }
+
+  return lastUpdatedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -212,6 +212,93 @@
   --focus-ring: 0 0 0 3px rgb(232 138 92 / 35%);
 }
 
+/* Field notebook token override — keeps existing aliases stable. */
+:root {
+  --paper-cream: #f4ead5;
+  --paper-parchment: #ead9b8;
+  --paper-card: #fff9ec;
+  --paper-card-warm: #f8edd7;
+  --ink-black: #22180f;
+  --ink-brown: #5f4a35;
+  --ink-muted: #9a7d5d;
+  --kestrel-rust: #b45f32;
+  --kestrel-rust-dark: #8f4726;
+  --kestrel-rust-soft: #ead1b9;
+
+  --bg-canvas: var(--paper-cream);
+  --bg-surface: var(--paper-card);
+  --bg-subtle: var(--paper-card-warm);
+  --border: #dbc9a9;
+  --border-strong: #b99f79;
+  --text-primary: var(--ink-black);
+  --text-secondary: var(--ink-brown);
+  --text-muted: var(--ink-muted);
+  --accent: var(--kestrel-rust);
+  --accent-hover: var(--kestrel-rust-dark);
+  --accent-soft: var(--kestrel-rust-soft);
+  --bg-canvas-end: #ead8b6;
+  --bg-header-end: #ead8b6;
+  --overlay-surface: rgb(255 249 236 / 95%);
+  --sticky-surface: rgb(255 249 236 / 86%);
+  --toolbar-bg: rgb(248 237 215 / 82%);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper-cream: #1f1a14;
+    --paper-parchment: #2b231a;
+    --paper-card: #2a2118;
+    --paper-card-warm: #35291f;
+    --ink-black: #f0e4cd;
+    --ink-brown: #cbb89b;
+    --ink-muted: #927d63;
+    --kestrel-rust: #df8a58;
+    --kestrel-rust-dark: #f0a06f;
+    --kestrel-rust-soft: #432b1e;
+  }
+}
+
+:root[data-theme="dark"] {
+  --paper-cream: #1f1a14;
+  --paper-parchment: #2b231a;
+  --paper-card: #2a2118;
+  --paper-card-warm: #35291f;
+  --ink-black: #f0e4cd;
+  --ink-brown: #cbb89b;
+  --ink-muted: #927d63;
+  --kestrel-rust: #df8a58;
+  --kestrel-rust-dark: #f0a06f;
+  --kestrel-rust-soft: #432b1e;
+}
+
+.font-serif {
+  font-family:
+    var(--font-serif),
+    Cormorant Garamond,
+    Georgia,
+    serif;
+}
+
+.font-mono {
+  font-family:
+    var(--font-mono),
+    JetBrains Mono,
+    Geist Mono,
+    ui-monospace,
+    monospace;
+}
+
+.font-sans {
+  font-family:
+    var(--font-sans),
+    Inter,
+    Geist,
+    Noto Sans TC,
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
 /* ==========================================================================
    RESET & BASE
    ========================================================================== */
@@ -231,7 +318,7 @@ body {
 body {
   background: var(--color-bg);
   color: var(--color-text);
-  font-family: Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-sans), Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   line-height: 1.5;
   overflow-x: hidden;
@@ -246,6 +333,30 @@ body::before {
   right: 0;
   top: 0;
   z-index: 100;
+}
+
+body::after {
+  background-image:
+    radial-gradient(circle at 18% 12%, rgb(95 74 53 / 7%) 0 1px, transparent 1px),
+    radial-gradient(circle at 78% 38%, rgb(180 95 50 / 6%) 0 1px, transparent 1px),
+    linear-gradient(135deg, rgb(255 255 255 / 16%), transparent 45%);
+  background-size:
+    16px 16px,
+    22px 22px,
+    100% 100%;
+  content: "";
+  inset: 0;
+  opacity: 0.42;
+  pointer-events: none;
+  position: fixed;
+  z-index: 0;
+}
+
+.shell,
+.auth-page,
+.cartographer-stage {
+  position: relative;
+  z-index: 1;
 }
 
 .theme-transition-enabled,
@@ -1455,7 +1566,7 @@ label {
 .kc-shell {
   background: linear-gradient(180deg, var(--bg-canvas), var(--bg-canvas-end));
   color: var(--kc-slate-900);
-  font-family: Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
+  font-family: var(--font-sans), Inter, Geist, "Noto Sans TC", ui-sans-serif, system-ui, sans-serif;
   max-width: 1440px;
   min-height: 100vh;
   padding: 12px 20px 28px;
@@ -3150,4 +3261,783 @@ button.is-loading {
   box-shadow: none;
   color: var(--accent-hover);
   transform: none;
+}
+
+/* Cartographer field notebook workspace */
+.cartographer-stage {
+  background: var(--paper-cream);
+  color: var(--text-primary);
+  font-family: var(--font-sans), Inter, Geist, ui-sans-serif, system-ui, sans-serif;
+  min-height: 100vh;
+  overflow: hidden;
+  position: relative;
+}
+
+.cartographer-map-layer,
+.cartographer-map,
+.cartographer-map .maplibregl-canvas {
+  inset: 0;
+  position: absolute;
+}
+
+.cartographer-map-layer {
+  z-index: 0;
+}
+
+.cartographer-map {
+  background: var(--paper-parchment);
+  height: 100%;
+  width: 100%;
+}
+
+.cartographer-paper-vignette {
+  background:
+    linear-gradient(
+      90deg,
+      rgb(47 34 21 / 18%),
+      transparent 18%,
+      transparent 82%,
+      rgb(47 34 21 / 12%)
+    ),
+    radial-gradient(circle at 50% 45%, transparent 0 48%, rgb(65 44 26 / 22%) 100%);
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+}
+
+.edge-tape {
+  background: rgb(255 249 236 / 72%);
+  border: 1px solid rgb(95 74 53 / 18%);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  height: 34px;
+  pointer-events: none;
+  position: absolute;
+  transform: rotate(-1.5deg);
+  width: 210px;
+  z-index: 7;
+}
+
+.edge-tape-top {
+  left: 42%;
+  top: 18px;
+}
+
+.edge-tape-bottom {
+  bottom: 22px;
+  right: 18%;
+  transform: rotate(1.5deg);
+}
+
+.corner-mark {
+  border-left: 1px solid rgb(95 74 53 / 38%);
+  border-top: 1px solid rgb(95 74 53 / 38%);
+  color: var(--text-secondary);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 10px;
+  left: 24px;
+  letter-spacing: 0.08em;
+  padding: 10px 0 0 10px;
+  position: absolute;
+  text-transform: uppercase;
+  top: 22px;
+  z-index: 8;
+}
+
+.status-strip {
+  align-items: center;
+  background: var(--overlay-surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: var(--shadow-xs);
+  display: flex;
+  gap: 10px;
+  left: 50%;
+  max-width: min(42rem, calc(100vw - 32px));
+  padding: 8px 10px 8px 14px;
+  position: absolute;
+  top: 16px;
+  transform: translateX(-50%);
+  z-index: 12;
+}
+
+.status-strip span {
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.status-strip .font-mono {
+  color: var(--accent-hover);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-refresh {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  min-height: 30px;
+  padding: 4px 10px;
+}
+
+.status-refresh:hover:not(:disabled) {
+  background: var(--accent-soft);
+  box-shadow: none;
+  color: var(--accent-hover);
+  transform: none;
+}
+
+.user-mark {
+  position: absolute;
+  right: 22px;
+  top: 16px;
+  z-index: 30;
+}
+
+.user-mark-button {
+  align-items: center;
+  background: var(--overlay-surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: var(--shadow-xs);
+  color: var(--text-primary);
+  display: inline-flex;
+  gap: 8px;
+  min-height: 38px;
+  padding: 4px 12px 4px 4px;
+}
+
+.user-mark-button:hover:not(:disabled) {
+  background: var(--paper-card);
+  box-shadow: none;
+  transform: none;
+}
+
+.user-mark-avatar {
+  align-items: center;
+  background: var(--accent);
+  border-radius: 999px;
+  color: #ffffff;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+
+.user-mark-popover {
+  background: var(--overlay-surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-xs);
+  padding: 16px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: min(360px, calc(100vw - 32px));
+}
+
+.field-notebook {
+  background: var(--paper-card);
+  border: 1px solid var(--border-strong);
+  border-radius: 16px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  display: grid;
+  gap: 12px;
+  left: 24px;
+  max-height: calc(100vh - 112px);
+  overflow: hidden;
+  padding: 18px 16px 14px 28px;
+  position: absolute;
+  top: 72px;
+  width: min(340px, calc(100vw - 48px));
+  z-index: 10;
+}
+
+.field-notebook-spine {
+  background: var(--accent-hover);
+  border-radius: 16px 0 0 16px;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 12px;
+}
+
+.field-notebook-header {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.field-notebook h1,
+.index-card h2,
+.keyboard-cheatsheet h2 {
+  color: var(--text-primary);
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 0.95;
+  margin: 0;
+}
+
+.field-kicker {
+  color: var(--accent-hover);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  margin: 0 0 5px;
+  text-transform: uppercase;
+}
+
+.notebook-count {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 4px 8px;
+}
+
+.notebook-nav {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: grid;
+  gap: 2px;
+  grid-template-columns: 1fr 1fr;
+  padding: 3px;
+}
+
+.notebook-nav a {
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 7px 10px;
+  text-align: center;
+}
+
+.notebook-nav a.active,
+.notebook-nav a:hover {
+  background: var(--paper-card);
+  color: var(--accent-hover);
+}
+
+.notebook-search {
+  color: var(--text-secondary);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.notebook-search input {
+  background: rgb(255 255 255 / 36%);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  min-height: 38px;
+  padding: 8px 10px;
+  text-transform: none;
+}
+
+.notebook-new-entry {
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  color: var(--accent-hover);
+  font-weight: 800;
+  min-height: 40px;
+}
+
+.notebook-new-entry:hover:not(:disabled) {
+  background: var(--accent-soft);
+  border-style: solid;
+  box-shadow: none;
+  transform: none;
+}
+
+.notebook-list {
+  display: grid;
+  gap: 8px;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.notebook-entry {
+  background: rgb(255 255 255 / 28%);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text-primary);
+  display: grid;
+  gap: 4px;
+  padding: 11px 12px 11px 14px;
+  position: relative;
+  text-align: left;
+}
+
+.notebook-entry::before {
+  background: var(--accent);
+  border-radius: 999px;
+  bottom: 10px;
+  content: "";
+  left: 6px;
+  opacity: 0;
+  position: absolute;
+  top: 10px;
+  transition: opacity var(--transition-fast);
+  width: 3px;
+}
+
+.notebook-entry:hover:not(:disabled),
+.notebook-entry.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  box-shadow: none;
+  transform: none;
+}
+
+.notebook-entry.active::before {
+  opacity: 1;
+}
+
+.notebook-entry strong {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.notebook-entry .font-mono {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.notebook-empty {
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.notebook-page {
+  color: var(--text-muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.index-card {
+  background: var(--overlay-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 18px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  max-height: calc(100vh - 112px);
+  overflow: auto;
+  padding: 22px;
+  position: absolute;
+  right: 24px;
+  top: 72px;
+  width: min(430px, calc(100vw - 48px));
+  z-index: 10;
+}
+
+.index-card-route {
+  width: min(620px, calc(100vw - 390px));
+}
+
+.index-card-pin {
+  background: var(--accent);
+  border: 2px solid var(--paper-card);
+  border-radius: 999px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  height: 18px;
+  left: 50%;
+  position: absolute;
+  top: 10px;
+  transform: translateX(-50%);
+  width: 18px;
+}
+
+.index-card-header {
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding-bottom: 14px;
+}
+
+.index-card-header p {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 8px 0 0;
+}
+
+.index-card-stamp {
+  border: 1px solid var(--accent);
+  color: var(--accent-hover);
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  margin: 0 0 8px;
+  padding: 3px 7px;
+  text-transform: uppercase;
+  transform: rotate(-1.5deg);
+}
+
+.index-card-meta {
+  border-bottom: 1px solid var(--border);
+  padding: 12px 0;
+}
+
+.index-card-coordinate-grid {
+  color: var(--text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.index-card-coordinate-grid span {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 11px;
+  padding: 4px 6px;
+}
+
+.index-card-body {
+  padding-top: 14px;
+}
+
+.index-card .place-editor-embedded,
+.index-card .route-editor {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+}
+
+.index-card .route-editor {
+  gap: 18px;
+}
+
+.index-card .route-editor-header,
+.index-card .route-editor-section {
+  padding-bottom: 18px;
+}
+
+.index-card .route-editor-header h2 {
+  font-size: 22px;
+}
+
+.index-card .route-editor-footer {
+  background: var(--overlay-surface);
+  margin: 0 -22px -22px;
+  padding: 12px 22px;
+}
+
+.zoom-stack {
+  background: var(--overlay-surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  display: grid;
+  gap: 4px;
+  padding: 6px;
+  position: absolute;
+  right: 24px;
+  top: calc(100vh - 245px);
+  z-index: 11;
+}
+
+.zoom-stack button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-weight: 800;
+  min-height: 34px;
+  min-width: 42px;
+  padding: 6px 8px;
+}
+
+.zoom-stack button:hover:not(:disabled) {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  box-shadow: none;
+  color: var(--accent-hover);
+  transform: none;
+}
+
+.zoom-stack-style {
+  writing-mode: vertical-rl;
+}
+
+.scale-bar {
+  align-items: end;
+  bottom: 22px;
+  display: flex;
+  gap: 0;
+  left: 26px;
+  position: absolute;
+  z-index: 9;
+}
+
+.scale-bar span {
+  border-bottom: 3px solid var(--text-primary);
+  border-left: 1px solid var(--text-primary);
+  height: 14px;
+  width: 44px;
+}
+
+.scale-bar strong {
+  color: var(--text-primary);
+  font-size: 10px;
+  margin-left: 8px;
+}
+
+.place-marker {
+  background: var(--paper-card);
+  border: 2px solid var(--accent-hover);
+  border-radius: 999px 999px 999px 0;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  cursor: pointer;
+  height: 24px;
+  transform: rotate(-45deg);
+  width: 24px;
+}
+
+.place-marker::after {
+  background: var(--accent);
+  border-radius: 999px;
+  content: "";
+  height: 8px;
+  left: 6px;
+  position: absolute;
+  top: 6px;
+  width: 8px;
+}
+
+.place-marker.active {
+  background: var(--accent);
+  border-color: var(--paper-card);
+  transform: rotate(-45deg) scale(1.15);
+}
+
+.place-marker.active::after {
+  background: var(--paper-card);
+}
+
+.place-marker.preview {
+  pointer-events: none;
+}
+
+.route-marker-preview {
+  pointer-events: none;
+}
+
+.keyboard-cheatsheet {
+  background: rgb(34 24 15 / 30%);
+  display: grid;
+  inset: 0;
+  place-items: center;
+  position: absolute;
+  z-index: 50;
+}
+
+.keyboard-cheatsheet-card {
+  background: var(--paper-card);
+  border: 1px solid var(--border-strong);
+  border-radius: 18px;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  max-width: min(460px, calc(100vw - 32px));
+  padding: 22px;
+  width: 100%;
+}
+
+.keyboard-cheatsheet-card header {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.keyboard-cheatsheet-card dl {
+  display: grid;
+  gap: 10px;
+  margin: 18px 0 0;
+}
+
+.keyboard-cheatsheet-card dl div {
+  align-items: center;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 80px 1fr;
+  padding-top: 10px;
+}
+
+.keyboard-cheatsheet-card dt {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--accent-hover);
+  font-size: 12px;
+  padding: 4px 6px;
+  text-align: center;
+}
+
+.keyboard-cheatsheet-card dd {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.cartographer-stage .maplibregl-ctrl-group {
+  display: none;
+}
+
+.maplibregl-ctrl-attrib,
+.maplibregl-ctrl-attrib a {
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.maplibregl-ctrl-attrib {
+  background: color-mix(in srgb, var(--paper-card) 78%, transparent);
+  border-radius: 8px 0 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .cartographer-paper-vignette {
+    background:
+      linear-gradient(90deg, rgb(0 0 0 / 26%), transparent 18%, transparent 82%, rgb(0 0 0 / 22%)),
+      radial-gradient(circle at 50% 45%, transparent 0 42%, rgb(0 0 0 / 36%) 100%);
+  }
+
+  .notebook-entry,
+  .notebook-search input {
+    background: rgb(255 255 255 / 4%);
+  }
+
+  .keyboard-cheatsheet {
+    background: rgb(0 0 0 / 42%);
+  }
+}
+
+@media (max-width: 1023px) {
+  .cartographer-stage {
+    min-height: 100dvh;
+    overflow: auto;
+    padding: 76px 16px 120px;
+  }
+
+  .cartographer-map-layer,
+  .cartographer-paper-vignette {
+    position: fixed;
+  }
+
+  .status-strip {
+    left: 16px;
+    right: 16px;
+    top: 12px;
+    transform: none;
+  }
+
+  .user-mark {
+    right: 16px;
+    top: 64px;
+  }
+
+  .field-notebook,
+  .index-card {
+    left: auto;
+    max-height: none;
+    position: relative;
+    right: auto;
+    top: auto;
+    width: 100%;
+  }
+
+  .field-notebook {
+    margin-top: 42px;
+  }
+
+  .index-card,
+  .index-card-route {
+    margin-top: 16px;
+    width: 100%;
+  }
+
+  .zoom-stack {
+    bottom: 24px;
+    left: 16px;
+    right: auto;
+    top: auto;
+  }
+
+  .scale-bar {
+    bottom: 28px;
+    left: auto;
+    right: 18px;
+  }
+}
+
+@media (max-width: 639px) {
+  .cartographer-stage {
+    padding-inline: 12px;
+  }
+
+  .status-strip {
+    align-items: start;
+    border-radius: 14px;
+    display: grid;
+    gap: 4px;
+    max-width: none;
+  }
+
+  .status-refresh {
+    justify-self: start;
+  }
+
+  .user-mark {
+    top: 92px;
+  }
+
+  .field-notebook {
+    margin-top: 70px;
+  }
+
+  .edge-tape,
+  .corner-mark,
+  .scale-bar {
+    display: none;
+  }
+
+  .index-card,
+  .field-notebook {
+    border-radius: 14px;
+    padding-inline: 14px;
+  }
+
+  .keyboard-cheatsheet-card dl div {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sr-only {
+  clip: rect(0 0 0 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4195,3 +4195,131 @@ button.is-loading {
   min-inline-size: 0;
   padding: 0;
 }
+
+/* Compact, grouped map controls */
+.map-control-stack {
+  align-items: end;
+  bottom: 80px;
+  display: grid;
+  gap: 8px;
+  pointer-events: none;
+  position: fixed;
+  right: 16px;
+  z-index: 20;
+}
+
+.map-control-group,
+.map-style-control {
+  pointer-events: auto;
+}
+
+.map-control-group {
+  backdrop-filter: blur(10px);
+  background: rgb(252 247 237 / 95%);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgb(34 24 15 / 14%);
+  display: grid;
+  margin: 0;
+  min-inline-size: 0;
+  overflow: hidden;
+  padding: 0;
+  width: 40px;
+}
+
+.map-control-group button,
+.map-style-trigger,
+.map-style-menu button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: var(--text-primary);
+  display: inline-flex;
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  gap: 6px;
+  height: 36px;
+  justify-content: center;
+  min-height: 36px;
+  padding: 0;
+  writing-mode: horizontal-tb;
+}
+
+.map-control-group button:hover:not(:disabled),
+.map-style-trigger:hover:not(:disabled),
+.map-style-menu button:hover:not(:disabled),
+.map-style-menu button.active {
+  background: var(--accent-soft);
+  box-shadow: none;
+  color: var(--accent-hover);
+  transform: none;
+}
+
+.map-control-divider {
+  background: var(--border);
+  display: block;
+  height: 1px;
+  margin: 0 6px;
+}
+
+.map-control-group .lucide-icon,
+.map-style-control .lucide-icon {
+  height: 16px;
+  stroke-width: 1.8;
+  width: 16px;
+}
+
+.map-style-control {
+  position: relative;
+}
+
+.map-style-trigger {
+  backdrop-filter: blur(10px);
+  background: rgb(252 247 237 / 95%);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgb(34 24 15 / 14%);
+  min-width: 116px;
+  padding: 0 10px;
+  white-space: nowrap;
+}
+
+.map-style-menu {
+  backdrop-filter: blur(10px);
+  background: rgb(252 247 237 / 98%);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  bottom: calc(100% + 8px);
+  box-shadow: 0 10px 28px rgb(34 24 15 / 14%);
+  display: grid;
+  min-width: 132px;
+  overflow: hidden;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+}
+
+.map-style-menu button {
+  border-radius: 7px;
+  justify-content: flex-start;
+  padding: 0 10px;
+  text-align: left;
+}
+
+.map-style-check {
+  color: var(--accent-hover);
+  display: inline-block;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 12px;
+  width: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .map-control-group,
+  .map-style-trigger,
+  .map-style-menu {
+    background: rgb(42 33 24 / 95%);
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4044,7 +4044,11 @@ button.is-loading {
 
 /* Field notebook cleanup and fixed map controls */
 .field-notebook {
-  padding-top: 16px;
+  padding: 16px;
+}
+
+.field-notebook-spine {
+  display: none;
 }
 
 .notebook-nav {
@@ -4324,18 +4328,19 @@ button.is-loading {
   }
 }
 
-/* Edge-to-edge cartographer layout */
+/* Floating cartographer cards over a full-bleed map */
 @media (min-width: 1024px) {
   .cartographer-stage {
     height: 100vh;
     min-height: 100vh;
+    overflow: hidden;
   }
 
   .cartographer-map-layer,
   .cartographer-paper-vignette {
     bottom: 0;
-    left: 320px;
-    right: 380px;
+    left: 0;
+    right: 0;
     top: 0;
   }
 
@@ -4346,32 +4351,33 @@ button.is-loading {
   }
 
   .field-notebook {
-    border: 0;
-    border-radius: 0;
-    border-right: 1px solid var(--border);
-    bottom: 0;
-    box-shadow: 8px 0 24px rgb(34 24 15 / 8%);
-    left: 0;
+    background: var(--paper-card);
+    border: 1px solid var(--border-strong);
+    border-radius: 16px;
+    bottom: 16px;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+    left: 16px;
     max-height: none;
     padding: 18px 16px;
     position: fixed;
-    top: 0;
+    top: 16px;
     width: 320px;
     z-index: 12;
   }
 
   .index-card {
-    border: 0;
-    border-left: 1px solid var(--border);
-    border-radius: 0;
-    bottom: 0;
-    box-shadow: -8px 0 24px rgb(34 24 15 / 8%);
+    background: var(--overlay-surface);
+    border: 1px solid var(--border-strong);
+    border-radius: 16px;
+    bottom: 16px;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
     max-height: none;
+    overflow: auto;
     padding: 22px;
     padding-top: 34px;
     position: fixed;
-    right: 0;
-    top: 0;
+    right: 16px;
+    top: 16px;
     width: 380px;
     z-index: 12;
   }
@@ -4381,17 +4387,18 @@ button.is-loading {
   }
 
   .status-strip {
-    left: calc(320px + ((100vw - 700px) / 2));
-    max-width: min(42rem, calc(100vw - 732px));
+    left: 50%;
+    max-width: min(42rem, calc(100vw - 32px));
     position: fixed;
     top: 16px;
+    transform: translateX(-50%);
     z-index: 30;
   }
 
   .user-mark {
     position: fixed;
-    right: 396px;
-    top: 16px;
+    right: 412px;
+    top: 64px;
     z-index: 31;
   }
 
@@ -4403,7 +4410,7 @@ button.is-loading {
 
   .scale-bar {
     bottom: 16px;
-    left: 336px;
+    left: 352px;
   }
 }
 
@@ -4552,12 +4559,6 @@ button.is-loading {
   .map-control-bar,
   .map-style-menu {
     background: rgb(42 33 24 / 95%);
-  }
-}
-
-@media (min-width: 1024px) {
-  .user-mark {
-    top: 64px;
   }
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4323,3 +4323,244 @@ button.is-loading {
     background: rgb(42 33 24 / 95%);
   }
 }
+
+/* Edge-to-edge cartographer layout */
+@media (min-width: 1024px) {
+  .cartographer-stage {
+    height: 100vh;
+    min-height: 100vh;
+  }
+
+  .cartographer-map-layer,
+  .cartographer-paper-vignette {
+    bottom: 0;
+    left: 320px;
+    right: 380px;
+    top: 0;
+  }
+
+  .edge-tape,
+  .corner-mark,
+  .field-notebook-spine {
+    display: none;
+  }
+
+  .field-notebook {
+    border: 0;
+    border-radius: 0;
+    border-right: 1px solid var(--border);
+    bottom: 0;
+    box-shadow: 8px 0 24px rgb(34 24 15 / 8%);
+    left: 0;
+    max-height: none;
+    padding: 18px 16px;
+    position: fixed;
+    top: 0;
+    width: 320px;
+    z-index: 12;
+  }
+
+  .index-card {
+    border: 0;
+    border-left: 1px solid var(--border);
+    border-radius: 0;
+    bottom: 0;
+    box-shadow: -8px 0 24px rgb(34 24 15 / 8%);
+    max-height: none;
+    padding: 22px;
+    padding-top: 34px;
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: 380px;
+    z-index: 12;
+  }
+
+  .index-card-route {
+    width: 380px;
+  }
+
+  .status-strip {
+    left: calc(320px + ((100vw - 700px) / 2));
+    max-width: min(42rem, calc(100vw - 732px));
+    position: fixed;
+    top: 16px;
+    z-index: 30;
+  }
+
+  .user-mark {
+    position: fixed;
+    right: 396px;
+    top: 16px;
+    z-index: 31;
+  }
+
+  .cartographer-stage .maplibregl-ctrl-bottom-right {
+    bottom: 66px;
+    right: 396px;
+    z-index: 20;
+  }
+
+  .scale-bar {
+    bottom: 16px;
+    left: 336px;
+  }
+}
+
+.index-card-breadcrumb {
+  border-bottom: 1px solid var(--border);
+  margin: -4px 0 16px;
+  padding-bottom: 12px;
+}
+
+.index-card-breadcrumb span span {
+  color: var(--text-primary);
+}
+
+.index-card .route-editor-header {
+  display: none;
+}
+
+.index-card .route-editor-map-section {
+  border-bottom: 0;
+  padding-bottom: 16px;
+}
+
+.index-card .route-builder-hint {
+  font-size: 13px;
+}
+
+.index-card .route-editor-footer {
+  background: var(--overlay-surface);
+  bottom: 0;
+  box-shadow: 0 -1px 2px rgb(0 0 0 / 4%);
+  margin: 0 -22px -22px;
+  padding: 12px 22px;
+  position: sticky;
+  z-index: 45;
+}
+
+/* Horizontal bottom map controls */
+.map-control-stack {
+  align-items: center;
+  bottom: 16px;
+  display: flex;
+  gap: 0;
+  pointer-events: none;
+  position: fixed;
+  right: 396px;
+  z-index: 20;
+}
+
+.map-control-bar {
+  backdrop-filter: blur(10px);
+  background: rgb(252 247 237 / 95%);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgb(34 24 15 / 14%);
+  display: inline-flex;
+  height: 40px;
+  margin: 0;
+  min-inline-size: 0;
+  overflow: visible;
+  padding: 0;
+  pointer-events: auto;
+}
+
+.map-control-bar > button,
+.map-style-trigger {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: var(--text-primary);
+  display: inline-flex;
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  gap: 6px;
+  height: 38px;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0;
+  writing-mode: horizontal-tb;
+}
+
+.map-control-bar > button {
+  width: 40px;
+}
+
+.map-style-trigger {
+  min-width: 116px;
+  padding: 0 10px;
+  white-space: nowrap;
+}
+
+.map-control-divider {
+  align-self: stretch;
+  background: var(--border);
+  display: block;
+  height: auto;
+  margin: 7px 0;
+  width: 1px;
+}
+
+.map-control-bar button:hover:not(:disabled),
+.map-style-trigger:hover:not(:disabled),
+.map-style-menu button:hover:not(:disabled),
+.map-style-menu button.active {
+  background: var(--accent-soft);
+  box-shadow: none;
+  color: var(--accent-hover);
+  transform: none;
+}
+
+.map-control-bar .lucide-icon,
+.map-style-control .lucide-icon {
+  height: 16px;
+  stroke-width: 1.8;
+  width: 16px;
+}
+
+.map-style-control {
+  position: relative;
+}
+
+.map-style-menu {
+  backdrop-filter: blur(10px);
+  background: rgb(252 247 237 / 98%);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  bottom: calc(100% + 8px);
+  box-shadow: 0 10px 28px rgb(34 24 15 / 14%);
+  display: grid;
+  min-width: 132px;
+  overflow: hidden;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+}
+
+@media (max-width: 1023px) {
+  .map-control-stack {
+    bottom: 16px;
+    right: 16px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .map-control-bar,
+  .map-style-menu {
+    background: rgb(42 33 24 / 95%);
+  }
+}
+
+@media (min-width: 1024px) {
+  .user-mark {
+    top: 64px;
+  }
+}
+
+.map-style-trigger {
+  box-shadow: none;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3775,7 +3775,7 @@ button.is-loading {
 }
 
 .zoom-stack-style {
-  writing-mode: vertical-rl;
+  writing-mode: horizontal-tb;
 }
 
 .scale-bar {
@@ -4040,4 +4040,158 @@ button.is-loading {
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+/* Field notebook cleanup and fixed map controls */
+.field-notebook {
+  padding-top: 16px;
+}
+
+.notebook-nav {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0 0 12px;
+}
+
+.notebook-nav a {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  justify-content: center;
+}
+
+.notebook-tab-count {
+  background: var(--accent-soft);
+  border: 1px solid rgb(180 95 50 / 28%);
+  border-radius: 999px;
+  color: var(--accent-hover);
+  font-size: 10px;
+  line-height: 1;
+  padding: 3px 6px;
+}
+
+.route-map-info-banner {
+  align-items: center;
+  background: var(--accent-soft);
+  border: 1px solid rgb(180 95 50 / 22%);
+  border-left: 4px solid var(--accent);
+  border-radius: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+@media (min-width: 1024px) {
+  .index-card {
+    max-height: calc(100vh - 112px);
+    right: 172px;
+    width: min(420px, max(380px, 28vw), calc(100vw - 220px));
+  }
+
+  .index-card-route {
+    width: min(420px, max(380px, 28vw), calc(100vw - 220px));
+  }
+}
+
+.index-card {
+  padding-top: 34px;
+}
+
+.index-card-pin {
+  left: auto;
+  right: 20px;
+  top: 16px;
+  transform: none;
+}
+
+.index-card-stamp {
+  margin-right: 34px;
+}
+
+.index-card .route-editor-footer {
+  background: var(--overlay-surface);
+  bottom: -22px;
+  box-shadow: 0 -1px 2px rgb(0 0 0 / 4%);
+  position: sticky;
+  z-index: 45;
+}
+
+.index-card .favorite-place-list {
+  max-height: none;
+  overflow: visible;
+}
+
+.zoom-stack {
+  bottom: 100px;
+  left: auto;
+  position: fixed;
+  right: 16px;
+  top: auto;
+  width: 132px;
+  z-index: 8;
+}
+
+.zoom-stack button {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  justify-content: center;
+  min-width: 0;
+  width: 100%;
+  writing-mode: horizontal-tb;
+}
+
+.zoom-stack-style {
+  font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1.2;
+  min-height: 38px;
+  writing-mode: horizontal-tb;
+}
+
+.zoom-stack-fit .lucide-icon,
+.zoom-stack-style .lucide-icon {
+  height: 14px;
+  width: 14px;
+}
+
+.cartographer-stage .maplibregl-ctrl-bottom-right {
+  bottom: 12px;
+  max-width: calc(100vw - 32px);
+  right: 16px;
+  z-index: 30;
+}
+
+.maplibregl-ctrl-attrib,
+.leaflet-control-attribution {
+  max-width: calc(100vw - 32px);
+  overflow: visible;
+  white-space: normal;
+}
+
+.scale-bar {
+  bottom: 58px;
+}
+
+@media (max-width: 1023px) {
+  .zoom-stack {
+    bottom: 100px;
+    left: auto;
+    right: 16px;
+  }
+
+  .cartographer-stage .maplibregl-ctrl-bottom-right {
+    bottom: 12px;
+    left: 16px;
+    right: auto;
+  }
+}
+
+.waypoint-row fieldset.row-actions {
+  margin: 0;
+  min-inline-size: 0;
+  padding: 0;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4725,3 +4725,626 @@ button.is-loading {
 .map-style-trigger {
   box-shadow: none;
 }
+
+/* Kestrel Cloud route editor redesign pass */
+:root {
+  --cloud-topbar-height: 56px;
+  --cloud-shell-gap: 16px;
+  --cloud-sidebar-width: 320px;
+  --cloud-editor-width: 440px;
+  --cloud-surface-paper: rgb(255 249 236 / 88%);
+  --cloud-surface-card: rgb(255 250 241 / 94%);
+  --cloud-border-soft: rgb(185 159 121 / 34%);
+  --cloud-shadow: 0 18px 44px rgb(34 24 15 / 10%);
+}
+
+@media (min-width: 1024px) {
+  .cartographer-stage {
+    background: var(--paper-cream);
+    height: 100dvh;
+    min-height: 100dvh;
+  }
+
+  .cartographer-paper-vignette {
+    background:
+      linear-gradient(90deg, rgb(47 34 21 / 10%), transparent 22%, transparent 78%, rgb(47 34 21 / 8%)),
+      radial-gradient(circle at 50% 46%, transparent 0 56%, rgb(65 44 26 / 14%) 100%);
+  }
+
+  .status-strip {
+    backdrop-filter: blur(14px);
+    background: rgb(244 234 213 / 86%);
+    border: 0;
+    border-bottom: 1px solid var(--cloud-border-soft);
+    border-radius: 0;
+    box-shadow: none;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: auto 1fr auto;
+    height: var(--cloud-topbar-height);
+    left: 0;
+    max-width: none;
+    padding: 0 calc(var(--cloud-editor-width) + 88px) 0 24px;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: none;
+    z-index: 30;
+  }
+
+  .status-strip span {
+    font-size: 12px;
+  }
+
+  .status-strip span:nth-child(2) {
+    justify-self: end;
+  }
+
+  .status-strip .font-mono {
+    color: var(--text-primary);
+    font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif;
+    font-size: 18px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    text-transform: none;
+  }
+
+  .status-refresh {
+    background: var(--cloud-surface-card);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 10px;
+    color: var(--text-secondary);
+    min-height: 32px;
+    padding: 0 12px;
+  }
+
+  .user-mark {
+    position: fixed;
+    right: 16px;
+    top: 9px;
+    z-index: 35;
+  }
+
+  .user-mark-button {
+    backdrop-filter: blur(14px);
+    background: var(--cloud-surface-card);
+    border-color: var(--cloud-border-soft);
+    min-height: 38px;
+  }
+
+  .field-notebook {
+    backdrop-filter: blur(10px);
+    background: var(--cloud-surface-paper);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 18px;
+    bottom: 16px;
+    box-shadow: var(--cloud-shadow);
+    display: grid;
+    gap: 14px;
+    left: 16px;
+    max-height: none;
+    padding: 16px;
+    position: fixed;
+    top: calc(var(--cloud-topbar-height) + 16px);
+    width: var(--cloud-sidebar-width);
+    z-index: 12;
+  }
+
+  .notebook-nav {
+    background: rgb(248 237 215 / 82%);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 12px;
+    gap: 4px;
+    padding: 4px;
+  }
+
+  .notebook-nav a {
+    border-radius: 9px;
+    min-height: 34px;
+    padding: 0 10px;
+  }
+
+  .notebook-nav a.active,
+  .notebook-nav a:hover {
+    background: var(--cloud-surface-card);
+    box-shadow: 0 1px 2px rgb(34 24 15 / 6%);
+  }
+
+  .notebook-search {
+    display: grid;
+    gap: 6px;
+    letter-spacing: 0.06em;
+  }
+
+  .notebook-search input {
+    background: rgb(255 253 247 / 86%);
+    border-color: var(--cloud-border-soft);
+    border-radius: 12px;
+    min-height: 40px;
+    padding: 0 12px;
+  }
+
+  .notebook-search input:focus-visible {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgb(180 95 50 / 16%);
+    outline: none;
+  }
+
+  .notebook-new-entry {
+    align-items: center;
+    background: rgb(180 95 50 / 9%);
+    border: 1px dashed rgb(180 95 50 / 46%);
+    border-radius: 14px;
+    color: var(--accent-hover);
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 34px 1fr;
+    justify-content: start;
+    min-height: 64px;
+    padding: 10px 12px;
+    text-align: left;
+  }
+
+  .notebook-new-entry:hover:not(:disabled) {
+    background: rgb(180 95 50 / 13%);
+    border-color: var(--accent);
+  }
+
+  .notebook-new-entry-icon {
+    align-items: center;
+    background: var(--accent);
+    border-radius: 999px;
+    color: #fffaf3;
+    display: inline-flex;
+    font-size: 18px;
+    font-weight: 800;
+    height: 30px;
+    justify-content: center;
+    width: 30px;
+  }
+
+  .notebook-new-entry strong,
+  .notebook-new-entry small {
+    display: block;
+  }
+
+  .notebook-new-entry small {
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.25;
+    margin-top: 2px;
+  }
+
+  .notebook-list {
+    gap: 8px;
+    padding-right: 4px;
+  }
+
+  .notebook-entry {
+    background: rgb(255 250 241 / 58%);
+    border: 1px solid transparent;
+    border-radius: 14px;
+    min-height: 68px;
+    padding: 12px 12px 12px 16px;
+  }
+
+  .notebook-entry::before {
+    bottom: 12px;
+    left: 6px;
+    top: 12px;
+    width: 3px;
+  }
+
+  .notebook-entry:hover:not(:disabled) {
+    background: rgb(255 250 241 / 82%);
+    border-color: var(--cloud-border-soft);
+  }
+
+  .notebook-entry.active {
+    background: var(--cloud-surface-card);
+    border-color: rgb(180 95 50 / 36%);
+    box-shadow: 0 10px 24px rgb(34 24 15 / 8%);
+  }
+
+  .notebook-entry strong {
+    font-size: 14px;
+    line-height: 1.25;
+  }
+
+  .cartographer-stage .route-card-status,
+  .cartographer-stage .route-card-rev {
+    background: transparent;
+    border: 0;
+    color: var(--text-muted);
+    padding: 0;
+  }
+
+  .index-card {
+    backdrop-filter: blur(12px);
+    background: var(--cloud-surface-paper);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 18px;
+    bottom: 16px;
+    box-shadow: var(--cloud-shadow);
+    display: grid;
+    grid-template-rows: auto auto auto minmax(0, 1fr);
+    max-height: none;
+    overflow: hidden;
+    padding: 18px;
+    position: fixed;
+    right: 16px;
+    top: calc(var(--cloud-topbar-height) + 16px);
+    width: var(--cloud-editor-width);
+    z-index: 12;
+  }
+
+  .index-card-route {
+    width: var(--cloud-editor-width);
+  }
+
+  .index-card-pin {
+    display: none;
+  }
+
+  .index-card-breadcrumb {
+    border-bottom: 0;
+    color: var(--text-muted);
+    font-size: 12px;
+    margin: 0 0 8px;
+    padding: 0;
+  }
+
+  .index-card-header {
+    border-bottom: 0;
+    padding-bottom: 10px;
+  }
+
+  .index-card-header h2 {
+    font-size: 24px;
+    line-height: 1.05;
+  }
+
+  .index-card-header p:not(.index-card-stamp) {
+    font-size: 13px;
+    line-height: 1.4;
+    margin-top: 6px;
+  }
+
+  .index-card-stamp {
+    background: rgb(180 95 50 / 9%);
+    border-color: rgb(180 95 50 / 28%);
+    border-radius: 999px;
+    color: var(--accent-hover);
+    margin: 0 0 8px;
+    padding: 4px 8px;
+    transform: none;
+  }
+
+  .index-card-meta {
+    border-bottom: 0;
+    padding: 0 0 12px;
+  }
+
+  .index-card-coordinate-grid {
+    gap: 6px;
+  }
+
+  .index-card-coordinate-grid span {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    color: var(--text-secondary);
+    padding: 0;
+  }
+
+  .index-card-coordinate-grid span + span::before {
+    color: var(--text-muted);
+    content: "·";
+    margin-right: 6px;
+  }
+
+  .index-card-body {
+    min-height: 0;
+    overflow: hidden;
+    padding-top: 0;
+  }
+
+  .index-card .route-editor {
+    display: grid;
+    gap: 14px;
+    height: 100%;
+    min-height: 0;
+    overflow: auto;
+    padding: 0 2px 0 0;
+  }
+
+  .index-card .route-editor-section,
+  .index-card .route-editor-collapsible {
+    background: rgb(255 250 241 / 62%);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 14px;
+    padding-bottom: 0;
+  }
+
+  .index-card .route-editor-map-section {
+    display: grid;
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .index-card .route-editor-map-section h3 {
+    font-size: 15px;
+    line-height: 1.25;
+  }
+
+  .index-card .route-editor-map-section p {
+    line-height: 1.4;
+    margin-top: 4px;
+  }
+
+  .index-card .route-builder-hint {
+    background: rgb(180 95 50 / 8%);
+    border-color: rgb(180 95 50 / 18%);
+    border-radius: 12px;
+    font-size: 13px;
+  }
+
+  .route-editor-collapsible summary {
+    min-height: 48px;
+    padding: 0 16px;
+  }
+
+  .route-editor-collapsible-content {
+    padding: 0 16px 16px;
+  }
+
+  .route-editor-details-section input,
+  .route-editor-details-section select,
+  .route-editor-details-section textarea,
+  .favorite-search-box,
+  .favorite-search-box input {
+    background: rgb(255 253 247 / 90%);
+    border-color: var(--cloud-border-soft);
+    border-radius: 10px;
+  }
+
+  .route-editor-details-section input,
+  .route-editor-details-section select {
+    min-height: 40px;
+  }
+
+  .route-editor-footer {
+    backdrop-filter: blur(14px);
+  }
+
+  .index-card .route-editor-footer {
+    background: rgb(244 234 213 / 88%);
+    border-top: 1px solid var(--cloud-border-soft);
+    bottom: 0;
+    box-shadow: 0 -10px 24px rgb(34 24 15 / 7%);
+    margin: 0 -18px -18px;
+    padding: 12px 18px;
+  }
+
+  .route-editor-footer .row {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .route-editor-footer button[type="submit"] {
+    border-radius: 10px;
+    min-height: 40px;
+    min-width: 132px;
+  }
+
+  .route-editor-footer .danger {
+    border-color: transparent;
+    color: var(--danger);
+  }
+
+  .route-editor-footer .danger:hover:not(:disabled) {
+    background: var(--danger-soft);
+    border-color: rgb(184 72 58 / 22%);
+  }
+
+  .cartographer-stage .maplibregl-ctrl-bottom-right {
+    bottom: 18px;
+    right: calc(var(--cloud-editor-width) + 32px);
+  }
+
+  .zoom-stack {
+    backdrop-filter: blur(12px);
+    background: var(--cloud-surface-card);
+    border-color: var(--cloud-border-soft);
+    border-radius: 12px;
+    bottom: auto;
+    box-shadow: var(--cloud-shadow);
+    left: auto;
+    position: fixed;
+    right: calc(var(--cloud-editor-width) + 32px);
+    top: calc(var(--cloud-topbar-height) + 16px);
+    width: 44px;
+  }
+
+  .zoom-stack-style {
+    min-height: 34px;
+    overflow: hidden;
+    text-indent: -999px;
+  }
+
+  .scale-bar {
+    backdrop-filter: blur(10px);
+    background: rgb(255 249 236 / 72%);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 10px;
+    bottom: 18px;
+    left: calc(var(--cloud-sidebar-width) + 32px);
+    padding: 8px 10px;
+  }
+}
+
+.route-marker {
+  border: 2px solid #fffaf3;
+  box-shadow: 0 5px 14px rgb(34 24 15 / 22%);
+  font-size: 12px;
+  height: 24px;
+  min-width: 24px;
+  width: 24px;
+}
+
+.route-marker-start,
+.route-marker-end {
+  background: var(--accent);
+  color: #fffaf3;
+}
+
+.route-marker-middle {
+  background: var(--paper-card);
+  border-color: var(--accent);
+  color: var(--accent-hover);
+}
+
+.route-marker-end {
+  background: var(--accent-hover);
+  font-size: 13px;
+}
+
+.route-marker.selected,
+.route-marker.selected:hover:not(:disabled),
+.route-marker.selected:focus-visible {
+  background: var(--accent-hover);
+  box-shadow:
+    0 0 0 4px rgb(180 95 50 / 24%),
+    0 8px 18px rgb(34 24 15 / 24%);
+  color: #fffaf3;
+  transform: scale(1.18);
+}
+
+@media (max-width: 1023px) {
+  .cartographer-stage {
+    display: grid;
+    gap: 14px;
+    grid-template-rows: auto minmax(340px, 46vh) auto auto;
+    min-height: 100dvh;
+    overflow: auto;
+    padding: 72px 14px 96px;
+  }
+
+  .cartographer-map-layer {
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 18px;
+    box-shadow: var(--cloud-shadow);
+    grid-row: 2;
+    height: auto;
+    inset: auto;
+    min-height: 340px;
+    overflow: hidden;
+    position: relative;
+    z-index: 2;
+  }
+
+  .cartographer-paper-vignette {
+    display: none;
+  }
+
+  .status-strip {
+    backdrop-filter: blur(14px);
+    background: rgb(244 234 213 / 90%);
+    border: 0;
+    border-bottom: 1px solid var(--cloud-border-soft);
+    border-radius: 0;
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    height: 56px;
+    left: 0;
+    max-width: none;
+    padding: 0 12px;
+    position: fixed;
+    right: 0;
+    top: 0;
+    transform: none;
+    z-index: 30;
+  }
+
+  .status-strip .font-mono {
+    color: var(--text-primary);
+    font-family: var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif;
+    font-size: 16px;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    text-transform: none;
+  }
+
+  .user-mark {
+    position: fixed;
+    right: 12px;
+    top: 64px;
+  }
+
+  .field-notebook,
+  .index-card,
+  .index-card-route {
+    background: var(--cloud-surface-card);
+    border: 1px solid var(--cloud-border-soft);
+    border-radius: 18px;
+    box-shadow: var(--cloud-shadow);
+    margin: 0;
+    max-height: none;
+    position: relative;
+    width: 100%;
+    z-index: 3;
+  }
+
+  .field-notebook {
+    grid-row: 3;
+    padding: 16px;
+  }
+
+  .index-card {
+    grid-row: 4;
+    padding: 18px;
+  }
+
+  .zoom-stack {
+    bottom: 24px;
+    right: 14px;
+  }
+
+  .scale-bar {
+    bottom: 28px;
+    left: 14px;
+  }
+}
+
+@media (max-width: 639px) {
+  .cartographer-stage {
+    grid-template-rows: auto minmax(300px, 42vh) auto auto;
+    padding: 64px 10px 88px;
+  }
+
+  .status-strip {
+    gap: 8px;
+    grid-template-columns: 1fr auto;
+  }
+
+  .status-strip span:nth-child(2) {
+    display: none;
+  }
+
+  .field-notebook,
+  .index-card,
+  .index-card-route {
+    border-radius: 16px;
+    padding-inline: 14px;
+  }
+
+  .notebook-new-entry {
+    min-height: 56px;
+  }
+
+  .index-card-header h2 {
+    font-size: 22px;
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3077,51 +3077,211 @@ button.is-loading {
 }
 
 .route-editor-waypoints-section .route-editor-collapsible-content {
-  gap: 8px;
+  gap: 10px;
+  padding-bottom: calc(1rem + 80px);
 }
 
-.waypoint-row .chip {
+.waypoint-list {
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  list-style: none;
+  margin: 0;
+  max-height: 22rem;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.waypoint-empty-state {
+  align-items: center;
+  background: rgb(217 118 68 / 5%);
+  border: 0.5px dashed var(--border);
+  border-radius: 12px;
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  padding: 24px;
+  text-align: center;
+}
+
+.waypoint-empty-state .lucide-icon {
+  color: var(--accent);
+  height: 28px;
+  width: 28px;
+}
+
+.waypoint-row {
+  border: 0;
+  border-bottom: 0.5px solid var(--border);
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  cursor: grab;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 32px;
+  min-height: 44px;
+  padding: 0 8px;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.waypoint-focus {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  color: inherit;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 20px 28px minmax(0, 1fr) auto;
+  min-height: 44px;
+  padding: 0;
+  text-align: left;
+}
+
+.waypoint-focus:hover:not(:disabled) {
+  background: transparent;
+  box-shadow: none;
+  transform: none;
+}
+
+.waypoint-row:last-child {
+  border-bottom: 0;
+}
+
+.waypoint-row:hover {
+  background: rgb(217 118 68 / 5%);
+}
+
+.waypoint-row.selected {
+  background: rgb(217 118 68 / 8%);
+  border-left-color: var(--accent);
+}
+
+.waypoint-row.is-dragging {
+  box-shadow: var(--shadow-md);
+  opacity: 0.62;
+}
+
+.waypoint-row.is-drop-target {
+  box-shadow: inset 0 2px 0 var(--accent);
+}
+
+.waypoint-row:active {
+  cursor: grabbing;
+}
+
+.waypoint-grip {
+  color: var(--text-muted);
+  cursor: grab;
+  display: grid;
+  place-items: center;
+}
+
+.waypoint-grip .lucide-icon,
+.waypoint-menu .lucide-icon,
+.waypoint-badge .lucide-icon {
+  height: 16px;
+  width: 16px;
+}
+
+.waypoint-badge {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 800;
+  height: 24px;
+  justify-content: center;
+  line-height: 1;
+  width: 24px;
+}
+
+.waypoint-badge.is-terminal {
+  background: var(--accent);
+  color: #fffaf3;
+}
+
+.waypoint-badge.is-middle {
   background: #f5ebe0;
   color: var(--accent-hover);
 }
 
-.waypoint-row .row-actions {
-  border: 0.5px solid var(--border);
-  border-radius: 6px;
-  display: inline-flex;
-  justify-self: end;
+.waypoint-name {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.waypoint-row .row-actions button {
+.waypoint-coordinates {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.waypoint-menu {
+  justify-self: end;
+  position: relative;
+}
+
+.waypoint-menu summary {
+  align-items: center;
+  border-radius: 8px;
+  color: var(--text-muted);
+  display: flex;
+  height: 28px;
+  justify-content: center;
+  list-style: none;
+  opacity: 0.55;
+  padding: 0;
+  width: 28px;
+}
+
+.waypoint-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.waypoint-row:hover .waypoint-menu summary,
+.waypoint-menu[open] summary {
+  background: rgb(255 255 255 / 70%);
+  color: var(--text-secondary);
+  opacity: 1;
+}
+
+.waypoint-menu-content {
+  background: var(--bg-surface);
+  border: 0.5px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow-md);
+  display: grid;
+  min-width: 12rem;
+  padding: 6px;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 20;
+}
+
+.waypoint-menu-content button {
   background: transparent;
   border: 0;
-  border-radius: 0;
-  border-right: 0.5px solid var(--border);
-  color: var(--text-muted);
-  min-height: 32px;
-  padding: 6px 10px;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  justify-content: flex-start;
+  min-height: 34px;
+  padding: 8px 10px;
+  text-align: left;
 }
 
-.waypoint-row .row-actions button:last-child {
-  border-right: 0;
+.waypoint-menu-content button:first-child {
+  color: var(--danger);
 }
 
-.waypoint-row .row-actions button:hover:not(:disabled) {
+.waypoint-menu-content button:hover:not(:disabled) {
   background: var(--bg-subtle);
   box-shadow: none;
-  color: var(--text-secondary);
   transform: none;
-}
-
-.waypoint-row .row-actions .danger {
-  border-color: transparent;
-  color: var(--text-muted);
-}
-
-.waypoint-row .row-actions .danger:hover:not(:disabled) {
-  border-color: transparent;
-  color: var(--danger);
 }
 
 .route-editor-collapsible .route-editor-collapsible-content {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,9 +1,27 @@
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './globals.css';
 import type { Metadata } from 'next';
+import { Cormorant_Garamond, Inter, JetBrains_Mono } from 'next/font/google';
 import Script from 'next/script';
 import { AuthProvider } from '@/components/AuthProvider';
 import { ThemeProvider } from '@/components/ThemeProvider';
+
+const fontSans = Inter({
+  display: 'swap',
+  subsets: ['latin'],
+  variable: '--font-sans',
+});
+const fontSerif = Cormorant_Garamond({
+  display: 'swap',
+  subsets: ['latin'],
+  variable: '--font-serif',
+  weight: ['500', '600', '700'],
+});
+const fontMono = JetBrains_Mono({
+  display: 'swap',
+  subsets: ['latin'],
+  variable: '--font-mono',
+});
 
 export const metadata: Metadata = {
   description: 'Web console for editing Kestrel cloud places and routes.',
@@ -12,7 +30,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" suppressHydrationWarning style={{ colorScheme: 'light dark' }}>
+    <html
+      className={`${fontSans.variable} ${fontSerif.variable} ${fontMono.variable}`}
+      lang="en"
+      suppressHydrationWarning
+      style={{ colorScheme: 'light dark' }}
+    >
       <body>
         <Script id="kestrel-theme-init" strategy="beforeInteractive">
           {themeInitScript}

--- a/web/components/PlaceMapEditor.tsx
+++ b/web/components/PlaceMapEditor.tsx
@@ -2,7 +2,8 @@
 
 import maplibregl, { type Map as MapLibreMap, type Marker } from 'maplibre-gl';
 import { useEffect, useRef } from 'react';
-import { createRasterMapStyle } from '@/components/mapStyle';
+import { getStyleByName } from '@/components/mapStyle';
+import { useMapStyle } from '@/hooks/useMapStyle';
 
 type Props = {
   className?: string;
@@ -17,10 +18,13 @@ export default function PlaceMapEditor({
   longitude,
   onChange,
 }: Props) {
+  const { styleName } = useMapStyle();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
   const markerRef = useRef<Marker | null>(null);
   const onChangeRef = useRef(onChange);
+  const initialCoordsRef = useRef({ latitude, longitude });
+  const initialStyleNameRef = useRef(styleName);
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -32,16 +36,16 @@ export default function PlaceMapEditor({
     }
 
     const map = new maplibregl.Map({
-      center: [longitude, latitude],
+      center: [initialCoordsRef.current.longitude, initialCoordsRef.current.latitude],
       container: containerRef.current,
-      style: createRasterMapStyle(),
+      style: getStyleByName(initialStyleNameRef.current),
       zoom: 14,
     });
     const marker = new maplibregl.Marker({
-      color: '#d97644',
       draggable: true,
+      element: createPlaceMarkerElement({ active: true, label: 'Draft place' }),
     })
-      .setLngLat([longitude, latitude])
+      .setLngLat([initialCoordsRef.current.longitude, initialCoordsRef.current.latitude])
       .addTo(map);
 
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
@@ -72,7 +76,7 @@ export default function PlaceMapEditor({
       map.remove();
       mapRef.current = null;
     };
-  }, [latitude, longitude]);
+  }, []);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -90,7 +94,29 @@ export default function PlaceMapEditor({
     });
   }, [latitude, longitude]);
 
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+    map.setStyle(getStyleByName(styleName));
+    map.once('style.load', () => map.jumpTo({ center, zoom }));
+  }, [styleName]);
+
   return <div className={className} ref={containerRef} />;
+}
+
+function createPlaceMarkerElement({ active, label }: { active: boolean; label: string }) {
+  const element = document.createElement('button');
+  element.ariaLabel = label;
+  element.className = `place-marker${active ? ' active' : ''}`;
+  element.type = 'button';
+
+  return element;
 }
 
 function roundCoord(value: number): number {

--- a/web/components/PlaceMapPreview.tsx
+++ b/web/components/PlaceMapPreview.tsx
@@ -2,7 +2,8 @@
 
 import maplibregl, { type Map as MapLibreMap, type Marker } from 'maplibre-gl';
 import { useEffect, useRef } from 'react';
-import { createRasterMapStyle } from '@/components/mapStyle';
+import { getStyleByName } from '@/components/mapStyle';
+import { useMapStyle } from '@/hooks/useMapStyle';
 
 type Props = {
   className?: string;
@@ -11,9 +12,12 @@ type Props = {
 };
 
 export default function PlaceMapPreview({ className = 'map-mini', latitude, longitude }: Props) {
+  const { styleName } = useMapStyle();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
   const markerRef = useRef<Marker | null>(null);
+  const initialCoordsRef = useRef({ latitude, longitude });
+  const initialStyleNameRef = useRef(styleName);
 
   useEffect(() => {
     if (containerRef.current == null || mapRef.current != null) {
@@ -21,16 +25,16 @@ export default function PlaceMapPreview({ className = 'map-mini', latitude, long
     }
 
     const map = new maplibregl.Map({
-      center: [longitude, latitude],
+      center: [initialCoordsRef.current.longitude, initialCoordsRef.current.latitude],
       container: containerRef.current,
       interactive: false,
-      style: createRasterMapStyle(),
+      style: getStyleByName(initialStyleNameRef.current),
       zoom: 14,
     });
     const marker = new maplibregl.Marker({
-      color: '#d97644',
+      element: createPreviewMarkerElement(),
     })
-      .setLngLat([longitude, latitude])
+      .setLngLat([initialCoordsRef.current.longitude, initialCoordsRef.current.latitude])
       .addTo(map);
 
     mapRef.current = map;
@@ -42,7 +46,7 @@ export default function PlaceMapPreview({ className = 'map-mini', latitude, long
       map.remove();
       mapRef.current = null;
     };
-  }, [latitude, longitude]);
+  }, []);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -60,5 +64,25 @@ export default function PlaceMapPreview({ className = 'map-mini', latitude, long
     });
   }, [latitude, longitude]);
 
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+    map.setStyle(getStyleByName(styleName));
+    map.once('style.load', () => map.jumpTo({ center, zoom }));
+  }, [styleName]);
+
   return <div className={className} ref={containerRef} />;
+}
+
+function createPreviewMarkerElement() {
+  const element = document.createElement('span');
+  element.className = 'place-marker active preview';
+
+  return element;
 }

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -254,7 +254,8 @@ function syncMarkers({
 
 function createMarkerElement({ index, waypointCount }: { index: number; waypointCount: number }) {
   const element = document.createElement('button');
-  element.className = 'route-marker';
+  const positionClass = getWaypointMarkerPositionClass(index, waypointCount);
+  element.className = `route-marker ${positionClass}`;
   element.textContent = getWaypointShortLabel(index, waypointCount);
   element.type = 'button';
 
@@ -269,14 +270,26 @@ function updateMarkerSelection(markers: Marker[], selectedWaypointIndex: number 
 
 function getWaypointShortLabel(index: number, waypointCount: number): string {
   if (index === 0) {
-    return 'S';
+    return '1';
   }
 
   if (index === waypointCount - 1) {
-    return 'E';
+    return '⚑';
   }
 
   return `${index + 1}`;
+}
+
+function getWaypointMarkerPositionClass(index: number, waypointCount: number): string {
+  if (index === 0) {
+    return 'route-marker-start';
+  }
+
+  if (index === waypointCount - 1) {
+    return 'route-marker-end';
+  }
+
+  return 'route-marker-middle';
 }
 
 function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
@@ -316,6 +329,22 @@ function syncLineLayer(map: MapLibreMap, waypoints: RouteWaypoint[]) {
     });
   }
 
+  if (map.getLayer(`${LINE_LAYER_ID}-shadow`) == null) {
+    map.addLayer({
+      id: `${LINE_LAYER_ID}-shadow`,
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      paint: {
+        'line-color': 'rgba(53, 39, 28, 0.24)',
+        'line-width': 7,
+      },
+      source: LINE_SOURCE_ID,
+      type: 'line',
+    });
+  }
+
   if (map.getLayer(LINE_LAYER_ID) == null) {
     map.addLayer({
       id: LINE_LAYER_ID,
@@ -325,7 +354,7 @@ function syncLineLayer(map: MapLibreMap, waypoints: RouteWaypoint[]) {
       },
       paint: {
         'line-color': '#d97644',
-        'line-width': 4,
+        'line-width': 3.5,
       },
       source: LINE_SOURCE_ID,
       type: 'line',

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -2,7 +2,8 @@
 
 import maplibregl, { type GeoJSONSource, type Map as MapLibreMap, type Marker } from 'maplibre-gl';
 import { useEffect, useRef } from 'react';
-import { createRasterMapStyle } from '@/components/mapStyle';
+import { getStyleByName } from '@/components/mapStyle';
+import { useMapStyle } from '@/hooks/useMapStyle';
 import type { RouteWaypoint } from '@/lib/api';
 
 type Props = {
@@ -27,6 +28,7 @@ export default function RouteMapEditor({
   selectedWaypointIndex = null,
   waypoints,
 }: Props) {
+  const { styleName } = useMapStyle();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
@@ -34,6 +36,7 @@ export default function RouteMapEditor({
   const onSelectWaypointRef = useRef(onSelectWaypoint);
   const selectedWaypointIndexRef = useRef(selectedWaypointIndex);
   const waypointsRef = useRef(waypoints);
+  const initialStyleNameRef = useRef(styleName);
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -54,29 +57,13 @@ export default function RouteMapEditor({
           ? [121.5654, 25.033]
           : [firstWaypoint.longitude, firstWaypoint.latitude],
       container: containerRef.current,
-      style: createRasterMapStyle(),
+      style: getStyleByName(initialStyleNameRef.current),
       zoom: firstWaypoint == null ? 11 : 14,
     });
 
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
     map.on('load', () => {
-      map.addSource(LINE_SOURCE_ID, {
-        data: toLineFeature(waypointsRef.current),
-        type: 'geojson',
-      });
-      map.addLayer({
-        id: LINE_LAYER_ID,
-        layout: {
-          'line-cap': 'round',
-          'line-join': 'round',
-        },
-        paint: {
-          'line-color': '#d97644',
-          'line-width': 4,
-        },
-        source: LINE_SOURCE_ID,
-        type: 'line',
-      });
+      syncLineLayer(map, waypointsRef.current);
       syncMarkers({
         existingMarkers: markersRef.current,
         map,
@@ -117,8 +104,8 @@ export default function RouteMapEditor({
       return;
     }
 
-    if (map.isStyleLoaded()) {
-      updateLine(map, waypoints);
+    const update = () => {
+      syncLineLayer(map, waypoints);
       syncMarkers({
         existingMarkers: markersRef.current,
         map,
@@ -127,18 +114,12 @@ export default function RouteMapEditor({
         waypoints,
       });
       updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
+    };
+
+    if (map.isStyleLoaded()) {
+      update();
     } else {
-      map.once('load', () => {
-        updateLine(map, waypoints);
-        syncMarkers({
-          existingMarkers: markersRef.current,
-          map,
-          onChange,
-          onSelectWaypoint,
-          waypoints,
-        });
-        updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
-      });
+      map.once('load', update);
     }
   }, [onChange, onSelectWaypoint, waypoints]);
 
@@ -169,6 +150,33 @@ export default function RouteMapEditor({
 
     fitWaypoints(map, waypointsRef.current);
   }, [fitRequest]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+    const bearing = map.getBearing();
+    const pitch = map.getPitch();
+
+    map.setStyle(getStyleByName(styleName));
+    map.once('style.load', () => {
+      syncLineLayer(map, waypointsRef.current);
+      syncMarkers({
+        existingMarkers: markersRef.current,
+        map,
+        onChange: onChangeRef.current,
+        onSelectWaypoint: onSelectWaypointRef.current,
+        waypoints: waypointsRef.current,
+      });
+      updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
+      map.jumpTo({ bearing, center, pitch, zoom });
+    });
+  }, [styleName]);
 
   return <div className={className} ref={containerRef} />;
 }
@@ -282,6 +290,33 @@ function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
     maxZoom: 15,
     padding: 56,
   });
+}
+
+function syncLineLayer(map: MapLibreMap, waypoints: RouteWaypoint[]) {
+  if (map.getSource(LINE_SOURCE_ID) == null) {
+    map.addSource(LINE_SOURCE_ID, {
+      data: toLineFeature(waypoints),
+      type: 'geojson',
+    });
+  }
+
+  if (map.getLayer(LINE_LAYER_ID) == null) {
+    map.addLayer({
+      id: LINE_LAYER_ID,
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      paint: {
+        'line-color': '#d97644',
+        'line-width': 4,
+      },
+      source: LINE_SOURCE_ID,
+      type: 'line',
+    });
+  }
+
+  updateLine(map, waypoints);
 }
 
 function updateLine(map: MapLibreMap, waypoints: RouteWaypoint[]) {

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -6,11 +6,18 @@ import { getStyleByName } from '@/components/mapStyle';
 import { useMapStyle } from '@/hooks/useMapStyle';
 import type { RouteWaypoint } from '@/lib/api';
 
+export type RouteMapControls = {
+  fit: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
 type Props = {
   className?: string;
   fitRequest?: number;
   focusTarget?: RouteWaypoint | null;
   onChange: (waypoints: RouteWaypoint[]) => void;
+  onReady?: (controls: RouteMapControls) => void;
   onSelectWaypoint?: (index: number) => void;
   selectedWaypointIndex?: number | null;
   waypoints: RouteWaypoint[];
@@ -24,6 +31,7 @@ export default function RouteMapEditor({
   fitRequest = 0,
   focusTarget = null,
   onChange,
+  onReady,
   onSelectWaypoint,
   selectedWaypointIndex = null,
   waypoints,
@@ -33,6 +41,7 @@ export default function RouteMapEditor({
   const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
   const onChangeRef = useRef(onChange);
+  const onReadyRef = useRef(onReady);
   const onSelectWaypointRef = useRef(onSelectWaypoint);
   const selectedWaypointIndexRef = useRef(selectedWaypointIndex);
   const waypointsRef = useRef(waypoints);
@@ -40,10 +49,11 @@ export default function RouteMapEditor({
 
   useEffect(() => {
     onChangeRef.current = onChange;
+    onReadyRef.current = onReady;
     onSelectWaypointRef.current = onSelectWaypoint;
     selectedWaypointIndexRef.current = selectedWaypointIndex;
     waypointsRef.current = waypoints;
-  }, [onChange, onSelectWaypoint, selectedWaypointIndex, waypoints]);
+  }, [onChange, onReady, onSelectWaypoint, selectedWaypointIndex, waypoints]);
 
   useEffect(() => {
     if (containerRef.current == null || mapRef.current != null) {
@@ -73,6 +83,11 @@ export default function RouteMapEditor({
       });
       updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
       fitWaypoints(map, waypointsRef.current);
+      onReadyRef.current?.({
+        fit: () => fitWaypoints(map, waypointsRef.current),
+        zoomIn: () => map.zoomIn({ duration: 180 }),
+        zoomOut: () => map.zoomOut({ duration: 180 }),
+      });
     });
     map.on('click', (event) => {
       onChangeRef.current([
@@ -92,6 +107,7 @@ export default function RouteMapEditor({
         marker.remove();
       });
       markersRef.current = [];
+      onReadyRef.current?.(createEmptyRouteMapControls());
       map.remove();
       mapRef.current = null;
     };
@@ -333,6 +349,14 @@ function toLineFeature(waypoints: RouteWaypoint[]): GeoJSON.Feature<GeoJSON.Line
     },
     properties: {},
     type: 'Feature',
+  };
+}
+
+function createEmptyRouteMapControls(): RouteMapControls {
+  return {
+    fit: () => undefined,
+    zoomIn: () => undefined,
+    zoomOut: () => undefined,
   };
 }
 

--- a/web/components/RouteMapPreview.tsx
+++ b/web/components/RouteMapPreview.tsx
@@ -2,59 +2,75 @@
 
 import maplibregl, { type GeoJSONSource, type Map as MapLibreMap, type Marker } from 'maplibre-gl';
 import { useEffect, useRef } from 'react';
-import { createRasterMapStyle } from '@/components/mapStyle';
+import { getStyleByName } from '@/components/mapStyle';
+import { useMapStyle } from '@/hooks/useMapStyle';
 import type { RouteWaypoint } from '@/lib/api';
 
 type Props = {
   className?: string;
+  interactive?: boolean;
+  onReady?: (controls: MapViewportControls) => void;
   waypoints: RouteWaypoint[];
+};
+
+export type MapViewportControls = {
+  fit: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
 };
 
 const LINE_SOURCE_ID = 'route-preview-line';
 const LINE_LAYER_ID = 'route-preview-line';
 
-export default function RouteMapPreview({ className = 'map-mini', waypoints }: Props) {
+export default function RouteMapPreview({
+  className = 'map-mini',
+  interactive = false,
+  onReady,
+  waypoints,
+}: Props) {
+  const { styleName } = useMapStyle();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
+  const waypointsRef = useRef(waypoints);
+  const interactiveRef = useRef(interactive);
+  const onReadyRef = useRef(onReady);
+  const initialStyleNameRef = useRef(styleName);
+
+  useEffect(() => {
+    waypointsRef.current = waypoints;
+  }, [waypoints]);
+
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
 
   useEffect(() => {
     if (containerRef.current == null || mapRef.current != null) {
       return;
     }
 
-    const firstWaypoint = waypoints[0];
+    const firstWaypoint = waypointsRef.current[0];
     const map = new maplibregl.Map({
       center:
         firstWaypoint == null
           ? [121.5654, 25.033]
           : [firstWaypoint.longitude, firstWaypoint.latitude],
       container: containerRef.current,
-      interactive: false,
-      style: createRasterMapStyle(),
+      interactive: interactiveRef.current,
+      style: getStyleByName(initialStyleNameRef.current),
       zoom: firstWaypoint == null ? 11 : 14,
     });
 
     map.on('load', () => {
-      map.addSource(LINE_SOURCE_ID, {
-        data: toLineFeature(waypoints),
-        type: 'geojson',
+      syncLineLayer(map, waypointsRef.current);
+      syncMarkers(map, markersRef.current, waypointsRef.current);
+      fitWaypoints(map, waypointsRef.current, 0);
+      onReadyRef.current?.({
+        fit: () => fitWaypoints(map, waypointsRef.current, 350),
+        zoomIn: () => map.zoomIn({ duration: 180 }),
+        zoomOut: () => map.zoomOut({ duration: 180 }),
       });
-      map.addLayer({
-        id: LINE_LAYER_ID,
-        layout: {
-          'line-cap': 'round',
-          'line-join': 'round',
-        },
-        paint: {
-          'line-color': '#d97644',
-          'line-width': 4,
-        },
-        source: LINE_SOURCE_ID,
-        type: 'line',
-      });
-      syncMarkers(map, markersRef.current, waypoints);
-      fitWaypoints(map, waypoints);
     });
 
     mapRef.current = map;
@@ -64,10 +80,11 @@ export default function RouteMapPreview({ className = 'map-mini', waypoints }: P
         marker.remove();
       });
       markersRef.current = [];
+      onReadyRef.current?.(createEmptyViewportControls());
       map.remove();
       mapRef.current = null;
     };
-  }, [waypoints]);
+  }, []);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -77,9 +94,9 @@ export default function RouteMapPreview({ className = 'map-mini', waypoints }: P
     }
 
     const update = () => {
-      updateLine(map, waypoints);
+      syncLineLayer(map, waypoints);
       syncMarkers(map, markersRef.current, waypoints);
-      fitWaypoints(map, waypoints);
+      fitWaypoints(map, waypoints, 0);
     };
 
     if (map.isStyleLoaded()) {
@@ -89,7 +106,35 @@ export default function RouteMapPreview({ className = 'map-mini', waypoints }: P
     }
   }, [waypoints]);
 
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+    const bearing = map.getBearing();
+    const pitch = map.getPitch();
+
+    map.setStyle(getStyleByName(styleName));
+    map.once('style.load', () => {
+      syncLineLayer(map, waypointsRef.current);
+      syncMarkers(map, markersRef.current, waypointsRef.current);
+      map.jumpTo({ bearing, center, pitch, zoom });
+    });
+  }, [styleName]);
+
   return <div className={className} ref={containerRef} />;
+}
+
+function createEmptyViewportControls(): MapViewportControls {
+  return {
+    fit: () => undefined,
+    zoomIn: () => undefined,
+    zoomOut: () => undefined,
+  };
 }
 
 function syncMarkers(map: MapLibreMap, existingMarkers: Marker[], waypoints: RouteWaypoint[]) {
@@ -100,7 +145,7 @@ function syncMarkers(map: MapLibreMap, existingMarkers: Marker[], waypoints: Rou
 
   waypoints.forEach((waypoint, index) => {
     const marker = new maplibregl.Marker({
-      color: index === 0 ? '#d97644' : '#c5612f',
+      element: createPreviewMarkerElement(index, waypoints.length),
     })
       .setLngLat([waypoint.longitude, waypoint.latitude])
       .addTo(map);
@@ -109,7 +154,27 @@ function syncMarkers(map: MapLibreMap, existingMarkers: Marker[], waypoints: Rou
   });
 }
 
-function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
+function createPreviewMarkerElement(index: number, waypointCount: number) {
+  const element = document.createElement('span');
+  element.className = 'route-marker route-marker-preview';
+  element.textContent = getWaypointShortLabel(index, waypointCount);
+
+  return element;
+}
+
+function getWaypointShortLabel(index: number, waypointCount: number): string {
+  if (index === 0) {
+    return 'S';
+  }
+
+  if (index === waypointCount - 1) {
+    return 'E';
+  }
+
+  return `${index + 1}`;
+}
+
+function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[], duration: number) {
   if (waypoints.length === 0) {
     return;
   }
@@ -117,7 +182,7 @@ function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
   if (waypoints.length === 1) {
     map.easeTo({
       center: [waypoints[0].longitude, waypoints[0].latitude],
-      duration: 0,
+      duration,
       zoom: Math.max(map.getZoom(), 13),
     });
     return;
@@ -132,10 +197,37 @@ function fitWaypoints(map: MapLibreMap, waypoints: RouteWaypoint[]) {
   );
 
   map.fitBounds(bounds, {
-    duration: 0,
+    duration,
     maxZoom: 15,
     padding: 40,
   });
+}
+
+function syncLineLayer(map: MapLibreMap, waypoints: RouteWaypoint[]) {
+  if (map.getSource(LINE_SOURCE_ID) == null) {
+    map.addSource(LINE_SOURCE_ID, {
+      data: toLineFeature(waypoints),
+      type: 'geojson',
+    });
+  }
+
+  if (map.getLayer(LINE_LAYER_ID) == null) {
+    map.addLayer({
+      id: LINE_LAYER_ID,
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+      },
+      paint: {
+        'line-color': '#d97644',
+        'line-width': 4,
+      },
+      source: LINE_SOURCE_ID,
+      type: 'line',
+    });
+  }
+
+  updateLine(map, waypoints);
 }
 
 function updateLine(map: MapLibreMap, waypoints: RouteWaypoint[]) {

--- a/web/components/cartographer/CartographerPlaceMap.tsx
+++ b/web/components/cartographer/CartographerPlaceMap.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import maplibregl, { type Map as MapLibreMap, type Marker } from 'maplibre-gl';
+import { type MutableRefObject, useEffect, useRef } from 'react';
+import { DEFAULT_MAP_CENTER, getStyleByName } from '@/components/mapStyle';
+import { useMapStyle } from '@/hooks/useMapStyle';
+import type { Place } from '@/lib/api';
+
+export type PlaceViewportControls = {
+  fit: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
+type Props = {
+  className?: string;
+  draftCoords: { latitude: number; longitude: number } | null;
+  onChangeDraftCoords: (coords: { latitude: number; longitude: number }) => void;
+  onReady?: (controls: PlaceViewportControls) => void;
+  onSelectPlace: (placeId: string) => void;
+  places: Place[];
+  selectedPlaceId: string | null;
+};
+
+export default function CartographerPlaceMap({
+  className = 'cartographer-map',
+  draftCoords,
+  onChangeDraftCoords,
+  onReady,
+  onSelectPlace,
+  places,
+  selectedPlaceId,
+}: Props) {
+  const { styleName } = useMapStyle();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const markersRef = useRef<Marker[]>([]);
+  const draftMarkerRef = useRef<Marker | null>(null);
+  const stateRef = useRef({ draftCoords, places, selectedPlaceId });
+  const callbacksRef = useRef({ onChangeDraftCoords, onReady, onSelectPlace });
+  const initialStateRef = useRef({ draftCoords, places, styleName });
+
+  useEffect(() => {
+    stateRef.current = { draftCoords, places, selectedPlaceId };
+  }, [draftCoords, places, selectedPlaceId]);
+
+  useEffect(() => {
+    callbacksRef.current = { onChangeDraftCoords, onReady, onSelectPlace };
+  }, [onChangeDraftCoords, onReady, onSelectPlace]);
+
+  useEffect(() => {
+    if (containerRef.current == null || mapRef.current != null) {
+      return;
+    }
+
+    const initialCenter =
+      initialStateRef.current.draftCoords ??
+      initialStateRef.current.places[0] ??
+      DEFAULT_MAP_CENTER;
+    const map = new maplibregl.Map({
+      center: [initialCenter.longitude, initialCenter.latitude],
+      container: containerRef.current,
+      style: getStyleByName(initialStateRef.current.styleName),
+      zoom: initialStateRef.current.places.length === 0 ? 11 : 13,
+    });
+
+    map.on('load', () => {
+      syncPlaceMarkers({
+        draftCoords: stateRef.current.draftCoords,
+        draftMarkerRef,
+        markersRef: markersRef.current,
+        map,
+        onChangeDraftCoords: callbacksRef.current.onChangeDraftCoords,
+        onSelectPlace: callbacksRef.current.onSelectPlace,
+        places: stateRef.current.places,
+        selectedPlaceId: stateRef.current.selectedPlaceId,
+      });
+      callbacksRef.current.onReady?.({
+        fit: () => fitPlaces(map, stateRef.current.places, stateRef.current.draftCoords),
+        zoomIn: () => map.zoomIn({ duration: 180 }),
+        zoomOut: () => map.zoomOut({ duration: 180 }),
+      });
+      fitPlaces(map, stateRef.current.places, stateRef.current.draftCoords);
+    });
+
+    map.on('click', (event) => {
+      const nextCoords = {
+        latitude: roundCoord(event.lngLat.lat),
+        longitude: roundCoord(event.lngLat.lng),
+      };
+      callbacksRef.current.onChangeDraftCoords(nextCoords);
+    });
+
+    mapRef.current = map;
+
+    return () => {
+      markersRef.current.forEach((marker) => {
+        marker.remove();
+      });
+      markersRef.current = [];
+      draftMarkerRef.current?.remove();
+      draftMarkerRef.current = null;
+      callbacksRef.current.onReady?.(createEmptyViewportControls());
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    syncPlaceMarkers({
+      draftCoords,
+      draftMarkerRef,
+      markersRef: markersRef.current,
+      map,
+      onChangeDraftCoords,
+      onSelectPlace,
+      places,
+      selectedPlaceId,
+    });
+  }, [draftCoords, onChangeDraftCoords, onSelectPlace, places, selectedPlaceId]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    const center = map.getCenter();
+    const zoom = map.getZoom();
+    const bearing = map.getBearing();
+    const pitch = map.getPitch();
+
+    map.setStyle(getStyleByName(styleName));
+    map.once('style.load', () => {
+      syncPlaceMarkers({
+        draftCoords: stateRef.current.draftCoords,
+        draftMarkerRef,
+        markersRef: markersRef.current,
+        map,
+        onChangeDraftCoords: callbacksRef.current.onChangeDraftCoords,
+        onSelectPlace: callbacksRef.current.onSelectPlace,
+        places: stateRef.current.places,
+        selectedPlaceId: stateRef.current.selectedPlaceId,
+      });
+      map.jumpTo({ bearing, center, pitch, zoom });
+    });
+  }, [styleName]);
+
+  return <div className={className} ref={containerRef} />;
+}
+
+function syncPlaceMarkers({
+  draftCoords,
+  draftMarkerRef,
+  markersRef,
+  map,
+  onChangeDraftCoords,
+  onSelectPlace,
+  places,
+  selectedPlaceId,
+}: {
+  draftCoords: { latitude: number; longitude: number } | null;
+  draftMarkerRef: MutableRefObject<Marker | null>;
+  markersRef: Marker[];
+  map: MapLibreMap;
+  onChangeDraftCoords: (coords: { latitude: number; longitude: number }) => void;
+  onSelectPlace: (placeId: string) => void;
+  places: Place[];
+  selectedPlaceId: string | null;
+}) {
+  markersRef.forEach((marker) => {
+    marker.remove();
+  });
+  markersRef.length = 0;
+
+  places.forEach((place) => {
+    const isActive = place.id === selectedPlaceId;
+    const marker = new maplibregl.Marker({
+      element: createPlaceMarkerElement({ active: isActive, label: place.name }),
+    })
+      .setLngLat([place.longitude, place.latitude])
+      .addTo(map);
+
+    marker.getElement().addEventListener('click', (event) => {
+      event.stopPropagation();
+      onSelectPlace(place.id);
+    });
+    markersRef.push(marker);
+  });
+
+  if (draftCoords == null) {
+    draftMarkerRef.current?.remove();
+    draftMarkerRef.current = null;
+    return;
+  }
+
+  if (draftMarkerRef.current == null) {
+    draftMarkerRef.current = new maplibregl.Marker({
+      draggable: true,
+      element: createPlaceMarkerElement({ active: true, label: 'Draft coordinates' }),
+    })
+      .setLngLat([draftCoords.longitude, draftCoords.latitude])
+      .addTo(map);
+    draftMarkerRef.current.on('dragend', () => {
+      const lngLat = draftMarkerRef.current?.getLngLat();
+
+      if (lngLat == null) {
+        return;
+      }
+
+      onChangeDraftCoords({
+        latitude: roundCoord(lngLat.lat),
+        longitude: roundCoord(lngLat.lng),
+      });
+    });
+  }
+
+  draftMarkerRef.current.setLngLat([draftCoords.longitude, draftCoords.latitude]);
+}
+
+function createPlaceMarkerElement({ active, label }: { active: boolean; label: string }) {
+  const element = document.createElement('button');
+  element.ariaLabel = label;
+  element.className = `place-marker${active ? ' active' : ''}`;
+  element.type = 'button';
+
+  return element;
+}
+
+function fitPlaces(
+  map: MapLibreMap,
+  places: Place[],
+  draftCoords: { latitude: number; longitude: number } | null,
+) {
+  const points = [
+    ...places.map((place) => ({ latitude: place.latitude, longitude: place.longitude })),
+    ...(draftCoords == null ? [] : [draftCoords]),
+  ];
+
+  if (points.length === 0) {
+    map.easeTo({
+      center: [DEFAULT_MAP_CENTER.longitude, DEFAULT_MAP_CENTER.latitude],
+      duration: 250,
+      zoom: 11,
+    });
+    return;
+  }
+
+  if (points.length === 1) {
+    map.easeTo({
+      center: [points[0].longitude, points[0].latitude],
+      duration: 250,
+      zoom: Math.max(map.getZoom(), 13),
+    });
+    return;
+  }
+
+  const bounds = points.reduce(
+    (currentBounds, point) => currentBounds.extend([point.longitude, point.latitude]),
+    new maplibregl.LngLatBounds(
+      [points[0].longitude, points[0].latitude],
+      [points[0].longitude, points[0].latitude],
+    ),
+  );
+
+  map.fitBounds(bounds, {
+    duration: 250,
+    maxZoom: 14,
+    padding: 92,
+  });
+}
+
+function createEmptyViewportControls(): PlaceViewportControls {
+  return {
+    fit: () => undefined,
+    zoomIn: () => undefined,
+    zoomOut: () => undefined,
+  };
+}
+
+function roundCoord(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/web/components/cartographer/CartographerPlaceMap.tsx
+++ b/web/components/cartographer/CartographerPlaceMap.tsx
@@ -80,7 +80,10 @@ export default function CartographerPlaceMap({
         zoomIn: () => map.zoomIn({ duration: 180 }),
         zoomOut: () => map.zoomOut({ duration: 180 }),
       });
-      fitPlaces(map, stateRef.current.places, stateRef.current.draftCoords);
+      panToSelectedPlace(map, stateRef.current.places, stateRef.current.selectedPlaceId, 0);
+      if (stateRef.current.selectedPlaceId == null) {
+        fitPlaces(map, stateRef.current.places, stateRef.current.draftCoords);
+      }
     });
 
     map.on('click', (event) => {
@@ -124,6 +127,16 @@ export default function CartographerPlaceMap({
       selectedPlaceId,
     });
   }, [draftCoords, onChangeDraftCoords, onSelectPlace, places, selectedPlaceId]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    panToSelectedPlace(map, places, selectedPlaceId, 350);
+  }, [places, selectedPlaceId]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -232,6 +245,25 @@ function createPlaceMarkerElement({ active, label }: { active: boolean; label: s
   element.type = 'button';
 
   return element;
+}
+
+function panToSelectedPlace(
+  map: MapLibreMap,
+  places: Place[],
+  selectedPlaceId: string | null,
+  duration: number,
+) {
+  const selectedPlace = places.find((place) => place.id === selectedPlaceId);
+
+  if (selectedPlace == null) {
+    return;
+  }
+
+  map.easeTo({
+    center: [selectedPlace.longitude, selectedPlace.latitude],
+    duration,
+    zoom: Math.max(map.getZoom(), 14),
+  });
 }
 
 function fitPlaces(

--- a/web/components/cartographer/CornerMark.tsx
+++ b/web/components/cartographer/CornerMark.tsx
@@ -1,0 +1,11 @@
+type CornerMarkProps = {
+  label?: string;
+};
+
+export function CornerMark({ label = 'Kestrel survey sheet' }: CornerMarkProps) {
+  return (
+    <div aria-hidden className="corner-mark">
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/web/components/cartographer/EdgeTape.tsx
+++ b/web/components/cartographer/EdgeTape.tsx
@@ -1,0 +1,8 @@
+export function EdgeTape() {
+  return (
+    <>
+      <span aria-hidden className="edge-tape edge-tape-top" />
+      <span aria-hidden className="edge-tape edge-tape-bottom" />
+    </>
+  );
+}

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -8,11 +8,9 @@ type FieldNotebookProps = {
   newLabel: string;
   onNewEntry: () => void;
   onSearchChange: (value: string) => void;
-  pageLabel: string;
   searchPlaceholder: string;
   searchRef?: RefObject<HTMLInputElement | null>;
   searchValue: string;
-  title: string;
 };
 
 export function FieldNotebook({
@@ -22,36 +20,31 @@ export function FieldNotebook({
   newLabel,
   onNewEntry,
   onSearchChange,
-  pageLabel,
   searchPlaceholder,
   searchRef,
   searchValue,
-  title,
 }: FieldNotebookProps) {
+  const activeCount = <span className="notebook-tab-count font-mono">{count}</span>;
+
   return (
-    <aside className="field-notebook" aria-label={`${title} field notebook`}>
+    <aside className="field-notebook" aria-label={`${activeSection} field notebook`}>
       <div aria-hidden className="field-notebook-spine" />
-      <header className="field-notebook-header">
-        <div>
-          <p className="field-kicker font-mono">{pageLabel}</p>
-          <h1 className="font-serif">{title}</h1>
-        </div>
-        <span className="notebook-count font-mono">{count}</span>
-      </header>
       <nav aria-label="Cartographer sections" className="notebook-nav">
         <Link
           aria-current={activeSection === 'places' ? 'page' : undefined}
           className={activeSection === 'places' ? 'active' : ''}
           href="/dashboard/places"
         >
-          Places
+          <span>Places</span>
+          {activeSection === 'places' ? activeCount : null}
         </Link>
         <Link
           aria-current={activeSection === 'routes' ? 'page' : undefined}
           className={activeSection === 'routes' ? 'active' : ''}
           href="/dashboard/routes"
         >
-          Routes
+          <span>Routes</span>
+          {activeSection === 'routes' ? activeCount : null}
         </Link>
       </nav>
       <label className="notebook-search font-mono">
@@ -67,7 +60,6 @@ export function FieldNotebook({
         + {newLabel}
       </button>
       <div className="notebook-list">{children}</div>
-      <footer className="notebook-page font-mono">{pageLabel}</footer>
     </aside>
   );
 }

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -57,7 +57,17 @@ export function FieldNotebook({
         />
       </label>
       <button className="notebook-new-entry" type="button" onClick={onNewEntry}>
-        + {newLabel}
+        <span aria-hidden className="notebook-new-entry-icon">
+          +
+        </span>
+        <span>
+          <strong>{newLabel}</strong>
+          <small>
+            {activeSection === 'routes'
+              ? 'Create from map pins or favorites'
+              : 'Save a place with coordinates'}
+          </small>
+        </span>
       </button>
       <div className="notebook-list">{children}</div>
     </aside>

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link';
+import type { ReactNode, RefObject } from 'react';
+
+type FieldNotebookProps = {
+  activeSection: 'places' | 'routes';
+  children: ReactNode;
+  count: number;
+  newLabel: string;
+  onNewEntry: () => void;
+  onSearchChange: (value: string) => void;
+  pageLabel: string;
+  searchPlaceholder: string;
+  searchRef?: RefObject<HTMLInputElement | null>;
+  searchValue: string;
+  title: string;
+};
+
+export function FieldNotebook({
+  activeSection,
+  children,
+  count,
+  newLabel,
+  onNewEntry,
+  onSearchChange,
+  pageLabel,
+  searchPlaceholder,
+  searchRef,
+  searchValue,
+  title,
+}: FieldNotebookProps) {
+  return (
+    <aside className="field-notebook" aria-label={`${title} field notebook`}>
+      <div aria-hidden className="field-notebook-spine" />
+      <header className="field-notebook-header">
+        <div>
+          <p className="field-kicker font-mono">{pageLabel}</p>
+          <h1 className="font-serif">{title}</h1>
+        </div>
+        <span className="notebook-count font-mono">{count}</span>
+      </header>
+      <nav aria-label="Cartographer sections" className="notebook-nav">
+        <Link
+          aria-current={activeSection === 'places' ? 'page' : undefined}
+          className={activeSection === 'places' ? 'active' : ''}
+          href="/dashboard/places"
+        >
+          Places
+        </Link>
+        <Link
+          aria-current={activeSection === 'routes' ? 'page' : undefined}
+          className={activeSection === 'routes' ? 'active' : ''}
+          href="/dashboard/routes"
+        >
+          Routes
+        </Link>
+      </nav>
+      <label className="notebook-search font-mono">
+        Search
+        <input
+          ref={searchRef}
+          placeholder={searchPlaceholder}
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      </label>
+      <button className="notebook-new-entry" type="button" onClick={onNewEntry}>
+        + {newLabel}
+      </button>
+      <div className="notebook-list">{children}</div>
+      <footer className="notebook-page font-mono">{pageLabel}</footer>
+    </aside>
+  );
+}

--- a/web/components/cartographer/IndexCard.tsx
+++ b/web/components/cartographer/IndexCard.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 type IndexCardProps = {
   actions?: ReactNode;
   children: ReactNode;
+  eyebrow?: ReactNode;
   meta?: ReactNode;
   stamp: string;
   subtitle?: string;
@@ -13,6 +14,7 @@ type IndexCardProps = {
 export function IndexCard({
   actions,
   children,
+  eyebrow,
   meta,
   stamp,
   subtitle,
@@ -22,6 +24,7 @@ export function IndexCard({
   return (
     <section className={`index-card index-card-${variant}`} aria-label={`${title} index card`}>
       <span aria-hidden className="index-card-pin" />
+      {eyebrow == null ? null : <div className="index-card-breadcrumb breadcrumb">{eyebrow}</div>}
       <header className="index-card-header">
         <div>
           <p className="index-card-stamp font-mono">{stamp}</p>

--- a/web/components/cartographer/IndexCard.tsx
+++ b/web/components/cartographer/IndexCard.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+
+type IndexCardProps = {
+  actions?: ReactNode;
+  children: ReactNode;
+  meta?: ReactNode;
+  stamp: string;
+  subtitle?: string;
+  title: string;
+  variant?: 'place' | 'route';
+};
+
+export function IndexCard({
+  actions,
+  children,
+  meta,
+  stamp,
+  subtitle,
+  title,
+  variant = 'place',
+}: IndexCardProps) {
+  return (
+    <section className={`index-card index-card-${variant}`} aria-label={`${title} index card`}>
+      <span aria-hidden className="index-card-pin" />
+      <header className="index-card-header">
+        <div>
+          <p className="index-card-stamp font-mono">{stamp}</p>
+          <h2 className="font-serif">{title}</h2>
+          {subtitle == null ? null : <p>{subtitle}</p>}
+        </div>
+        {actions == null ? null : <div className="index-card-actions">{actions}</div>}
+      </header>
+      {meta == null ? null : <div className="index-card-meta">{meta}</div>}
+      <div className="index-card-body">{children}</div>
+    </section>
+  );
+}

--- a/web/components/cartographer/KeyboardCheatsheet.tsx
+++ b/web/components/cartographer/KeyboardCheatsheet.tsx
@@ -1,0 +1,48 @@
+type KeyboardCheatsheetProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const shortcuts = [
+  ['g p', 'Go to Places'],
+  ['g r', 'Go to Routes'],
+  ['n', 'Create a new entry'],
+  ['/', 'Focus notebook search'],
+  ['?', 'Show or hide this sheet'],
+  ['Esc', 'Close overlays'],
+];
+
+export function KeyboardCheatsheet({ isOpen, onClose }: KeyboardCheatsheetProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="keyboard-cheatsheet"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div className="keyboard-cheatsheet-card">
+        <header>
+          <div>
+            <p className="field-kicker font-mono">shortcuts</p>
+            <h2 className="font-serif">Keyboard field notes</h2>
+          </div>
+          <button className="secondary" type="button" onClick={onClose}>
+            Close
+          </button>
+        </header>
+        <dl>
+          {shortcuts.map(([keys, label]) => (
+            <div key={keys}>
+              <dt className="font-mono">{keys}</dt>
+              <dd>{label}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/web/components/cartographer/ScaleBar.tsx
+++ b/web/components/cartographer/ScaleBar.tsx
@@ -1,0 +1,10 @@
+export function ScaleBar() {
+  return (
+    <div aria-hidden className="scale-bar">
+      <span />
+      <span />
+      <span />
+      <strong className="font-mono">1 km</strong>
+    </div>
+  );
+}

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+type StageProps = {
+  children: ReactNode;
+  map: ReactNode;
+  mode: 'places' | 'routes';
+};
+
+export function Stage({ children, map, mode }: StageProps) {
+  return (
+    <main className={`cartographer-stage cartographer-stage-${mode}`}>
+      <div className="cartographer-map-layer">{map}</div>
+      <div aria-hidden className="cartographer-paper-vignette" />
+      {children}
+    </main>
+  );
+}

--- a/web/components/cartographer/StatusStrip.tsx
+++ b/web/components/cartographer/StatusStrip.tsx
@@ -1,0 +1,31 @@
+type StatusStripProps = {
+  error?: string | null;
+  isRefreshing?: boolean;
+  lastUpdatedLabel?: string | null;
+  onRefresh: () => void;
+};
+
+export function StatusStrip({
+  error = null,
+  isRefreshing = false,
+  lastUpdatedLabel = null,
+  onRefresh,
+}: StatusStripProps) {
+  return (
+    <div className="status-strip" role={error == null ? undefined : 'status'}>
+      <span className="font-mono">Kestrel Cloud</span>
+      <span>
+        {error ?? (lastUpdatedLabel == null ? 'Survey sheet ready' : `Updated ${lastUpdatedLabel}`)}
+      </span>
+      <button
+        aria-busy={isRefreshing}
+        className="status-refresh"
+        disabled={isRefreshing}
+        type="button"
+        onClick={onRefresh}
+      >
+        Refresh
+      </button>
+    </div>
+  );
+}

--- a/web/components/cartographer/UserMark.tsx
+++ b/web/components/cartographer/UserMark.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { type FormEvent, useState } from 'react';
+import { formatError } from '@/components/dashboard/utils';
+import { useTheme } from '@/components/ThemeProvider';
+
+type UserMarkProps = {
+  onChangePassword: (input: { currentPassword: string; newPassword: string }) => Promise<void>;
+  onLogout: () => void;
+  username: string;
+};
+
+export function UserMark({ onChangePassword, onLogout, username }: UserMarkProps) {
+  const { isHydrated, theme, toggleTheme } = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function submitPasswordChange(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setNotice(null);
+    setError(null);
+    setIsSaving(true);
+
+    try {
+      await onChangePassword({ currentPassword, newPassword });
+      setCurrentPassword('');
+      setNewPassword('');
+      setNotice('Password updated.');
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="user-mark">
+      <button
+        aria-expanded={isOpen}
+        className="user-mark-button"
+        type="button"
+        onClick={() => setIsOpen((current) => !current)}
+      >
+        <span aria-hidden className="user-mark-avatar">
+          {username.slice(0, 1).toUpperCase()}
+        </span>
+        <span>{username}</span>
+      </button>
+      {isOpen ? (
+        <div className="user-mark-popover">
+          <div className="stack">
+            <div>
+              <strong>Account</strong>
+              <p className="muted no-margin">Theme, password, and session controls.</p>
+            </div>
+            {error == null ? null : <div className="error">{error}</div>}
+            {notice == null ? null : <div className="success">{notice}</div>}
+            <button
+              className="secondary"
+              disabled={!isHydrated}
+              type="button"
+              onClick={toggleTheme}
+            >
+              {theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            </button>
+            <form className="stack" onSubmit={submitPasswordChange}>
+              <label>
+                Current password
+                <input
+                  autoComplete="current-password"
+                  minLength={12}
+                  required
+                  type="password"
+                  value={currentPassword}
+                  onChange={(event) => setCurrentPassword(event.target.value)}
+                />
+              </label>
+              <label>
+                New password
+                <input
+                  autoComplete="new-password"
+                  minLength={12}
+                  required
+                  type="password"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                />
+              </label>
+              <button disabled={isSaving} type="submit">
+                {isSaving ? 'Saving…' : 'Change password'}
+              </button>
+            </form>
+            <button className="secondary" type="button" onClick={onLogout}>
+              Logout
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/components/cartographer/ZoomStack.tsx
+++ b/web/components/cartographer/ZoomStack.tsx
@@ -14,20 +14,43 @@ export function ZoomStack({ onFit, onZoomIn, onZoomOut }: ZoomStackProps) {
   return (
     <fieldset className="zoom-stack">
       <legend className="sr-only">Map controls</legend>
-      <button type="button" onClick={onZoomIn}>
+      <button aria-label="Zoom in" type="button" onClick={onZoomIn}>
         +
       </button>
-      <button type="button" onClick={onZoomOut}>
+      <button aria-label="Zoom out" type="button" onClick={onZoomOut}>
         −
       </button>
-      <button type="button" onClick={onFit}>
+      <button className="zoom-stack-fit" type="button" onClick={onFit}>
+        <FitIcon />
         Fit
       </button>
       {canToggle ? (
         <button className="zoom-stack-style" type="button" onClick={toggleStyleName}>
-          {label}
+          <BookOpenIcon />
+          <span>Map: {label}</span>
         </button>
       ) : null}
     </fieldset>
+  );
+}
+
+function FitIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+      <path d="M16 3h3a2 2 0 0 1 2 2v3" />
+      <path d="M8 21H5a2 2 0 0 1-2-2v-3" />
+      <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+    </svg>
+  );
+}
+
+function BookOpenIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M12 7v14" />
+      <path d="M3 18a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4v13a3 3 0 0 0-3-3z" />
+      <path d="M21 18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-5a4 4 0 0 0-4 4v13a3 3 0 0 1 3-3z" />
+    </svg>
   );
 }

--- a/web/components/cartographer/ZoomStack.tsx
+++ b/web/components/cartographer/ZoomStack.tsx
@@ -44,8 +44,8 @@ export function ZoomStack({ onFit, onZoomIn, onZoomOut }: ZoomStackProps) {
 
   return (
     <div className="map-control-stack">
-      <fieldset className="map-control-group zoom-control-group">
-        <legend className="sr-only">Zoom controls</legend>
+      <fieldset className="map-control-bar">
+        <legend className="sr-only">Map controls</legend>
         <button aria-label="Zoom in" type="button" onClick={onZoomIn}>
           <PlusIcon />
         </button>
@@ -53,50 +53,47 @@ export function ZoomStack({ onFit, onZoomIn, onZoomOut }: ZoomStackProps) {
         <button aria-label="Zoom out" type="button" onClick={onZoomOut}>
           <MinusIcon />
         </button>
-      </fieldset>
-
-      <fieldset className="map-control-group fit-control-group">
-        <legend className="sr-only">Viewport controls</legend>
+        <span aria-hidden className="map-control-divider" />
         <button aria-label="Fit to all pins" title="Fit to all pins" type="button" onClick={onFit}>
           <MaximizeIcon />
         </button>
+        <span aria-hidden className="map-control-divider" />
+        <div className="map-style-control" ref={styleControlRef}>
+          <button
+            aria-expanded={isStyleMenuOpen}
+            aria-haspopup="menu"
+            className="map-style-trigger"
+            type="button"
+            onClick={() => setIsStyleMenuOpen((current) => !current)}
+          >
+            <MapIcon />
+            <span>{label}</span>
+            <ChevronDownIcon />
+          </button>
+          {isStyleMenuOpen ? (
+            <div className="map-style-menu" role="menu">
+              {availableStyles.map((styleOption) => (
+                <button
+                  aria-checked={styleOption.name === styleName}
+                  className={styleOption.name === styleName ? 'active' : ''}
+                  key={styleOption.name}
+                  role="menuitemradio"
+                  type="button"
+                  onClick={() => {
+                    setStyleName(styleOption.name);
+                    setIsStyleMenuOpen(false);
+                  }}
+                >
+                  <span aria-hidden className="map-style-check">
+                    {styleOption.name === styleName ? '✓' : ''}
+                  </span>
+                  {styleOption.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
       </fieldset>
-
-      <div className="map-style-control" ref={styleControlRef}>
-        <button
-          aria-expanded={isStyleMenuOpen}
-          aria-haspopup="menu"
-          className="map-style-trigger"
-          type="button"
-          onClick={() => setIsStyleMenuOpen((current) => !current)}
-        >
-          <MapIcon />
-          <span>{label}</span>
-          <ChevronDownIcon />
-        </button>
-        {isStyleMenuOpen ? (
-          <div className="map-style-menu" role="menu">
-            {availableStyles.map((styleOption) => (
-              <button
-                aria-checked={styleOption.name === styleName}
-                className={styleOption.name === styleName ? 'active' : ''}
-                key={styleOption.name}
-                role="menuitemradio"
-                type="button"
-                onClick={() => {
-                  setStyleName(styleOption.name);
-                  setIsStyleMenuOpen(false);
-                }}
-              >
-                <span aria-hidden className="map-style-check">
-                  {styleOption.name === styleName ? '✓' : ''}
-                </span>
-                {styleOption.label}
-              </button>
-            ))}
-          </div>
-        ) : null}
-      </div>
     </div>
   );
 }

--- a/web/components/cartographer/ZoomStack.tsx
+++ b/web/components/cartographer/ZoomStack.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import { useMapStyle } from '@/hooks/useMapStyle';
 
 type ZoomStackProps = {
@@ -9,32 +10,115 @@ type ZoomStackProps = {
 };
 
 export function ZoomStack({ onFit, onZoomIn, onZoomOut }: ZoomStackProps) {
-  const { canToggle, label, toggleStyleName } = useMapStyle();
+  const { availableStyles, label, setStyleName, styleName } = useMapStyle();
+  const [isStyleMenuOpen, setIsStyleMenuOpen] = useState(false);
+  const styleControlRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isStyleMenuOpen) {
+      return;
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (styleControlRef.current?.contains(event.target as Node) === true) {
+        return;
+      }
+
+      setIsStyleMenuOpen(false);
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsStyleMenuOpen(false);
+      }
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isStyleMenuOpen]);
 
   return (
-    <fieldset className="zoom-stack">
-      <legend className="sr-only">Map controls</legend>
-      <button aria-label="Zoom in" type="button" onClick={onZoomIn}>
-        +
-      </button>
-      <button aria-label="Zoom out" type="button" onClick={onZoomOut}>
-        −
-      </button>
-      <button className="zoom-stack-fit" type="button" onClick={onFit}>
-        <FitIcon />
-        Fit
-      </button>
-      {canToggle ? (
-        <button className="zoom-stack-style" type="button" onClick={toggleStyleName}>
-          <BookOpenIcon />
-          <span>Map: {label}</span>
+    <div className="map-control-stack">
+      <fieldset className="map-control-group zoom-control-group">
+        <legend className="sr-only">Zoom controls</legend>
+        <button aria-label="Zoom in" type="button" onClick={onZoomIn}>
+          <PlusIcon />
         </button>
-      ) : null}
-    </fieldset>
+        <span aria-hidden className="map-control-divider" />
+        <button aria-label="Zoom out" type="button" onClick={onZoomOut}>
+          <MinusIcon />
+        </button>
+      </fieldset>
+
+      <fieldset className="map-control-group fit-control-group">
+        <legend className="sr-only">Viewport controls</legend>
+        <button aria-label="Fit to all pins" title="Fit to all pins" type="button" onClick={onFit}>
+          <MaximizeIcon />
+        </button>
+      </fieldset>
+
+      <div className="map-style-control" ref={styleControlRef}>
+        <button
+          aria-expanded={isStyleMenuOpen}
+          aria-haspopup="menu"
+          className="map-style-trigger"
+          type="button"
+          onClick={() => setIsStyleMenuOpen((current) => !current)}
+        >
+          <MapIcon />
+          <span>{label}</span>
+          <ChevronDownIcon />
+        </button>
+        {isStyleMenuOpen ? (
+          <div className="map-style-menu" role="menu">
+            {availableStyles.map((styleOption) => (
+              <button
+                aria-checked={styleOption.name === styleName}
+                className={styleOption.name === styleName ? 'active' : ''}
+                key={styleOption.name}
+                role="menuitemradio"
+                type="button"
+                onClick={() => {
+                  setStyleName(styleOption.name);
+                  setIsStyleMenuOpen(false);
+                }}
+              >
+                <span aria-hidden className="map-style-check">
+                  {styleOption.name === styleName ? '✓' : ''}
+                </span>
+                {styleOption.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
   );
 }
 
-function FitIcon() {
+function PlusIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
+
+function MinusIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
+
+function MaximizeIcon() {
   return (
     <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
       <path d="M8 3H5a2 2 0 0 0-2 2v3" />
@@ -45,12 +129,20 @@ function FitIcon() {
   );
 }
 
-function BookOpenIcon() {
+function MapIcon() {
   return (
     <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
-      <path d="M12 7v14" />
-      <path d="M3 18a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4v13a3 3 0 0 0-3-3z" />
-      <path d="M21 18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-5a4 4 0 0 0-4 4v13a3 3 0 0 1 3-3z" />
+      <path d="M14.5 4.5 9.5 2 3 5.5v16l6.5-3.5 5 2.5 6.5-3.5v-16z" />
+      <path d="M9.5 2v16" />
+      <path d="M14.5 4.5v16" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="m6 9 6 6 6-6" />
     </svg>
   );
 }

--- a/web/components/cartographer/ZoomStack.tsx
+++ b/web/components/cartographer/ZoomStack.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useMapStyle } from '@/hooks/useMapStyle';
+
+type ZoomStackProps = {
+  onFit?: () => void;
+  onZoomIn?: () => void;
+  onZoomOut?: () => void;
+};
+
+export function ZoomStack({ onFit, onZoomIn, onZoomOut }: ZoomStackProps) {
+  const { canToggle, label, toggleStyleName } = useMapStyle();
+
+  return (
+    <fieldset className="zoom-stack">
+      <legend className="sr-only">Map controls</legend>
+      <button type="button" onClick={onZoomIn}>
+        +
+      </button>
+      <button type="button" onClick={onZoomOut}>
+        −
+      </button>
+      <button type="button" onClick={onFit}>
+        Fit
+      </button>
+      {canToggle ? (
+        <button className="zoom-stack-style" type="button" onClick={toggleStyleName}>
+          {label}
+        </button>
+      ) : null}
+    </fieldset>
+  );
+}

--- a/web/components/cartographer/useKeyboardShortcuts.ts
+++ b/web/components/cartographer/useKeyboardShortcuts.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type ShortcutHandlers = {
+  onClose?: () => void;
+  onFocusSearch?: () => void;
+  onGoPlaces?: () => void;
+  onGoRoutes?: () => void;
+  onNew?: () => void;
+  onToggleHelp?: () => void;
+};
+
+const SEQUENCE_TIMEOUT_MS = 900;
+
+export function useKeyboardShortcuts({
+  onClose,
+  onFocusSearch,
+  onGoPlaces,
+  onGoRoutes,
+  onNew,
+  onToggleHelp,
+}: ShortcutHandlers) {
+  const sequenceRef = useRef<string | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    function clearSequence() {
+      sequenceRef.current = null;
+      if (timeoutRef.current != null) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    }
+
+    function startSequence(value: string) {
+      clearSequence();
+      sequenceRef.current = value;
+      timeoutRef.current = window.setTimeout(clearSequence, SEQUENCE_TIMEOUT_MS);
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        clearSequence();
+        onClose?.();
+        return;
+      }
+
+      if (event.key === '?') {
+        event.preventDefault();
+        clearSequence();
+        onToggleHelp?.();
+        return;
+      }
+
+      if (event.key === '/') {
+        event.preventDefault();
+        clearSequence();
+        onFocusSearch?.();
+        return;
+      }
+
+      if (event.key.toLowerCase() === 'n') {
+        event.preventDefault();
+        clearSequence();
+        onNew?.();
+        return;
+      }
+
+      if (event.key.toLowerCase() === 'g') {
+        event.preventDefault();
+        startSequence('g');
+        return;
+      }
+
+      if (sequenceRef.current === 'g') {
+        const key = event.key.toLowerCase();
+
+        if (key === 'p') {
+          event.preventDefault();
+          clearSequence();
+          onGoPlaces?.();
+          return;
+        }
+
+        if (key === 'r') {
+          event.preventDefault();
+          clearSequence();
+          onGoRoutes?.();
+          return;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      clearSequence();
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose, onFocusSearch, onGoPlaces, onGoRoutes, onNew, onToggleHelp]);
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const tagName = target.tagName.toLowerCase();
+
+  return (
+    tagName === 'input' ||
+    tagName === 'select' ||
+    tagName === 'textarea' ||
+    target.isContentEditable
+  );
+}

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -21,11 +21,15 @@ export default function PlaceEditor({
   onDelete,
   onSave,
   place,
+  showHeader = true,
+  showMap = true,
 }: {
   draftCoords?: { latitude: number; longitude: number };
   onDelete?: () => void;
   onSave: (input: PlaceInput) => void;
   place: Place | null;
+  showHeader?: boolean;
+  showMap?: boolean;
 }) {
   const [name, setName] = useState(place?.name ?? '');
   const [latitude, setLatitude] = useState(
@@ -53,6 +57,15 @@ export default function PlaceEditor({
     [draftCoords, latitude, longitude, place],
   );
 
+  useEffect(() => {
+    if (draftCoords == null) {
+      return;
+    }
+
+    setLatitude(formatCoordinateInput(draftCoords.latitude));
+    setLongitude(formatCoordinateInput(draftCoords.longitude));
+  }, [draftCoords]);
+
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
@@ -76,23 +89,36 @@ export default function PlaceEditor({
     }
   }
 
+  function confirmDelete() {
+    if (window.confirm('Delete this place? This cannot be undone.')) {
+      onDelete?.();
+    }
+  }
+
   return (
-    <form className="panel stack place-editor" onSubmit={submit}>
-      <header className="place-editor-header">
-        <div className="breadcrumb">
-          Places / <span>{place?.name ?? 'New place'}</span>
-        </div>
-        <h2>{place == null ? 'New place' : place.name}</h2>
-      </header>
+    <form
+      className={`${showMap ? 'panel ' : ''}stack place-editor${showMap ? '' : ' place-editor-embedded'}`}
+      onSubmit={submit}
+    >
+      {showHeader ? (
+        <header className="place-editor-header">
+          <div className="breadcrumb">
+            Places / <span>{place?.name ?? 'New place'}</span>
+          </div>
+          <h2>{place == null ? 'New place' : place.name}</h2>
+        </header>
+      ) : null}
       {error == null ? null : <div className="error">{error}</div>}
-      <PlaceMapEditor
-        latitude={mapCoords.latitude}
-        longitude={mapCoords.longitude}
-        onChange={(coords) => {
-          setLatitude(formatCoordinateInput(coords.latitude));
-          setLongitude(formatCoordinateInput(coords.longitude));
-        }}
-      />
+      {showMap ? (
+        <PlaceMapEditor
+          latitude={mapCoords.latitude}
+          longitude={mapCoords.longitude}
+          onChange={(coords) => {
+            setLatitude(formatCoordinateInput(coords.latitude));
+            setLongitude(formatCoordinateInput(coords.longitude));
+          }}
+        />
+      ) : null}
       <label>
         Name
         <input required value={name} onChange={(event) => setName(event.target.value)} />
@@ -129,7 +155,7 @@ export default function PlaceEditor({
       <footer className="route-editor-footer place-editor-footer">
         <div className="row">
           {onDelete == null ? null : (
-            <button className="danger" disabled={isSaving} type="button" onClick={onDelete}>
+            <button className="danger" disabled={isSaving} type="button" onClick={confirmDelete}>
               Delete
             </button>
           )}

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -254,170 +254,6 @@ export default function RouteEditor({
       )}
       {error == null ? null : <div className="error route-editor-error">{error}</div>}
 
-      <section className="route-editor-section route-editor-map-section">
-        {isBackgroundMapMode ? null : (
-          <div>
-            <h3>Route editor</h3>
-            <p className="muted">Drag, drop, refine. Your route, your pace.</p>
-          </div>
-        )}
-        <div className="route-builder-hint">
-          <InfoIcon />
-          {routeBuilderHint}
-        </div>
-        {mapMode === 'embedded' ? (
-          <>
-            <div className="map-builder">
-              <RouteMapEditor
-                fitRequest={fitRequest}
-                focusTarget={focusTarget}
-                selectedWaypointIndex={selectedWaypointIndex}
-                waypoints={waypoints}
-                onChange={setWaypoints}
-                onSelectWaypoint={setSelectedWaypointIndex}
-              />
-              <div className="map-instruction">
-                Click map to add waypoint · Drag markers to adjust
-              </div>
-            </div>
-            <div className="map-action-row">
-              <button
-                className="secondary"
-                disabled={waypoints.length === 0}
-                title="Auto-frame the map to show all waypoints"
-                type="button"
-                onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
-              >
-                Fit route
-              </button>
-              <span className="muted">
-                Add from map click, then expand Waypoints for exact coordinates.
-              </span>
-            </div>
-          </>
-        ) : null}
-
-        <details className="route-editor-collapsible route-editor-waypoints-section" open>
-          <summary>
-            <span>Waypoints ({waypoints.length})</span>
-            <span className="muted">{formatWaypointSummary(waypoints, places)}</span>
-          </summary>
-          <div className="route-editor-collapsible-content">
-            {waypoints.length === 0 ? (
-              <div className="waypoint-empty-state">
-                <MapPinIcon />
-                <strong>No waypoints yet</strong>
-                <span className="muted">
-                  Tap the map to add your first waypoint, or pick from favorites below.
-                </span>
-              </div>
-            ) : (
-              <ul className="waypoint-list" aria-label="Route waypoints">
-                {waypoints.map((waypoint, index) => {
-                  const waypointName = formatWaypointName(waypoint, places, `Pin ${index + 1}`);
-
-                  const waypointRowClassName = [
-                    'waypoint-row',
-                    selectedWaypointIndex === index ? 'selected' : '',
-                    draggedWaypointIndex === index ? 'is-dragging' : '',
-                    dragOverWaypointIndex === index && draggedWaypointIndex !== index
-                      ? 'is-drop-target'
-                      : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ');
-
-                  return (
-                    <li
-                      className={waypointRowClassName}
-                      draggable
-                      key={getWaypointKey(waypoint, index)}
-                      onDragEnd={() => {
-                        setDraggedWaypointIndex(null);
-                        setDragOverWaypointIndex(null);
-                      }}
-                      onDragEnter={() => setDragOverWaypointIndex(index)}
-                      onDragOver={(event) => event.preventDefault()}
-                      onDragStart={(event) => {
-                        setDraggedWaypointIndex(index);
-                        event.dataTransfer.effectAllowed = 'move';
-                        event.dataTransfer.setData('text/plain', String(index));
-                      }}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        const fromIndex = Number(event.dataTransfer.getData('text/plain'));
-
-                        if (Number.isInteger(fromIndex) && fromIndex !== index) {
-                          moveWaypoint(waypoints, setWaypoints, fromIndex, index);
-                          setSelectedWaypointIndex(index);
-                        }
-
-                        setDraggedWaypointIndex(null);
-                        setDragOverWaypointIndex(null);
-                      }}
-                    >
-                      <button
-                        className="waypoint-focus"
-                        type="button"
-                        onClick={() => focusWaypoint(waypoint, index)}
-                      >
-                        <span className="waypoint-grip" title="Drag to reorder">
-                          <GripVerticalIcon />
-                        </span>
-                        <span className={getWaypointBadgeClassName(index, waypoints.length)}>
-                          {index === waypoints.length - 1 && waypoints.length > 1 ? (
-                            <FlagIcon />
-                          ) : (
-                            index + 1
-                          )}
-                        </span>
-                        <span className="waypoint-name" title={waypointName}>
-                          {waypointName}
-                        </span>
-                        <span className="waypoint-coordinates mono">
-                          {formatWaypointCoords(waypoint)}
-                        </span>
-                      </button>
-                      <details className="waypoint-menu">
-                        <summary aria-label={`More options for ${waypointName}`}>
-                          <MoreHorizontalIcon />
-                        </summary>
-                        <div className="waypoint-menu-content">
-                          <button type="button" onClick={() => removeWaypoint(index)}>
-                            Remove from route
-                          </button>
-                          <button type="button" onClick={() => insertWaypointAfter(index)}>
-                            Insert pin after
-                          </button>
-                          <button type="button" onClick={() => editWaypointCoordinates(index)}>
-                            Edit coordinates
-                          </button>
-                        </div>
-                      </details>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            <button
-              className="secondary button-icon-label"
-              disabled={waypoints.length === 0}
-              type="button"
-              onClick={duplicateLastWaypoint}
-            >
-              <PlusIcon />
-              Duplicate last waypoint
-            </button>
-          </div>
-        </details>
-
-        <FavoriteWaypointPicker
-          mode={favoritePickerMode}
-          places={places}
-          onSelect={addFavoriteWaypoint}
-        />
-      </section>
-
       <details
         className="route-editor-section route-editor-collapsible route-editor-details-section"
         open
@@ -457,6 +293,168 @@ export default function RouteEditor({
               onChange={(event) => setDescription(event.target.value)}
             />
           </label>
+        </div>
+      </details>
+
+      <section className="route-editor-section route-editor-map-section">
+        {isBackgroundMapMode ? null : (
+          <div>
+            <h3>Route builder</h3>
+            <p className="muted">Add pins on the map or pick from favorites.</p>
+          </div>
+        )}
+        <div className="route-builder-hint">
+          <InfoIcon />
+          {routeBuilderHint}
+        </div>
+        {mapMode === 'embedded' ? (
+          <>
+            <div className="map-builder">
+              <RouteMapEditor
+                fitRequest={fitRequest}
+                focusTarget={focusTarget}
+                selectedWaypointIndex={selectedWaypointIndex}
+                waypoints={waypoints}
+                onChange={setWaypoints}
+                onSelectWaypoint={setSelectedWaypointIndex}
+              />
+              <div className="map-instruction">
+                Click map to add waypoint · Drag markers to adjust
+              </div>
+            </div>
+            <div className="map-action-row">
+              <button
+                className="secondary"
+                disabled={waypoints.length === 0}
+                title="Auto-frame the map to show all waypoints"
+                type="button"
+                onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
+              >
+                Fit route
+              </button>
+              <span className="muted">Use Waypoints below to review, reorder, or edit pins.</span>
+            </div>
+          </>
+        ) : null}
+
+        <FavoriteWaypointPicker
+          mode={favoritePickerMode}
+          places={places}
+          onSelect={addFavoriteWaypoint}
+        />
+      </section>
+
+      <details className="route-editor-section route-editor-collapsible route-editor-waypoints-section" open={waypoints.length > 0}>
+        <summary>
+          <span>Waypoints ({waypoints.length})</span>
+          <span className="muted">{formatWaypointSummary(waypoints, places)}</span>
+        </summary>
+        <div className="route-editor-collapsible-content">
+          {waypoints.length === 0 ? (
+            <div className="waypoint-empty-state">
+              <MapPinIcon />
+              <strong>No waypoints yet</strong>
+              <span className="muted">
+                Tap the map to add your first waypoint, or pick from favorites above.
+              </span>
+            </div>
+          ) : (
+            <ul className="waypoint-list" aria-label="Route waypoints">
+              {waypoints.map((waypoint, index) => {
+                const waypointName = formatWaypointName(waypoint, places, `Pin ${index + 1}`);
+
+                const waypointRowClassName = [
+                  'waypoint-row',
+                  selectedWaypointIndex === index ? 'selected' : '',
+                  draggedWaypointIndex === index ? 'is-dragging' : '',
+                  dragOverWaypointIndex === index && draggedWaypointIndex !== index
+                    ? 'is-drop-target'
+                    : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ');
+
+                return (
+                  <li
+                    className={waypointRowClassName}
+                    draggable
+                    key={getWaypointKey(waypoint, index)}
+                    onDragEnd={() => {
+                      setDraggedWaypointIndex(null);
+                      setDragOverWaypointIndex(null);
+                    }}
+                    onDragEnter={() => setDragOverWaypointIndex(index)}
+                    onDragOver={(event) => event.preventDefault()}
+                    onDragStart={(event) => {
+                      setDraggedWaypointIndex(index);
+                      event.dataTransfer.effectAllowed = 'move';
+                      event.dataTransfer.setData('text/plain', String(index));
+                    }}
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      const fromIndex = Number(event.dataTransfer.getData('text/plain'));
+
+                      if (Number.isInteger(fromIndex) && fromIndex !== index) {
+                        moveWaypoint(waypoints, setWaypoints, fromIndex, index);
+                        setSelectedWaypointIndex(index);
+                      }
+
+                      setDraggedWaypointIndex(null);
+                      setDragOverWaypointIndex(null);
+                    }}
+                  >
+                    <button
+                      className="waypoint-focus"
+                      type="button"
+                      onClick={() => focusWaypoint(waypoint, index)}
+                    >
+                      <span className="waypoint-grip" title="Drag to reorder">
+                        <GripVerticalIcon />
+                      </span>
+                      <span className={getWaypointBadgeClassName(index, waypoints.length)}>
+                        {index === waypoints.length - 1 && waypoints.length > 1 ? (
+                          <FlagIcon />
+                        ) : (
+                          index + 1
+                        )}
+                      </span>
+                      <span className="waypoint-name" title={waypointName}>
+                        {waypointName}
+                      </span>
+                      <span className="waypoint-coordinates mono">
+                        {formatWaypointCoords(waypoint)}
+                      </span>
+                    </button>
+                    <details className="waypoint-menu">
+                      <summary aria-label={`More options for ${waypointName}`}>
+                        <MoreHorizontalIcon />
+                      </summary>
+                      <div className="waypoint-menu-content">
+                        <button type="button" onClick={() => removeWaypoint(index)}>
+                          Remove from route
+                        </button>
+                        <button type="button" onClick={() => insertWaypointAfter(index)}>
+                          Insert pin after
+                        </button>
+                        <button type="button" onClick={() => editWaypointCoordinates(index)}>
+                          Edit coordinates
+                        </button>
+                      </div>
+                    </details>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <button
+            className="secondary button-icon-label"
+            disabled={waypoints.length === 0}
+            type="button"
+            onClick={duplicateLastWaypoint}
+          >
+            <PlusIcon />
+            Duplicate last waypoint
+          </button>
         </div>
       </details>
 

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -73,6 +73,7 @@ export default function RouteEditor({
       ? internalSelectedWaypointIndex
       : controlledSelectedWaypointIndex;
   const setWaypoints = onWaypointsChange ?? setInternalWaypoints;
+  const isBackgroundMapMode = mapMode === 'background';
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length, mapMode);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
@@ -185,26 +186,30 @@ export default function RouteEditor({
 
   return (
     <form className="panel route-editor" onSubmit={submit}>
-      <header className="route-editor-header">
-        <div className="stack">
-          <div className="breadcrumb">
-            Routes / <span>{route?.name ?? 'New route'}</span>
+      {isBackgroundMapMode ? null : (
+        <header className="route-editor-header">
+          <div className="stack">
+            <div className="breadcrumb">
+              Routes / <span>{route?.name ?? 'New route'}</span>
+            </div>
+            <h2>{route == null ? 'New route' : route.name}</h2>
+            {route?.currentRevision == null ? null : (
+              <span className="chip rev-chip">
+                latest revision {route.currentRevision.revisionNumber}
+              </span>
+            )}
           </div>
-          <h2>{route == null ? 'New route' : route.name}</h2>
-          {route?.currentRevision == null ? null : (
-            <span className="chip rev-chip">
-              latest revision {route.currentRevision.revisionNumber}
-            </span>
-          )}
-        </div>
-      </header>
+        </header>
+      )}
       {error == null ? null : <div className="error route-editor-error">{error}</div>}
 
       <section className="route-editor-section route-editor-map-section">
-        <div>
-          <h3>Route editor</h3>
-          <p className="muted">Drag, drop, refine. Your route, your pace.</p>
-        </div>
+        {isBackgroundMapMode ? null : (
+          <div>
+            <h3>Route editor</h3>
+            <p className="muted">Drag, drop, refine. Your route, your pace.</p>
+          </div>
+        )}
         <div className="route-builder-hint">
           <InfoIcon />
           {routeBuilderHint}
@@ -244,7 +249,7 @@ export default function RouteEditor({
         <details className="route-editor-collapsible route-editor-waypoints-section" open>
           <summary>
             <span>Waypoints ({waypoints.length})</span>
-            <span className="muted">{formatWaypointSummary(waypoints)}</span>
+            <span className="muted">{formatWaypointSummary(waypoints, places)}</span>
           </summary>
           <div className="route-editor-collapsible-content">
             {waypoints.map((waypoint, index) => (
@@ -532,8 +537,11 @@ function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
   return `${waypoint.sequence ?? index}-${waypoint.latitude}-${waypoint.longitude}`;
 }
 
-function formatWaypointSummary(waypoints: RouteWaypoint[]): string {
-  if (waypoints.length === 0) {
+function formatWaypointSummary(waypoints: RouteWaypoint[], places: Place[]): string {
+  const firstWaypoint = waypoints[0];
+  const lastWaypoint = waypoints.at(-1);
+
+  if (firstWaypoint == null || lastWaypoint == null) {
     return 'Start by adding a point';
   }
 
@@ -541,7 +549,21 @@ function formatWaypointSummary(waypoints: RouteWaypoint[]): string {
     return 'Add one more waypoint to save';
   }
 
-  return 'Current route order';
+  return `${formatWaypointName(firstWaypoint, places, 'Start')} → ${formatWaypointName(
+    lastWaypoint,
+    places,
+    'End',
+  )}`;
+}
+
+function formatWaypointName(waypoint: RouteWaypoint, places: Place[], fallback: string): string {
+  return (
+    places.find(
+      (place) =>
+        Math.abs(place.latitude - waypoint.latitude) < 0.00001 &&
+        Math.abs(place.longitude - waypoint.longitude) < 0.00001,
+    )?.name ?? fallback
+  );
 }
 
 function getWaypointLabel(index: number, waypointCount: number): string {
@@ -562,7 +584,7 @@ function getRouteBuilderHint(
   mapMode: 'background' | 'embedded',
 ): string {
   if (mapMode === 'background' && waypointCount >= 2) {
-    return 'Tap the background map to add a waypoint. Drag map pins to adjust the route.';
+    return 'Tap the map to add a waypoint · Drag pins to adjust';
   }
 
   if (waypointCount === 0) {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -25,22 +25,34 @@ const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
 });
 
 export default function RouteEditor({
+  mapMode = 'embedded',
   onDelete,
+  onFocusTargetChange,
   onSave,
+  onSelectedWaypointIndexChange,
+  onWaypointsChange,
   places = [],
   route,
+  selectedWaypointIndex: controlledSelectedWaypointIndex,
+  waypoints: controlledWaypoints,
 }: {
+  mapMode?: 'background' | 'embedded';
   onDelete?: () => void;
+  onFocusTargetChange?: (waypoint: RouteWaypoint | null) => void;
   onSave: (input: RouteInput) => void;
+  onSelectedWaypointIndexChange?: (index: number | null) => void;
+  onWaypointsChange?: (waypoints: RouteWaypoint[]) => void;
   places?: Place[];
   route: Route | null;
+  selectedWaypointIndex?: number | null;
+  waypoints?: RouteWaypoint[];
 }) {
   const [name, setName] = useState(route?.name ?? '');
   const [description, setDescription] = useState(route?.description ?? '');
   const [defaultSpeedKmh, setDefaultSpeedKmh] = useState(route?.defaultSpeedKmh.toString() ?? '5');
   const [mode, setMode] = useState<RouteMode>(route?.mode ?? 'ONCE');
   const [isPublic, setIsPublic] = useState(route?.isPublic ?? false);
-  const [waypoints, setWaypoints] = useState<RouteWaypoint[]>(
+  const [internalWaypoints, setInternalWaypoints] = useState<RouteWaypoint[]>(
     route?.currentRevision?.waypoints.map((waypoint) => ({
       latitude: waypoint.latitude,
       longitude: waypoint.longitude,
@@ -48,20 +60,44 @@ export default function RouteEditor({
   );
   const [fitRequest, setFitRequest] = useState(0);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
-  const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
+  const [internalSelectedWaypointIndex, setInternalSelectedWaypointIndex] = useState<number | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [saveNotice, setSaveNotice] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const saveNoticeTimeoutRef = useRef<number | null>(null);
+  const waypoints = controlledWaypoints ?? internalWaypoints;
+  const selectedWaypointIndex =
+    controlledSelectedWaypointIndex === undefined
+      ? internalSelectedWaypointIndex
+      : controlledSelectedWaypointIndex;
+  const setWaypoints = onWaypointsChange ?? setInternalWaypoints;
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
+
+  const setSelectedWaypointIndex = useCallback(
+    (nextIndex: number | null) => {
+      setInternalSelectedWaypointIndex(nextIndex);
+      onSelectedWaypointIndexChange?.(nextIndex);
+    },
+    [onSelectedWaypointIndexChange],
+  );
+
+  const setRouteFocusTarget = useCallback(
+    (nextFocusTarget: RouteWaypoint | null) => {
+      setFocusTarget(nextFocusTarget);
+      onFocusTargetChange?.(nextFocusTarget);
+    },
+    [onFocusTargetChange],
+  );
 
   useEffect(() => {
     if (selectedWaypointIndex != null && selectedWaypointIndex >= waypoints.length) {
       setSelectedWaypointIndex(null);
     }
-  }, [selectedWaypointIndex, waypoints.length]);
+  }, [selectedWaypointIndex, setSelectedWaypointIndex, waypoints.length]);
 
   useEffect(
     () => () => {
@@ -113,7 +149,7 @@ export default function RouteEditor({
     const nextWaypoints = waypoints.length === 0 ? [waypoint] : [...waypoints, waypoint];
 
     setWaypoints(nextWaypoints);
-    setFocusTarget(waypoint);
+    setRouteFocusTarget(waypoint);
     setSelectedWaypointIndex(nextWaypoints.length - 1);
   }
 
@@ -130,13 +166,15 @@ export default function RouteEditor({
 
   function removeWaypoint(index: number) {
     setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index));
-    setSelectedWaypointIndex((currentIndex) => {
-      if (currentIndex == null || currentIndex === index) {
-        return null;
-      }
 
-      return currentIndex > index ? currentIndex - 1 : currentIndex;
-    });
+    if (selectedWaypointIndex == null || selectedWaypointIndex === index) {
+      setSelectedWaypointIndex(null);
+      return;
+    }
+
+    setSelectedWaypointIndex(
+      selectedWaypointIndex > index ? selectedWaypointIndex - 1 : selectedWaypointIndex,
+    );
   }
 
   function confirmDelete() {
@@ -171,40 +209,46 @@ export default function RouteEditor({
           <InfoIcon />
           {routeBuilderHint}
         </div>
-        <FavoriteWaypointPicker
-          mode={favoritePickerMode}
-          places={places}
-          onSelect={addFavoriteWaypoint}
-        />
-        <div className="map-builder">
-          <RouteMapEditor
-            fitRequest={fitRequest}
-            focusTarget={focusTarget}
-            selectedWaypointIndex={selectedWaypointIndex}
-            waypoints={waypoints}
-            onChange={setWaypoints}
-            onSelectWaypoint={setSelectedWaypointIndex}
-          />
-          <div className="map-instruction">Click map to add waypoint · Drag markers to adjust</div>
-        </div>
-        <div className="map-action-row">
-          <button
-            className="secondary"
-            disabled={waypoints.length === 0}
-            title="Auto-frame the map to show all waypoints"
-            type="button"
-            onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
-          >
-            Fit route
-          </button>
-          <span className="muted">
-            Add from map click, then expand Waypoints for exact coordinates.
-          </span>
-        </div>
+        {mapMode === 'embedded' ? (
+          <>
+            <div className="map-builder">
+              <RouteMapEditor
+                fitRequest={fitRequest}
+                focusTarget={focusTarget}
+                selectedWaypointIndex={selectedWaypointIndex}
+                waypoints={waypoints}
+                onChange={setWaypoints}
+                onSelectWaypoint={setSelectedWaypointIndex}
+              />
+              <div className="map-instruction">
+                Click map to add waypoint · Drag markers to adjust
+              </div>
+            </div>
+            <div className="map-action-row">
+              <button
+                className="secondary"
+                disabled={waypoints.length === 0}
+                title="Auto-frame the map to show all waypoints"
+                type="button"
+                onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
+              >
+                Fit route
+              </button>
+              <span className="muted">
+                Add from map click, then expand Waypoints for exact coordinates.
+              </span>
+            </div>
+          </>
+        ) : (
+          <div className="route-map-info-banner">
+            <InfoIcon />
+            Tap the background map to add a waypoint. Drag map pins to adjust the route.
+          </div>
+        )}
 
-        <details className="route-editor-collapsible route-editor-waypoints-section">
+        <details className="route-editor-collapsible route-editor-waypoints-section" open>
           <summary>
-            <span>{formatWaypointCount(waypoints.length)}</span>
+            <span>Waypoints ({waypoints.length})</span>
             <span className="muted">{formatWaypointSummary(waypoints)}</span>
           </summary>
           <div className="route-editor-collapsible-content">
@@ -216,6 +260,7 @@ export default function RouteEditor({
               >
                 <span className="chip">{getWaypointLabel(index, waypoints.length)}</span>
                 <input
+                  aria-label={`${getWaypointLabel(index, waypoints.length)} latitude`}
                   inputMode="decimal"
                   value={waypoint.latitude}
                   onChange={(event) =>
@@ -223,13 +268,15 @@ export default function RouteEditor({
                   }
                 />
                 <input
+                  aria-label={`${getWaypointLabel(index, waypoints.length)} longitude`}
                   inputMode="decimal"
                   value={waypoint.longitude}
                   onChange={(event) =>
                     updateWaypoint(waypoints, setWaypoints, index, 'longitude', event.target.value)
                   }
                 />
-                <div className="row-actions">
+                <fieldset className="row-actions">
+                  <legend className="sr-only">Waypoint actions</legend>
                   <button
                     className="secondary"
                     disabled={index === 0}
@@ -247,9 +294,9 @@ export default function RouteEditor({
                     ↓
                   </button>
                   <button className="danger" type="button" onClick={() => removeWaypoint(index)}>
-                    ×
+                    Remove
                   </button>
-                </div>
+                </fieldset>
               </div>
             ))}
             <button
@@ -259,10 +306,16 @@ export default function RouteEditor({
               onClick={duplicateLastWaypoint}
             >
               <PlusIcon />
-              Add waypoint
+              Duplicate last waypoint
             </button>
           </div>
         </details>
+
+        <FavoriteWaypointPicker
+          mode={favoritePickerMode}
+          places={places}
+          onSelect={addFavoriteWaypoint}
+        />
       </section>
 
       <details
@@ -482,10 +535,6 @@ function formatFavoritePlaceCoords(place: Place): string {
 
 function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
   return `${waypoint.sequence ?? index}-${waypoint.latitude}-${waypoint.longitude}`;
-}
-
-function formatWaypointCount(waypointCount: number): string {
-  return `${waypointCount} waypoint${waypointCount === 1 ? '' : 's'}`;
 }
 
 function formatWaypointSummary(waypoints: RouteWaypoint[]): string {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -73,7 +73,7 @@ export default function RouteEditor({
       ? internalSelectedWaypointIndex
       : controlledSelectedWaypointIndex;
   const setWaypoints = onWaypointsChange ?? setInternalWaypoints;
-  const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length);
+  const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length, mapMode);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
 
@@ -239,12 +239,7 @@ export default function RouteEditor({
               </span>
             </div>
           </>
-        ) : (
-          <div className="route-map-info-banner">
-            <InfoIcon />
-            Tap the background map to add a waypoint. Drag map pins to adjust the route.
-          </div>
-        )}
+        ) : null}
 
         <details className="route-editor-collapsible route-editor-waypoints-section" open>
           <summary>
@@ -538,26 +533,15 @@ function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
 }
 
 function formatWaypointSummary(waypoints: RouteWaypoint[]): string {
-  const firstWaypoint = waypoints[0];
-  const lastWaypoint = waypoints.at(-1);
-
-  if (firstWaypoint == null || lastWaypoint == null) {
+  if (waypoints.length === 0) {
     return 'Start by adding a point';
   }
 
   if (waypoints.length === 1) {
-    return `Starts at ${formatShortCoord(firstWaypoint.latitude)}, ${formatShortCoord(
-      firstWaypoint.longitude,
-    )}`;
+    return 'Add one more waypoint to save';
   }
 
-  return `Start at ${formatShortCoord(firstWaypoint.latitude)}, end at ${formatShortCoord(
-    lastWaypoint.latitude,
-  )}`;
-}
-
-function formatShortCoord(value: number | string): string {
-  return Number(value).toFixed(2);
+  return 'Current route order';
 }
 
 function getWaypointLabel(index: number, waypointCount: number): string {
@@ -572,7 +556,15 @@ function getWaypointLabel(index: number, waypointCount: number): string {
   return `Stop ${index + 1}`;
 }
 
-function getRouteBuilderHint(waypointCount: number, placeCount: number): string {
+function getRouteBuilderHint(
+  waypointCount: number,
+  placeCount: number,
+  mapMode: 'background' | 'embedded',
+): string {
+  if (mapMode === 'background' && waypointCount >= 2) {
+    return 'Tap the background map to add a waypoint. Drag map pins to adjust the route.';
+  }
+
   if (waypointCount === 0) {
     return placeCount === 0
       ? 'Start by clicking the map to add your first waypoint.'

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -60,6 +60,8 @@ export default function RouteEditor({
   );
   const [fitRequest, setFitRequest] = useState(0);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
+  const [draggedWaypointIndex, setDraggedWaypointIndex] = useState<number | null>(null);
+  const [dragOverWaypointIndex, setDragOverWaypointIndex] = useState<number | null>(null);
   const [internalSelectedWaypointIndex, setInternalSelectedWaypointIndex] = useState<number | null>(
     null,
   );
@@ -165,6 +167,50 @@ export default function RouteEditor({
     setSelectedWaypointIndex(waypoints.length);
   }
 
+  function insertWaypointAfter(index: number) {
+    const waypoint = waypoints[index];
+
+    if (waypoint == null) {
+      return;
+    }
+
+    const nextWaypoints = [...waypoints];
+    nextWaypoints.splice(index + 1, 0, waypoint);
+    setWaypoints(nextWaypoints);
+    setSelectedWaypointIndex(index + 1);
+  }
+
+  function editWaypointCoordinates(index: number) {
+    const waypoint = waypoints[index];
+
+    if (waypoint == null) {
+      return;
+    }
+
+    const input = window.prompt(
+      'Edit coordinates as latitude, longitude',
+      `${waypoint.latitude.toFixed(6)}, ${waypoint.longitude.toFixed(6)}`,
+    );
+
+    if (input == null) {
+      return;
+    }
+
+    const [latitude, longitude] = input.split(',').map((value) => Number(value.trim()));
+
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+      window.alert('Enter coordinates as latitude, longitude.');
+      return;
+    }
+
+    setWaypoints(
+      waypoints.map((currentWaypoint, currentIndex) =>
+        currentIndex === index ? { ...currentWaypoint, latitude, longitude } : currentWaypoint,
+      ),
+    );
+    setRouteFocusTarget({ latitude, longitude });
+  }
+
   function removeWaypoint(index: number) {
     setWaypoints(waypoints.filter((_, currentIndex) => currentIndex !== index));
 
@@ -176,6 +222,11 @@ export default function RouteEditor({
     setSelectedWaypointIndex(
       selectedWaypointIndex > index ? selectedWaypointIndex - 1 : selectedWaypointIndex,
     );
+  }
+
+  function focusWaypoint(waypoint: RouteWaypoint, index: number) {
+    setSelectedWaypointIndex(index);
+    setRouteFocusTarget(waypoint);
   }
 
   function confirmDelete() {
@@ -252,53 +303,102 @@ export default function RouteEditor({
             <span className="muted">{formatWaypointSummary(waypoints, places)}</span>
           </summary>
           <div className="route-editor-collapsible-content">
-            {waypoints.map((waypoint, index) => (
-              <div
-                className={`waypoint-row ${selectedWaypointIndex === index ? 'selected' : ''}`}
-                key={getWaypointKey(waypoint, index)}
-                onPointerDown={() => setSelectedWaypointIndex(index)}
-              >
-                <span className="chip">{getWaypointLabel(index, waypoints.length)}</span>
-                <input
-                  aria-label={`${getWaypointLabel(index, waypoints.length)} latitude`}
-                  inputMode="decimal"
-                  value={waypoint.latitude}
-                  onChange={(event) =>
-                    updateWaypoint(waypoints, setWaypoints, index, 'latitude', event.target.value)
-                  }
-                />
-                <input
-                  aria-label={`${getWaypointLabel(index, waypoints.length)} longitude`}
-                  inputMode="decimal"
-                  value={waypoint.longitude}
-                  onChange={(event) =>
-                    updateWaypoint(waypoints, setWaypoints, index, 'longitude', event.target.value)
-                  }
-                />
-                <fieldset className="row-actions">
-                  <legend className="sr-only">Waypoint actions</legend>
-                  <button
-                    className="secondary"
-                    disabled={index === 0}
-                    type="button"
-                    onClick={() => moveWaypoint(waypoints, setWaypoints, index, index - 1)}
-                  >
-                    ↑
-                  </button>
-                  <button
-                    className="secondary"
-                    disabled={index === waypoints.length - 1}
-                    type="button"
-                    onClick={() => moveWaypoint(waypoints, setWaypoints, index, index + 1)}
-                  >
-                    ↓
-                  </button>
-                  <button className="danger" type="button" onClick={() => removeWaypoint(index)}>
-                    Remove
-                  </button>
-                </fieldset>
+            {waypoints.length === 0 ? (
+              <div className="waypoint-empty-state">
+                <MapPinIcon />
+                <strong>No waypoints yet</strong>
+                <span className="muted">
+                  Tap the map to add your first waypoint, or pick from favorites below.
+                </span>
               </div>
-            ))}
+            ) : (
+              <ul className="waypoint-list" aria-label="Route waypoints">
+                {waypoints.map((waypoint, index) => {
+                  const waypointName = formatWaypointName(waypoint, places, `Pin ${index + 1}`);
+
+                  const waypointRowClassName = [
+                    'waypoint-row',
+                    selectedWaypointIndex === index ? 'selected' : '',
+                    draggedWaypointIndex === index ? 'is-dragging' : '',
+                    dragOverWaypointIndex === index && draggedWaypointIndex !== index
+                      ? 'is-drop-target'
+                      : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
+
+                  return (
+                    <li
+                      className={waypointRowClassName}
+                      draggable
+                      key={getWaypointKey(waypoint, index)}
+                      onDragEnd={() => {
+                        setDraggedWaypointIndex(null);
+                        setDragOverWaypointIndex(null);
+                      }}
+                      onDragEnter={() => setDragOverWaypointIndex(index)}
+                      onDragOver={(event) => event.preventDefault()}
+                      onDragStart={(event) => {
+                        setDraggedWaypointIndex(index);
+                        event.dataTransfer.effectAllowed = 'move';
+                        event.dataTransfer.setData('text/plain', String(index));
+                      }}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        const fromIndex = Number(event.dataTransfer.getData('text/plain'));
+
+                        if (Number.isInteger(fromIndex) && fromIndex !== index) {
+                          moveWaypoint(waypoints, setWaypoints, fromIndex, index);
+                          setSelectedWaypointIndex(index);
+                        }
+
+                        setDraggedWaypointIndex(null);
+                        setDragOverWaypointIndex(null);
+                      }}
+                    >
+                      <button
+                        className="waypoint-focus"
+                        type="button"
+                        onClick={() => focusWaypoint(waypoint, index)}
+                      >
+                        <span className="waypoint-grip" title="Drag to reorder">
+                          <GripVerticalIcon />
+                        </span>
+                        <span className={getWaypointBadgeClassName(index, waypoints.length)}>
+                          {index === waypoints.length - 1 && waypoints.length > 1 ? (
+                            <FlagIcon />
+                          ) : (
+                            index + 1
+                          )}
+                        </span>
+                        <span className="waypoint-name" title={waypointName}>
+                          {waypointName}
+                        </span>
+                        <span className="waypoint-coordinates mono">
+                          {formatWaypointCoords(waypoint)}
+                        </span>
+                      </button>
+                      <details className="waypoint-menu">
+                        <summary aria-label={`More options for ${waypointName}`}>
+                          <MoreHorizontalIcon />
+                        </summary>
+                        <div className="waypoint-menu-content">
+                          <button type="button" onClick={() => removeWaypoint(index)}>
+                            Remove from route
+                          </button>
+                          <button type="button" onClick={() => insertWaypointAfter(index)}>
+                            Insert pin after
+                          </button>
+                          <button type="button" onClick={() => editWaypointCoordinates(index)}>
+                            Edit coordinates
+                          </button>
+                        </div>
+                      </details>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
             <button
               className="secondary button-icon-label"
               disabled={waypoints.length === 0}
@@ -549,10 +649,10 @@ function formatWaypointSummary(waypoints: RouteWaypoint[], places: Place[]): str
     return 'Add one more waypoint to save';
   }
 
-  return `${formatWaypointName(firstWaypoint, places, 'Start')} → ${formatWaypointName(
+  return `${formatWaypointName(firstWaypoint, places, 'Pin 1')} → ${formatWaypointName(
     lastWaypoint,
     places,
-    'End',
+    `Pin ${waypoints.length}`,
   )}`;
 }
 
@@ -566,16 +666,14 @@ function formatWaypointName(waypoint: RouteWaypoint, places: Place[], fallback: 
   );
 }
 
-function getWaypointLabel(index: number, waypointCount: number): string {
-  if (index === 0) {
-    return 'Start';
-  }
+function getWaypointBadgeClassName(index: number, waypointCount: number): string {
+  const positionClass = index === 0 || index === waypointCount - 1 ? 'is-terminal' : 'is-middle';
 
-  if (index === waypointCount - 1) {
-    return 'End';
-  }
+  return `waypoint-badge ${positionClass}`;
+}
 
-  return `Stop ${index + 1}`;
+function formatWaypointCoords(waypoint: RouteWaypoint): string {
+  return `${waypoint.latitude.toFixed(5)}, ${waypoint.longitude.toFixed(5)}`;
 }
 
 function getRouteBuilderHint(
@@ -818,23 +916,35 @@ function MapPinIcon() {
   );
 }
 
-function updateWaypoint(
-  waypoints: RouteWaypoint[],
-  setWaypoints: (waypoints: RouteWaypoint[]) => void,
-  index: number,
-  field: 'latitude' | 'longitude',
-  value: string,
-) {
-  const parsedValue = Number(value);
+function GripVerticalIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <circle cx="9" cy="12" r="1" />
+      <circle cx="9" cy="5" r="1" />
+      <circle cx="9" cy="19" r="1" />
+      <circle cx="15" cy="12" r="1" />
+      <circle cx="15" cy="5" r="1" />
+      <circle cx="15" cy="19" r="1" />
+    </svg>
+  );
+}
 
-  if (!Number.isFinite(parsedValue)) {
-    return;
-  }
+function MoreHorizontalIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="1" />
+      <circle cx="19" cy="12" r="1" />
+      <circle cx="5" cy="12" r="1" />
+    </svg>
+  );
+}
 
-  setWaypoints(
-    waypoints.map((waypoint, currentIndex) =>
-      currentIndex === index ? { ...waypoint, [field]: parsedValue } : waypoint,
-    ),
+function FlagIcon() {
+  return (
+    <svg aria-hidden="true" className="lucide-icon" fill="none" viewBox="0 0 24 24">
+      <path d="M4 22V4" />
+      <path d="M4 4h12l-1 4 1 4H4" />
+    </svg>
   );
 }
 

--- a/web/components/mapStyle.ts
+++ b/web/components/mapStyle.ts
@@ -1,11 +1,51 @@
 import type { StyleSpecification } from 'maplibre-gl';
 
+export type MapStyleName = 'field-notebook' | 'plain';
+
 export const DEFAULT_MAP_CENTER = {
   latitude: 25.033,
   longitude: 121.5654,
 };
 
-export function createRasterMapStyle(): StyleSpecification {
+export const DEFAULT_MAP_STYLE: MapStyleName = 'field-notebook';
+
+const OSM_ATTRIBUTION = '© OpenStreetMap contributors';
+const OSM_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+const MAP_STYLE_OPTIONS: Array<{ description: string; label: string; name: MapStyleName }> = [
+  {
+    description: 'Paper-tinted OSM raster tiles for the Kestrel field notebook workspace.',
+    label: 'Field notebook',
+    name: 'field-notebook',
+  },
+  {
+    description: 'Plain OSM raster tiles for troubleshooting and maximum familiarity.',
+    label: 'Plain',
+    name: 'plain',
+  },
+];
+
+export function getAvailableMapStyles() {
+  return MAP_STYLE_OPTIONS;
+}
+
+export function isMapStyleName(value: string | null): value is MapStyleName {
+  return value === 'field-notebook' || value === 'plain';
+}
+
+export function getNextMapStyleName(styleName: MapStyleName): MapStyleName {
+  return styleName === 'field-notebook' ? 'plain' : 'field-notebook';
+}
+
+export function getMapStyleLabel(styleName: MapStyleName): string {
+  return MAP_STYLE_OPTIONS.find((option) => option.name === styleName)?.label ?? 'Map';
+}
+
+export function getStyleByName(styleName: MapStyleName): StyleSpecification {
+  return styleName === 'plain' ? createPlainMapStyle() : createFieldNotebookMapStyle();
+}
+
+export function createPlainMapStyle(): StyleSpecification {
   return {
     glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
     layers: [
@@ -16,13 +56,56 @@ export function createRasterMapStyle(): StyleSpecification {
       },
     ],
     sources: {
-      osm: {
-        attribution: '© OpenStreetMap contributors',
-        tileSize: 256,
-        tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-        type: 'raster',
-      },
+      osm: createOsmRasterSource(),
     },
     version: 8,
+  };
+}
+
+export function createFieldNotebookMapStyle(): StyleSpecification {
+  return {
+    glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+    layers: [
+      {
+        id: 'paper',
+        paint: {
+          'background-color': '#efe1c3',
+        },
+        type: 'background',
+      },
+      {
+        id: 'osm-paper-wash',
+        paint: {
+          'raster-brightness-max': 0.93,
+          'raster-brightness-min': 0.08,
+          'raster-contrast': -0.22,
+          'raster-hue-rotate': 12,
+          'raster-opacity': 0.72,
+          'raster-saturation': -0.58,
+        },
+        source: 'osm',
+        type: 'raster',
+      },
+      {
+        id: 'paper-veil',
+        paint: {
+          'background-color': 'rgba(244, 226, 190, 0.18)',
+        },
+        type: 'background',
+      },
+    ],
+    sources: {
+      osm: createOsmRasterSource(),
+    },
+    version: 8,
+  };
+}
+
+function createOsmRasterSource(): StyleSpecification['sources'][string] {
+  return {
+    attribution: OSM_ATTRIBUTION,
+    tileSize: 256,
+    tiles: [OSM_TILE_URL],
+    type: 'raster',
   };
 }

--- a/web/components/mapStyle.ts
+++ b/web/components/mapStyle.ts
@@ -1,23 +1,18 @@
 import type { StyleSpecification } from 'maplibre-gl';
 
-export type MapStyleName = 'dark' | 'field-notebook' | 'plain' | 'satellite' | 'terrain';
+export type MapStyleName = 'dark' | 'plain' | 'satellite' | 'terrain';
 
 export const DEFAULT_MAP_CENTER = {
   latitude: 25.033,
   longitude: 121.5654,
 };
 
-export const DEFAULT_MAP_STYLE: MapStyleName = 'field-notebook';
+export const DEFAULT_MAP_STYLE: MapStyleName = 'plain';
 
 const OSM_ATTRIBUTION = '© OpenStreetMap contributors';
 const OSM_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 
 const MAP_STYLE_OPTIONS: Array<{ description: string; label: string; name: MapStyleName }> = [
-  {
-    description: 'Paper-tinted OSM raster tiles for the Kestrel field notebook workspace.',
-    label: 'Notebook',
-    name: 'field-notebook',
-  },
   {
     description: 'Plain OSM raster tiles for troubleshooting and maximum familiarity.',
     label: 'Plain',
@@ -45,13 +40,7 @@ export function getAvailableMapStyles() {
 }
 
 export function isMapStyleName(value: string | null): value is MapStyleName {
-  return (
-    value === 'dark' ||
-    value === 'field-notebook' ||
-    value === 'plain' ||
-    value === 'satellite' ||
-    value === 'terrain'
-  );
+  return value === 'dark' || value === 'plain' || value === 'satellite' || value === 'terrain';
 }
 
 export function getNextMapStyleName(styleName: MapStyleName): MapStyleName {
@@ -82,7 +71,7 @@ export function getStyleByName(styleName: MapStyleName): StyleSpecification {
     return createDarkMapStyle();
   }
 
-  return createFieldNotebookMapStyle();
+  return createPlainMapStyle();
 }
 
 export function createPlainMapStyle(): StyleSpecification {

--- a/web/components/mapStyle.ts
+++ b/web/components/mapStyle.ts
@@ -1,6 +1,6 @@
 import type { StyleSpecification } from 'maplibre-gl';
 
-export type MapStyleName = 'field-notebook' | 'plain';
+export type MapStyleName = 'dark' | 'field-notebook' | 'plain' | 'satellite' | 'terrain';
 
 export const DEFAULT_MAP_CENTER = {
   latitude: 25.033,
@@ -15,13 +15,28 @@ const OSM_TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 const MAP_STYLE_OPTIONS: Array<{ description: string; label: string; name: MapStyleName }> = [
   {
     description: 'Paper-tinted OSM raster tiles for the Kestrel field notebook workspace.',
-    label: 'Field notebook',
+    label: 'Notebook',
     name: 'field-notebook',
   },
   {
     description: 'Plain OSM raster tiles for troubleshooting and maximum familiarity.',
     label: 'Plain',
     name: 'plain',
+  },
+  {
+    description: 'No-key public satellite imagery for photo context.',
+    label: 'Satellite',
+    name: 'satellite',
+  },
+  {
+    description: 'Warm terrain-inspired OSM raster styling without a keyed provider.',
+    label: 'Terrain',
+    name: 'terrain',
+  },
+  {
+    description: 'Warm dusk OSM raster styling without a keyed provider.',
+    label: 'Dark',
+    name: 'dark',
   },
 ];
 
@@ -30,11 +45,20 @@ export function getAvailableMapStyles() {
 }
 
 export function isMapStyleName(value: string | null): value is MapStyleName {
-  return value === 'field-notebook' || value === 'plain';
+  return (
+    value === 'dark' ||
+    value === 'field-notebook' ||
+    value === 'plain' ||
+    value === 'satellite' ||
+    value === 'terrain'
+  );
 }
 
 export function getNextMapStyleName(styleName: MapStyleName): MapStyleName {
-  return styleName === 'field-notebook' ? 'plain' : 'field-notebook';
+  const currentIndex = MAP_STYLE_OPTIONS.findIndex((option) => option.name === styleName);
+  const nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % MAP_STYLE_OPTIONS.length;
+
+  return MAP_STYLE_OPTIONS[nextIndex].name;
 }
 
 export function getMapStyleLabel(styleName: MapStyleName): string {
@@ -42,7 +66,23 @@ export function getMapStyleLabel(styleName: MapStyleName): string {
 }
 
 export function getStyleByName(styleName: MapStyleName): StyleSpecification {
-  return styleName === 'plain' ? createPlainMapStyle() : createFieldNotebookMapStyle();
+  if (styleName === 'plain') {
+    return createPlainMapStyle();
+  }
+
+  if (styleName === 'satellite') {
+    return createSatelliteMapStyle();
+  }
+
+  if (styleName === 'terrain') {
+    return createTerrainMapStyle();
+  }
+
+  if (styleName === 'dark') {
+    return createDarkMapStyle();
+  }
+
+  return createFieldNotebookMapStyle();
 }
 
 export function createPlainMapStyle(): StyleSpecification {
@@ -51,6 +91,95 @@ export function createPlainMapStyle(): StyleSpecification {
     layers: [
       {
         id: 'osm',
+        source: 'osm',
+        type: 'raster',
+      },
+    ],
+    sources: {
+      osm: createOsmRasterSource(),
+    },
+    version: 8,
+  };
+}
+
+export function createSatelliteMapStyle(): StyleSpecification {
+  return {
+    glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+    layers: [
+      {
+        id: 'satellite-imagery',
+        source: 'satellite',
+        type: 'raster',
+      },
+    ],
+    sources: {
+      satellite: {
+        attribution:
+          'Tiles © Esri — Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community',
+        tileSize: 256,
+        tiles: [
+          'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        ],
+        type: 'raster',
+      },
+    },
+    version: 8,
+  };
+}
+
+export function createTerrainMapStyle(): StyleSpecification {
+  return {
+    glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+    layers: [
+      {
+        id: 'terrain-paper',
+        paint: {
+          'background-color': '#e9d7af',
+        },
+        type: 'background',
+      },
+      {
+        id: 'osm-terrain-wash',
+        paint: {
+          'raster-brightness-max': 0.86,
+          'raster-brightness-min': 0.12,
+          'raster-contrast': 0.08,
+          'raster-hue-rotate': 26,
+          'raster-opacity': 0.82,
+          'raster-saturation': -0.2,
+        },
+        source: 'osm',
+        type: 'raster',
+      },
+    ],
+    sources: {
+      osm: createOsmRasterSource(),
+    },
+    version: 8,
+  };
+}
+
+export function createDarkMapStyle(): StyleSpecification {
+  return {
+    glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+    layers: [
+      {
+        id: 'dusk-paper',
+        paint: {
+          'background-color': '#241c16',
+        },
+        type: 'background',
+      },
+      {
+        id: 'osm-dusk-wash',
+        paint: {
+          'raster-brightness-max': 0.48,
+          'raster-brightness-min': 0.02,
+          'raster-contrast': -0.08,
+          'raster-hue-rotate': 24,
+          'raster-opacity': 0.92,
+          'raster-saturation': -0.5,
+        },
         source: 'osm',
         type: 'raster',
       },

--- a/web/hooks/useMapStyle.ts
+++ b/web/hooks/useMapStyle.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DEFAULT_MAP_STYLE,
+  getAvailableMapStyles,
+  getMapStyleLabel,
+  getNextMapStyleName,
+  isMapStyleName,
+  type MapStyleName,
+} from '@/components/mapStyle';
+
+const STORAGE_KEY = 'kestrel-map-style';
+const MAP_STYLE_EVENT = 'kestrel-map-style-change';
+let hasLoggedStyleInfo = false;
+
+type MapStyleContextDetail = {
+  styleName: MapStyleName;
+};
+
+export function useMapStyle() {
+  const [styleName, setStyleNameState] = useState<MapStyleName>(DEFAULT_MAP_STYLE);
+  const availableStyles = useMemo(() => getAvailableMapStyles(), []);
+
+  useEffect(() => {
+    setStyleNameState(readStoredMapStyle() ?? DEFAULT_MAP_STYLE);
+    logMapStyleInfoOnce();
+
+    function handleStorage(event: StorageEvent) {
+      if (event.key === STORAGE_KEY) {
+        setStyleNameState(isMapStyleName(event.newValue) ? event.newValue : DEFAULT_MAP_STYLE);
+      }
+    }
+
+    function handleLocalChange(event: Event) {
+      const customEvent = event as CustomEvent<MapStyleContextDetail>;
+      setStyleNameState(customEvent.detail.styleName);
+    }
+
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener(MAP_STYLE_EVENT, handleLocalChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener(MAP_STYLE_EVENT, handleLocalChange);
+    };
+  }, []);
+
+  const setStyleName = useCallback((nextStyleName: MapStyleName) => {
+    writeStoredMapStyle(nextStyleName);
+    setStyleNameState(nextStyleName);
+    window.dispatchEvent(
+      new CustomEvent<MapStyleContextDetail>(MAP_STYLE_EVENT, {
+        detail: { styleName: nextStyleName },
+      }),
+    );
+  }, []);
+
+  const toggleStyleName = useCallback(() => {
+    setStyleName(getNextMapStyleName(styleName));
+  }, [setStyleName, styleName]);
+
+  return {
+    availableStyles,
+    canToggle: availableStyles.length > 1,
+    label: getMapStyleLabel(styleName),
+    setStyleName,
+    styleName,
+    toggleStyleName,
+  };
+}
+
+function readStoredMapStyle(): MapStyleName | null {
+  try {
+    const storedStyleName = window.localStorage.getItem(STORAGE_KEY);
+
+    return isMapStyleName(storedStyleName) ? storedStyleName : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredMapStyle(styleName: MapStyleName) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, styleName);
+  } catch {
+    // A blocked or full Web Storage area should not break map rendering.
+  }
+}
+
+function logMapStyleInfoOnce() {
+  if (hasLoggedStyleInfo || process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  hasLoggedStyleInfo = true;
+  console.info(
+    'Kestrel map styles use built-in no-key OpenStreetMap raster sources; no map provider key is required.',
+  );
+}


### PR DESCRIPTION
## Summary
- implement the field-notebook / cartographer dashboard for Places and Routes with full-viewport map stages, floating notebooks, index cards, user controls, and keyboard shortcuts
- add paper/ink/rust typography tokens, Google font wiring, paper grain, warm dark compatibility, and cartographer responsive guardrails
- replace the old OSM-only map style helper with typed built-in `field-notebook` and `plain` MapLibre styles plus localStorage-backed style switching (`kestrel-map-style`)
- preserve existing place/route save, delete, share, route waypoint, map click/drag, and account/theme/password flows
- mark all five implementation plans complete and document the no-key OpenStreetMap raster + local paper-tint provider decision

## Verification
- `cd web && npm exec -- biome ci .`
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `git diff --check`
- Browser smoke with mock backend: login, `/dashboard/places`, `/dashboard/routes`, `/share/demo-place`, `/share/demo-route`
- Browser smoke confirmed Places/Routes cartographer stage, no old topbar/tabs, no horizontal overflow at 1280 / 780 / 390px, map style toggle persists `kestrel-map-style`, route markers survive style toggle, keyboard shortcuts (`?`, `Esc`, `/`, `g p`) work outside inputs, and user menu theme/password controls are reachable
- Verified no keyed map-provider implementation: `rg -n "NEXT_PUBLIC_.*MAP|api_key=" web` returned no hits