### PR TITLE
fix(web): resolve route editor overflow

### DIFF
--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -40,6 +40,7 @@ export default function RoutesDashboardPage() {
   const [routeQuery, setRouteQuery] = useState('');
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [viewportControls, setViewportControls] = useState<RouteMapControls | null>(null);
+  const [fitRequest, setFitRequest] = useState(0);
   const [draftWaypoints, setDraftWaypoints] = useState<RouteWaypoint[]>([]);
   const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
@@ -94,14 +95,19 @@ export default function RoutesDashboardPage() {
   }, [auth.isAuthenticated, auth.isHydrated, loadRoutes]);
 
   useEffect(() => {
-    setDraftWaypoints(
+    const nextWaypoints =
       selectedRoute?.currentRevision?.waypoints.map((waypoint) => ({
         latitude: waypoint.latitude,
         longitude: waypoint.longitude,
-      })) ?? [],
-    );
+      })) ?? [];
+
+    setDraftWaypoints(nextWaypoints);
     setSelectedWaypointIndex(null);
     setFocusTarget(null);
+
+    if (nextWaypoints.length > 0) {
+      setFitRequest((currentRequest) => currentRequest + 1);
+    }
   }, [selectedRoute]);
 
   const createNewRoute = useCallback(() => {
@@ -159,6 +165,7 @@ export default function RoutesDashboardPage() {
       map={
         <RouteMapEditor
           className="cartographer-map"
+          fitRequest={fitRequest}
           focusTarget={focusTarget}
           selectedWaypointIndex={selectedWaypointIndex}
           waypoints={selectedWaypoints}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5348,3 +5348,76 @@ button.is-loading {
     font-size: 22px;
   }
 }
+
+/* Route editor overflow and selection-fit fixes */
+.index-card,
+.index-card-route,
+.index-card-body,
+.index-card .route-editor {
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+.index-card .route-editor {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.route-editor-waypoints-section {
+  min-width: 0;
+}
+
+.route-editor-waypoints-section .route-editor-collapsible-content {
+  min-width: 0;
+}
+
+.route-editor-waypoints-section .waypoint-list {
+  box-sizing: border-box;
+  max-height: min(360px, 38vh);
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-block: 2px;
+  scrollbar-gutter: stable;
+}
+
+.route-editor-waypoints-section .waypoint-row {
+  box-sizing: border-box;
+  min-width: 0;
+  overflow: visible;
+}
+
+.route-editor-waypoints-section .waypoint-focus {
+  min-width: 0;
+}
+
+.route-editor-waypoints-section .waypoint-name,
+.route-editor-waypoints-section .waypoint-coordinates {
+  min-width: 0;
+}
+
+.index-card .route-editor-footer {
+  box-sizing: border-box;
+  margin: 0;
+  position: sticky;
+  width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .field-notebook {
+    gap: 10px;
+  }
+
+  .notebook-nav a {
+    min-height: 30px;
+    padding-block: 0;
+  }
+
+  .notebook-search input {
+    min-height: 36px;
+  }
+
+  .notebook-new-entry {
+    min-height: 56px;
+    padding-block: 8px;
+  }
+}


### PR DESCRIPTION
## Summary
- prevent horizontal overflow in the route editor panel and waypoint list
- constrain waypoint list scrolling so rows are not clipped
- auto-fit the map when selecting a route with waypoints
- tighten the routes sidebar controls to preserve list space

## Verification
- npm run lint
- npm run typecheck