### PR TITLE
fix(web): refine cartographer list states

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -221,7 +221,11 @@ export default function PlacesDashboardPage() {
         ))}
         {filteredPlaces.length === 0 && !isLoading ? (
           <div className="notebook-empty">
-            <p className="muted no-margin">No matching places on this page.</p>
+            <p className="muted no-margin">
+              {places.length === 0
+                ? 'No places yet. Use New place to save your first coordinate.'
+                : 'No places match this search.'}
+            </p>
           </div>
         ) : null}
       </FieldNotebook>

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -219,7 +219,11 @@ export default function RoutesDashboardPage() {
         ))}
         {filteredRoutes.length === 0 && !isLoading ? (
           <div className="notebook-empty">
-            <p className="muted no-margin">No matching routes on this page.</p>
+            <p className="muted no-margin">
+              {routes.length === 0
+                ? 'No routes yet. Use New route to start with map pins or favorites.'
+                : 'No routes match this search.'}
+            </p>
           </div>
         ) : null}
       </FieldNotebook>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5609,3 +5609,27 @@ button.is-loading {
 .cartographer-stage .place-editor-footer {
   background: rgb(255 249 236 / 92%);
 }
+
+/* Softer active notebook rows: keep selection clear without a heavy filled card. */
+.cartographer-stage .notebook-entry.active {
+  background: rgb(180 95 50 / 10%);
+  border-color: rgb(180 95 50 / 34%);
+  box-shadow: none;
+  color: var(--text-primary);
+}
+
+.cartographer-stage .notebook-entry.active::before {
+  background: var(--accent);
+  opacity: 1;
+}
+
+.cartographer-stage .notebook-entry.active strong,
+.cartographer-stage .notebook-entry.active .font-mono {
+  color: var(--text-primary);
+}
+
+.cartographer-stage .notebook-entry.active .chip {
+  background: rgb(255 249 236 / 72%);
+  border-color: rgb(180 95 50 / 24%);
+  color: var(--accent-hover);
+}


### PR DESCRIPTION
## Summary
- distinguish empty notebook lists from search-with-no-results states
- soften active notebook row styling to reduce visual weight
- keep tag chips readable on active rows

## Verification
- npm run lint
- npm run typecheck
- local Docker Compose smoke with admin/admin