### PR TITLE
fix(web): stabilize notebook tabs

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -196,7 +196,6 @@ export default function PlacesDashboardPage() {
       />
       <FieldNotebook
         activeSection="places"
-        count={places.length}
         newLabel="New place"
         searchPlaceholder="Find a place"
         searchRef={searchRef}

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -189,7 +189,6 @@ export default function RoutesDashboardPage() {
       />
       <FieldNotebook
         activeSection="routes"
-        count={routes.length}
         newLabel="New route"
         searchPlaceholder="Find a route"
         searchRef={searchRef}

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -4,7 +4,6 @@ import type { ReactNode, RefObject } from 'react';
 type FieldNotebookProps = {
   activeSection: 'places' | 'routes';
   children: ReactNode;
-  count: number;
   newLabel: string;
   onNewEntry: () => void;
   onSearchChange: (value: string) => void;
@@ -16,7 +15,6 @@ type FieldNotebookProps = {
 export function FieldNotebook({
   activeSection,
   children,
-  count,
   newLabel,
   onNewEntry,
   onSearchChange,
@@ -24,8 +22,6 @@ export function FieldNotebook({
   searchRef,
   searchValue,
 }: FieldNotebookProps) {
-  const activeCount = <span className="notebook-tab-count font-mono">{count}</span>;
-
   return (
     <aside className="field-notebook" aria-label={`${activeSection} field notebook`}>
       <div aria-hidden className="field-notebook-spine" />
@@ -36,7 +32,6 @@ export function FieldNotebook({
           href="/dashboard/places"
         >
           <span>Places</span>
-          {activeSection === 'places' ? activeCount : null}
         </Link>
         <Link
           aria-current={activeSection === 'routes' ? 'page' : undefined}
@@ -44,7 +39,6 @@ export function FieldNotebook({
           href="/dashboard/routes"
         >
           <span>Routes</span>
-          {activeSection === 'routes' ? activeCount : null}
         </Link>
       </nav>
       <label className="notebook-search font-mono">


### PR DESCRIPTION
## Summary
- remove active-only count badges from Places / Routes notebook tabs
- keep tab labels stable when switching between dashboard sections

## Verification
- npm run lint
- npm run typecheck
- local check: Places and Routes tab widths match on both pages