### PR TITLE
Clarify foreground notification copy

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
@@ -408,7 +408,9 @@ class LocationService : Service() {
                 CHANNEL_ID,
                 getString(R.string.location_service_channel_name),
                 NotificationManager.IMPORTANCE_LOW,
-            ),
+            ).apply {
+                description = getString(R.string.location_service_channel_description)
+            },
         )
     }
 
@@ -423,10 +425,10 @@ class LocationService : Service() {
             )
         val text =
             when {
-                currentMode == MockState.Mode.Idle -> getString(R.string.location_service_text)
-                currentMode == MockState.Mode.Single -> "Single point mock active"
-                paused -> "Route paused"
-                else -> "Route playing"
+                currentMode == MockState.Mode.Idle -> getString(R.string.location_service_text_ready)
+                currentMode == MockState.Mode.Single -> getString(R.string.location_service_text_single)
+                paused -> getString(R.string.location_service_text_route_paused)
+                else -> getString(R.string.location_service_text_route_playing)
             }
         val builder =
             NotificationCompat
@@ -439,13 +441,25 @@ class LocationService : Service() {
 
         if (currentMode == MockState.Mode.Route) {
             if (paused) {
-                builder.addAction(0, "Resume", servicePI(REQ_RESUME, ACTION_RESUME))
+                builder.addAction(
+                    0,
+                    getString(R.string.location_service_action_resume),
+                    servicePI(REQ_RESUME, ACTION_RESUME),
+                )
             } else {
-                builder.addAction(0, "Pause", servicePI(REQ_PAUSE, ACTION_PAUSE))
+                builder.addAction(
+                    0,
+                    getString(R.string.location_service_action_pause),
+                    servicePI(REQ_PAUSE, ACTION_PAUSE),
+                )
             }
         }
         if (currentMode != MockState.Mode.Idle) {
-            builder.addAction(0, "Stop", servicePI(REQ_STOP, ACTION_STOP))
+            builder.addAction(
+                0,
+                getString(R.string.location_service_action_stop),
+                servicePI(REQ_STOP, ACTION_STOP),
+            )
         }
         return builder.build()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,14 @@
 <resources>
     <string name="app_name">Kestrel</string>
     <string name="location_service_channel_name">Mock location</string>
-    <string name="location_service_title">Kestrel mock location</string>
-    <string name="location_service_text">Mock location is active</string>
+    <string name="location_service_channel_description">Shows when Kestrel is providing mock location updates.</string>
+    <string name="location_service_title">Kestrel is controlling location</string>
+    <string name="location_service_text_ready">Mock location service is ready</string>
+    <string name="location_service_text_single">Holding a single mock location</string>
+    <string name="location_service_text_route_paused">Mock route paused</string>
+    <string name="location_service_text_route_playing">Playing a mock route</string>
+    <string name="location_service_action_pause">Pause</string>
+    <string name="location_service_action_resume">Resume</string>
+    <string name="location_service_action_stop">Stop</string>
     <string name="asset_statements" translatable="false"><![CDATA[[{"relation":["delegate_permission/common.get_login_creds"],"target":{"namespace":"web","site":"https://kestrel.narumi.dev"}}]]]></string>
 </resources>

--- a/docs/plans/2026-05-10_engineering-backlog-plan.md
+++ b/docs/plans/2026-05-10_engineering-backlog-plan.md
@@ -23,7 +23,7 @@ This backlog comes from the general TODO and the operations/DX sections of the c
 - [ ] Generate or publish OpenAPI docs for auth/library/sync/sharing APIs.
 - [ ] Decide client generation strategy: TypeScript generated client, Kotlin generated client, or documented hand-written client rules.
 - [ ] Add Android jitter option for mock samples: configurable lat/lng and speed perturbation, default off, with `MovementEngine`/service tests where possible.
-- [ ] Improve foreground notification title/text and channel description.
+- [x] Improve foreground notification title/text and channel description. Completed in `docs/plans/archived/2026-05-23_foreground-notification-copy-plan.md`; verified with stale-copy `rg` check and `just check`.
 - [ ] Replace default Android Studio app icon with Kestrel adaptive icon assets.
 - [ ] Add Generate route advanced parameters: starting bearing, turn variance, and optional seed.
 - [ ] Add Android route revision history UI only if a concrete product need appears; keep current-revision-only storage/load behavior as the default until that slice is planned.

--- a/docs/plans/archived/2026-05-23_foreground-notification-copy-plan.md
+++ b/docs/plans/archived/2026-05-23_foreground-notification-copy-plan.md
@@ -1,0 +1,35 @@
+# Foreground notification copy plan
+
+## Goal
+
+Make Kestrel's foreground location-service notification clearer and more maintainable by improving the notification title, mode-specific text, and Android notification channel description.
+
+## Context
+
+Current notification copy is split between `app/src/main/res/values/strings.xml` and hard-coded strings in `LocationService.kt`. The notification channel has a name but no description. This is a small app-polish item from `docs/plans/2026-05-10_engineering-backlog-plan.md`.
+
+## Non-Goals
+
+- Do not redesign notification behavior, actions, icons, priority, or foreground-service lifecycle.
+- Do not add zh-TW / ja localization in this slice; keep the current default English resource set.
+
+## Plan
+
+- [x] Add string resources in `app/src/main/res/values/strings.xml` for the channel description and each notification state/action label so notification copy is resource-backed; verified by inspecting the resource names and usages in `LocationService.kt`.
+- [x] Update `LocationService.ensureChannel()` to set `NotificationChannel.description` to the new channel description; verified by reading `LocationService.kt` and confirming the description is assigned before `createNotificationChannel()`.
+- [x] Update `LocationService.buildNotification()` to use clearer copy for idle/default, single-point, route-playing, and route-paused states, plus resource-backed Pause/Resume/Stop action labels; verified with `rg -n 'Single point mock active|Route paused|Route playing|"Pause"|"Resume"|"Stop"' app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt` returning no stale hard-coded notification copy.
+- [x] Run `just check` to verify formatting and static checks for the Android project. Initial run exposed unrelated web formatting drift in `web/app/globals.css` and `web/components/dashboard/RouteEditor.tsx`; after targeted Biome formatting, `just check` passed.
+- [x] Update `docs/plans/2026-05-10_engineering-backlog-plan.md` to mark the foreground notification wording item complete, including the verification command evidence.
+
+## Risks
+
+- Existing notification channels keep their old user-visible metadata on devices where the channel already exists; verification of the new channel description may require clearing app data or a fresh install.
+- Over-specific copy could imply mock location is active while the service is only ready/restoring; keep idle/default text distinct from active single-point or route states.
+
+## Completion Checklist
+
+- [x] Foreground notification title/text/action copy is resource-backed and clearer, verified by `LocationService.kt` and `strings.xml` diffs.
+- [x] Notification channel description is set in `LocationService.ensureChannel()`, verified by code inspection.
+- [x] No stale hard-coded notification status/action strings remain in `LocationService.kt`, verified by `rg -n 'Single point mock active|Route paused|Route playing|"Pause"|"Resume"|"Stop"' app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt` returning no output.
+- [x] Android checks pass as part of `just check`; full `just check` passed after targeted Biome formatting of unrelated web formatting drift.
+- [x] The engineering backlog foreground-notification item is checked off with evidence in `docs/plans/2026-05-10_engineering-backlog-plan.md`.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3119,7 +3119,9 @@ button.is-loading {
   grid-template-columns: minmax(0, 1fr) 32px;
   min-height: 44px;
   padding: 0 8px;
-  transition: background 150ms ease, border-color 150ms ease;
+  transition:
+    background 150ms ease,
+    border-color 150ms ease;
 }
 
 .waypoint-focus {
@@ -4747,7 +4749,13 @@ button.is-loading {
 
   .cartographer-paper-vignette {
     background:
-      linear-gradient(90deg, rgb(47 34 21 / 10%), transparent 22%, transparent 78%, rgb(47 34 21 / 8%)),
+      linear-gradient(
+        90deg,
+        rgb(47 34 21 / 10%),
+        transparent 22%,
+        transparent 78%,
+        rgb(47 34 21 / 8%)
+      ),
       radial-gradient(circle at 50% 46%, transparent 0 56%, rgb(65 44 26 / 14%) 100%);
   }
 

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -344,7 +344,10 @@ export default function RouteEditor({
         />
       </section>
 
-      <details className="route-editor-section route-editor-collapsible route-editor-waypoints-section" open={waypoints.length > 0}>
+      <details
+        className="route-editor-section route-editor-collapsible route-editor-waypoints-section"
+        open={waypoints.length > 0}
+      >
         <summary>
           <span>Waypoints ({waypoints.length})</span>
           <span className="muted">{formatWaypointSummary(waypoints, places)}</span>


### PR DESCRIPTION
## Summary
- add resource-backed foreground notification title, state text, and actions
- set the mock-location notification channel description
- archive the completed notification-copy plan and mark the backlog item complete
- apply existing Biome formatting drift so repository checks pass

## Verification
- rg -n 'Single point mock active|Route paused|Route playing|"Pause"|"Resume"|"Stop"' app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
- just check
- just build