### PR TITLE
Simplify Android launcher icon

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,37 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <path android:pathData="M0,0h108v108h-108z">
-        <aapt:attr name="android:fillColor">
-            <gradient
-                android:endX="92"
-                android:endY="102"
-                android:startX="16"
-                android:startY="6"
-                android:type="linear">
-                <item
-                    android:color="#123F46"
-                    android:offset="0" />
-                <item
-                    android:color="#1D6B63"
-                    android:offset="0.55" />
-                <item
-                    android:color="#D89B45"
-                    android:offset="1" />
-            </gradient>
-        </aapt:attr>
-    </path>
     <path
-        android:fillColor="#1AFFFFFF"
-        android:pathData="M-6,72L118,28L118,44L-6,88z" />
-    <path
-        android:fillColor="#14FFFFFF"
-        android:pathData="M-8,92L116,52L116,64L-8,104z" />
-    <path
-        android:fillColor="#182B1B10"
-        android:pathData="M0,0h108v18h-108z" />
+        android:fillColor="#0D3440"
+        android:pathData="M0,0h108v108h-108z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -4,21 +4,15 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#33000000"
-        android:pathData="M28,75L45,61L37,55L16,41L36,46L55,21L68,49L93,41L76,56L82,88L55,69L31,88z" />
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M25.5,77.1C39.8,59.3 59.3,46.9 86.9,38.9C70.9,59.3 48.7,72.7 25.5,77.1z" />
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M25,70L43,58L35,52L18,38L38,44L54,20L65,48L90,38L72,55L78,84L54,66L30,84L36,55z" />
-    <path
-        android:fillColor="#123F46"
-        android:pathData="M49,54L58,36L62,51L57,59z" />
-    <path
-        android:fillColor="#123F46"
-        android:pathData="M40,50L51,59L36,56z" />
-    <path
-        android:fillColor="#123F46"
-        android:pathData="M67,52L58,60L73,56z" />
+        android:pathData="M22,62C39.8,49.5 60.2,40.7 86,37.1C68.2,52.2 44.2,62.9 22,62z" />
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M54,45L58,55L51,55z" />
+        android:pathData="M27.3,48.7C44.2,40.7 62,36.2 83.4,35.3C67.4,45.1 47.8,51.3 27.3,48.7z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M38,37.1C52.2,32.6 66.5,30.9 81.6,32.6C68.2,38.9 53.1,41.5 38,37.1z" />
 </vector>

--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -5,5 +5,14 @@
     android:viewportHeight="108">
     <path
         android:fillColor="#FFFFFFFF"
-        android:pathData="M25,70L43,58L35,52L18,38L38,44L54,20L65,48L90,38L72,55L78,84L54,66L30,84L36,55z" />
+        android:pathData="M25.5,77.1C39.8,59.3 59.3,46.9 86.9,38.9C70.9,59.3 48.7,72.7 25.5,77.1z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M22,62C39.8,49.5 60.2,40.7 86,37.1C68.2,52.2 44.2,62.9 22,62z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M27.3,48.7C44.2,40.7 62,36.2 83.4,35.3C67.4,45.1 47.8,51.3 27.3,48.7z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M38,37.1C52.2,32.6 66.5,30.9 81.6,32.6C68.2,38.9 53.1,41.5 38,37.1z" />
 </vector>

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,5 +1,6 @@
 ## GOTCHA
 
+- Android adaptive launcher icon layers are `108dp × 108dp`; keep important artwork inside the central `66dp × 66dp` safe zone (`x/y = 21..87`) and size the logo about `48..66dp`. Legacy launcher PNG sizes are mdpi 48, hdpi 72, xhdpi 96, xxhdpi 144, xxxhdpi 192 px.
 - Android `:app:assembleRelease` currently produces `app/build/outputs/apk/release/app-release-unsigned.apk` because there is no signing config yet. Any workflow or release docs must call the artifact unsigned until keystore-based signing is added.
 - The auto-tag flow must push tags with `PAT_TOKEN`, not the default `GITHUB_TOKEN`, or the follow-up `push.tags` release workflow will not fire.
 - Backend Prisma schema edits are not visible to TypeScript/Nest until `cd backend && npm run prisma:generate` refreshes `node_modules/@prisma/client`; if `shareLink` or other new model types seem to be missing during `npm run typecheck`/`npm run build`, regenerate the client first.


### PR DESCRIPTION
## Summary
- replace the launcher foreground with a simple four-feather kestrel wing mark
- keep the wing mark inside Android's 66dp adaptive icon safe zone on a 108dp canvas
- keep the adaptive background as a single deep teal vector for clean scaling
- use the same safe-zone wing mark for the monochrome adaptive icon layer

## Verification
- generated preview: /tmp/kestrel-icon-candidate-v11-safe.svg.png
- just build
- just check