### PR TITLE
fix(backend): serialize polling with opt-out

### DIFF
--- a/backend/src/remote-control/remote-control.service.spec.ts
+++ b/backend/src/remote-control/remote-control.service.spec.ts
@@ -396,8 +396,12 @@ describe('RemoteControlService', () => {
       },
       where: { status: RemoteCommandStatus.QUEUED },
     });
-    expect(prismaService.device.update.mock.calls[0]?.[0]).toMatchObject({
+    expect(prismaService.device.updateMany.mock.calls[0]?.[0]).toMatchObject({
       data: { lastSeenAt: new Date('2026-06-20T08:00:00.000Z') },
+      where: {
+        clientDeviceId: 'client-1',
+        remoteControlEnabled: true,
+      },
     });
   });
 
@@ -459,6 +463,7 @@ describe('RemoteControlService', () => {
   });
 
   it('expires queued commands and returns nothing when remote control is disabled', async () => {
+    prismaService.device.updateMany.mockResolvedValue({ count: 0 });
     prismaService.device.findFirst.mockResolvedValue({
       id: 'device-1',
       remoteControlEnabled: false,

--- a/backend/src/remote-control/remote-control.service.ts
+++ b/backend/src/remote-control/remote-control.service.ts
@@ -172,15 +172,23 @@ export class RemoteControlService {
     const now = new Date();
 
     return this.prismaService.$transaction(async (tx) => {
-      const device = await this.assertOwnDevice(
-        tx,
-        userId,
-        deviceId,
-        input.clientDeviceId,
-      );
+      await this.assertOwnDevice(tx, userId, deviceId, input.clientDeviceId);
       await this.expireStaleCommands(tx, now, { deviceId, userId });
 
-      if (!device.remoteControlEnabled) {
+      const enabled = await tx.device.updateMany({
+        data: {
+          lastSeenAt: now,
+        },
+        where: {
+          clientDeviceId: input.clientDeviceId,
+          id: deviceId,
+          platform: DevicePlatform.ANDROID,
+          remoteControlEnabled: true,
+          userId,
+        },
+      });
+
+      if (enabled.count === 0) {
         await tx.remoteCommand.updateMany({
           data: {
             errorMessage: REMOTE_CONTROL_DISABLED_MESSAGE,
@@ -240,15 +248,6 @@ export class RemoteControlService {
           deliveredCommands.push(command);
         }
       }
-
-      await tx.device.update({
-        data: {
-          lastSeenAt: now,
-        },
-        where: {
-          id: deviceId,
-        },
-      });
 
       return {
         commands: deliveredCommands.map((command) =>


### PR DESCRIPTION
## Summary
- recheck and lock enabled Android device rows before claiming queued commands during poll
- expire queued commands and return an empty batch if the enabled recheck fails

## Validation
- cd backend && npm test -- --runInBand
- cd backend && npx tsc --noEmit -p tsconfig.build.json --incremental false
- cd backend && npm run lint -- --max-warnings=0

Fixes follow-up review feedback from #153.