### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "author": "",
   "private": true,

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.disallowKotlinSourceSets=false
-appVersionCode=9
-appVersionName=0.2.0
+appVersionCode=10
+appVersionName=0.3.0

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kestrel-web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kestrel-web",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "maplibre-gl": "^5.14.0",
         "next": "^16.2.9",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kestrel-web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3301",


### PR DESCRIPTION
## Summary
- bump shared Android/backend/web version to `0.3.0` via `minor`
- bump Android `appVersionCode` to `10`

## Notes
- generated by `.github/workflows/bump-version.yml`
- requires repository secret `PAT_TOKEN` so the resulting PR can trigger downstream CI workflows