### PR TITLE
Improve Google Maps link handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,17 +45,7 @@
 
                 <data android:scheme="geo" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:host="maps.google.com"
-                    android:scheme="https" />
-            </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -65,17 +55,17 @@
                     android:host="google.com"
                     android:pathPrefix="/maps"
                     android:scheme="https" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
                 <data
                     android:host="www.google.com"
                     android:pathPrefix="/maps"
                     android:scheme="https" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
@@ -75,8 +75,13 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun consumeMapLinkIntent(intent: Intent?) {
-        if (intent?.action != Intent.ACTION_VIEW) return
-        pendingMapLinkPoint = intent.dataString?.let(::parseCoordInput)
+        val raw =
+            when (intent?.action) {
+                Intent.ACTION_VIEW -> intent.dataString
+                Intent.ACTION_SEND -> intent.getStringExtra(Intent.EXTRA_TEXT)
+                else -> null
+            }
+        pendingMapLinkPoint = raw?.let(::parseCoordInput)
     }
 
     companion object {

--- a/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
+++ b/app/src/main/java/dev/narumi/kestrel/MainActivity.kt
@@ -78,7 +78,7 @@ class MainActivity : ComponentActivity() {
         val raw =
             when (intent?.action) {
                 Intent.ACTION_VIEW -> intent.dataString
-                Intent.ACTION_SEND -> intent.getStringExtra(Intent.EXTRA_TEXT)
+                Intent.ACTION_SEND -> intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
                 else -> null
             }
         pendingMapLinkPoint = raw?.let(::parseCoordInput)


### PR DESCRIPTION
## Summary
- handle text/plain shared map links in MainActivity
- scope web map intents to google.com/maps and www.google.com/maps
- keep geo: testing and mark Google Maps web links autoVerify-capable for device app-link overrides

## Tests
- just build
- just br
- just check