### PR TITLE
Improve route editor hierarchy

### DIFF
--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -197,7 +197,7 @@ export default function PlacesDashboardPage() {
       <FieldNotebook
         activeSection="places"
         newLabel="New place"
-        searchPlaceholder="Find a place"
+        searchPlaceholder="Search places..."
         searchRef={searchRef}
         searchValue={placeQuery}
         onNewEntry={createNewPlace}

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -211,27 +211,18 @@ export default function RoutesDashboardPage() {
           >
             <span className="route-card-title-row">
               <strong className="route-card-title">{route.name}</strong>
-              <span className="route-card-badges">
-                {route.isPublic ? <span className="route-card-status">Public</span> : null}
-                <span className="route-card-rev">
-                  Revision {route.currentRevision?.revisionNumber ?? '—'}
-                </span>
-              </span>
+              {route.isPublic ? <span className="route-card-status">Public</span> : null}
             </span>
-            <span className="route-card-metrics">
-              <span>
-                <small>Distance</small>
-                <strong>{formatRouteDistance(route)}</strong>
-              </span>
-              <span>
-                <small>Speed</small>
-                <strong>{route.defaultSpeedKmh} km/h</strong>
-              </span>
-              <span>
-                <small>Mode</small>
-                <strong>{formatMode(route.mode)}</strong>
-              </span>
+            <span className="route-card-meta-line">
+              {formatRouteDistance(route)} · {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
+              · Revision {route.currentRevision?.revisionNumber ?? '—'}
             </span>
+            {selectedRouteId === route.id ? (
+              <span className="route-card-selected-detail">
+                {(route.currentRevision?.waypoints.length ?? 0).toLocaleString()} waypoints
+                {route.description == null ? '' : ` · ${route.description}`}
+              </span>
+            ) : null}
           </button>
         ))}
         {filteredRoutes.length === 0 && !isLoading ? (

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -187,10 +187,15 @@ export default function RoutesDashboardPage() {
         onChangePassword={changePassword}
         onLogout={auth.logout}
       />
+      <div className="route-mode-bar" role="status">
+        <strong>Editing route</strong>
+        <span>Click map to add waypoint</span>
+        <span>Drag pins to adjust; drag rows to reorder</span>
+      </div>
       <FieldNotebook
         activeSection="routes"
         newLabel="New route"
-        searchPlaceholder="Find a route"
+        searchPlaceholder="Search routes..."
         searchRef={searchRef}
         searchValue={routeQuery}
         onNewEntry={createNewRoute}
@@ -205,14 +210,27 @@ export default function RoutesDashboardPage() {
             onClick={() => setSelectedRouteId(route.id)}
           >
             <span className="route-card-title-row">
-              <strong>{route.name}</strong>
-              {route.isPublic ? <span className="route-card-status">public</span> : null}
+              <strong className="route-card-title">{route.name}</strong>
+              <span className="route-card-badges">
+                {route.isPublic ? <span className="route-card-status">Public</span> : null}
+                <span className="route-card-rev">
+                  Revision {route.currentRevision?.revisionNumber ?? '—'}
+                </span>
+              </span>
             </span>
-            <span className="font-mono">
-              {formatRouteDistance(route)} · {route.defaultSpeedKmh} km/h · {formatMode(route.mode)}
-            </span>
-            <span className="route-card-rev font-mono">
-              rev {route.currentRevision?.revisionNumber ?? '—'}
+            <span className="route-card-metrics">
+              <span>
+                <small>Distance</small>
+                <strong>{formatRouteDistance(route)}</strong>
+              </span>
+              <span>
+                <small>Speed</small>
+                <strong>{route.defaultSpeedKmh} km/h</strong>
+              </span>
+              <span>
+                <small>Mode</small>
+                <strong>{formatMode(route.mode)}</strong>
+              </span>
             </span>
           </button>
         ))}
@@ -234,13 +252,12 @@ export default function RoutesDashboardPage() {
         }
         stamp={
           selectedRoute == null
-            ? 'draft route'
-            : `revision ${selectedRoute.currentRevision?.revisionNumber ?? '—'}`
+            ? 'Draft route'
+            : `Revision ${selectedRoute.currentRevision?.revisionNumber ?? '—'}`
         }
         subtitle="Build the path, tune playback, and publish the latest route when ready."
         title={selectedRoute?.name ?? 'New route'}
         variant="route"
-        meta={<RouteMeta route={selectedRoute} />}
       >
         <RouteEditor
           key={selectedRoute?.id ?? 'new-route'}
@@ -264,30 +281,6 @@ export default function RoutesDashboardPage() {
       <ScaleBar />
       <KeyboardCheatsheet isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
     </Stage>
-  );
-}
-
-function RouteMeta({ route }: { route: Route | null }) {
-  if (route == null) {
-    return (
-      <div className="index-card-coordinate-grid font-mono">
-        <span>0 waypoints</span>
-        <span>draft</span>
-      </div>
-    );
-  }
-
-  const waypointCount = route.currentRevision?.waypoints.length ?? 0;
-
-  return (
-    <div className="index-card-coordinate-grid font-mono">
-      <span>
-        {waypointCount} waypoint{waypointCount === 1 ? '' : 's'}
-      </span>
-      <span>{formatRouteDistance(route)}</span>
-      <span>{route.defaultSpeedKmh} km/h</span>
-      <span>{formatMode(route.mode)}</span>
-    </div>
   );
 }
 

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -13,7 +13,11 @@ import { UserMark } from '@/components/cartographer/UserMark';
 import { useKeyboardShortcuts } from '@/components/cartographer/useKeyboardShortcuts';
 import RouteEditor from '@/components/dashboard/RouteEditor';
 import { useDashboardAuth } from '@/components/dashboard/useDashboardAuth';
-import { formatError, formatMode } from '@/components/dashboard/utils';
+import {
+  formatError,
+  formatMode,
+  formatRouteDistanceFromWaypoints,
+} from '@/components/dashboard/utils';
 import type { RouteMapControls } from '@/components/RouteMapEditor';
 import type { Place, Route, RouteInput, RouteWaypoint } from '@/lib/api';
 
@@ -286,38 +290,7 @@ function NotebookSkeleton() {
 }
 
 function formatRouteDistance(route: Route): string {
-  const waypoints = route.currentRevision?.waypoints ?? [];
-  const distanceKm = waypoints.slice(1).reduce((totalDistance, waypoint, index) => {
-    const previousWaypoint = waypoints[index];
-
-    return totalDistance + getDistanceKm(previousWaypoint, waypoint);
-  }, 0);
-
-  if (distanceKm < 10) {
-    return `${distanceKm.toFixed(1)} km`;
-  }
-
-  return `${Math.round(distanceKm)} km`;
-}
-
-function getDistanceKm(
-  from: { latitude: number; longitude: number },
-  to: { latitude: number; longitude: number },
-): number {
-  const earthRadiusKm = 6371;
-  const deltaLatitude = toRadians(to.latitude - from.latitude);
-  const deltaLongitude = toRadians(to.longitude - from.longitude);
-  const fromLatitude = toRadians(from.latitude);
-  const toLatitude = toRadians(to.latitude);
-  const haversine =
-    Math.sin(deltaLatitude / 2) ** 2 +
-    Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.sin(deltaLongitude / 2) ** 2;
-
-  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
-}
-
-function toRadians(degrees: number): number {
-  return (degrees * Math.PI) / 180;
+  return formatRouteDistanceFromWaypoints(route.currentRevision?.waypoints ?? []);
 }
 
 function useRelativeUpdatedLabel(lastUpdatedAt: Date | null): string | null {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5717,7 +5717,7 @@ button.is-loading {
   gap: 10px;
 }
 
-.notebook-nav {
+.sidebar-tabs {
   align-items: center;
   background: var(--bg-subtle);
   border: 1px solid var(--cloud-border-soft, var(--border));
@@ -5728,29 +5728,49 @@ button.is-loading {
   padding: 3px;
 }
 
-.notebook-nav a {
+.sidebar-tabs a {
   align-items: center;
   border-radius: 9px;
+  color: var(--text-secondary);
   display: inline-flex;
+  font-size: 12px;
+  font-weight: 700;
   justify-content: center;
   min-height: 30px;
   padding: 0 10px;
 }
 
-.notebook-nav a.active,
-.notebook-nav a:hover {
+.sidebar-tabs a.active,
+.sidebar-tabs a:hover {
   background: var(--bg-surface);
   box-shadow: 0 1px 2px rgb(34 24 15 / 6%);
   color: var(--accent-hover);
 }
 
-.notebook-search {
+.sidebar-search {
+  color: var(--text-secondary);
   display: grid;
+  font-size: 10px;
   gap: 0;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.notebook-search input {
+.sidebar-search input {
+  background: rgb(255 253 247 / 90%);
+  border: 1px solid var(--cloud-border-soft, var(--border));
+  border-radius: 12px;
+  color: var(--text-primary);
+  font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
   min-height: 36px;
+  padding: 0 12px;
+  text-transform: none;
+}
+
+.sidebar-search input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgb(180 95 50 / 16%);
+  outline: none;
 }
 
 .route-mode-bar {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5712,9 +5712,45 @@ button.is-loading {
   color: var(--accent-hover);
 }
 
-/* Route editor hierarchy pass */
+/* Sidebar and route editor hierarchy pass */
+.field-notebook {
+  gap: 10px;
+}
+
+.notebook-nav {
+  align-items: center;
+  background: var(--bg-subtle);
+  border: 1px solid var(--cloud-border-soft, var(--border));
+  border-radius: 12px;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: 1fr 1fr;
+  padding: 3px;
+}
+
+.notebook-nav a {
+  align-items: center;
+  border-radius: 9px;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 10px;
+}
+
+.notebook-nav a.active,
+.notebook-nav a:hover {
+  background: var(--bg-surface);
+  box-shadow: 0 1px 2px rgb(34 24 15 / 6%);
+  color: var(--accent-hover);
+}
+
 .notebook-search {
+  display: grid;
   gap: 0;
+}
+
+.notebook-search input {
+  min-height: 36px;
 }
 
 .route-mode-bar {
@@ -5759,12 +5795,13 @@ button.is-loading {
 }
 
 .route-notebook-entry {
-  gap: 8px;
-  padding-left: 14px;
+  gap: 4px;
+  min-height: 58px;
+  padding: 10px 12px 10px 14px;
 }
 
 .route-card-title-row {
-  align-items: flex-start;
+  align-items: center;
   display: flex;
   gap: 8px;
   justify-content: space-between;
@@ -5775,20 +5812,12 @@ button.is-loading {
   min-width: 0;
 }
 
-.route-card-badges {
-  display: flex;
-  flex-shrink: 0;
-  flex-wrap: wrap;
-  gap: 4px;
-  justify-content: flex-end;
-}
-
-.cartographer-stage .route-card-status,
-.cartographer-stage .route-card-rev {
+.cartographer-stage .route-card-status {
   background: rgb(180 95 50 / 10%);
   border: 1px solid rgb(180 95 50 / 24%);
   border-radius: 999px;
   color: var(--accent-hover);
+  flex-shrink: 0;
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.04em;
@@ -5797,13 +5826,29 @@ button.is-loading {
   text-transform: uppercase;
 }
 
-.route-card-metrics {
-  display: grid;
-  gap: 6px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.route-card-meta-line,
+.route-card-selected-detail {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.route-card-metrics > span,
+.route-card-meta-line {
+  white-space: nowrap;
+}
+
+.route-card-selected-detail {
+  background: var(--bg-subtle);
+  border: 1px solid var(--cloud-border-soft, var(--border));
+  border-radius: 9px;
+  margin-top: 2px;
+  padding: 5px 7px;
+  white-space: nowrap;
+}
+
 .route-summary-grid > span {
   background: var(--bg-surface);
   border: 1px solid var(--cloud-border-soft, var(--border));
@@ -5814,7 +5859,6 @@ button.is-loading {
   padding: 7px 8px;
 }
 
-.route-card-metrics small,
 .route-summary-grid small {
   color: var(--text-muted);
   font-size: 10px;
@@ -5823,7 +5867,6 @@ button.is-loading {
   text-transform: uppercase;
 }
 
-.route-card-metrics strong,
 .route-summary-grid strong {
   color: var(--text-primary);
   font-size: 12px;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5715,6 +5715,11 @@ button.is-loading {
 /* Sidebar and route editor hierarchy pass */
 .field-notebook {
   gap: 10px;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+}
+
+.notebook-list {
+  align-content: start;
 }
 
 .sidebar-tabs {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5711,3 +5711,247 @@ button.is-loading {
   border-color: rgb(180 95 50 / 24%);
   color: var(--accent-hover);
 }
+
+/* Route editor hierarchy pass */
+.notebook-search {
+  gap: 0;
+}
+
+.route-mode-bar {
+  align-items: center;
+  backdrop-filter: blur(14px);
+  background: var(--overlay-surface);
+  border: 1px solid var(--cloud-border-soft, var(--border));
+  border-radius: 999px;
+  box-shadow: 0 10px 28px rgb(34 24 15 / 10%);
+  color: var(--text-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 13px;
+  gap: 8px;
+  padding: 8px 12px;
+  position: fixed;
+  z-index: 14;
+}
+
+.route-mode-bar strong {
+  color: var(--text-primary);
+}
+
+.route-mode-bar span + span::before {
+  color: var(--text-muted);
+  content: "·";
+  margin-right: 8px;
+}
+
+@media (min-width: 1024px) {
+  .route-mode-bar {
+    left: calc(var(--cloud-sidebar-width, 320px) + 32px);
+    right: calc(var(--cloud-editor-width, 440px) + 80px);
+    top: calc(var(--cloud-topbar-height, 56px) + 16px);
+  }
+}
+
+@media (max-width: 1023px) {
+  .route-mode-bar {
+    display: none;
+  }
+}
+
+.route-notebook-entry {
+  gap: 8px;
+  padding-left: 14px;
+}
+
+.route-card-title-row {
+  align-items: flex-start;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.route-card-title {
+  color: var(--text-primary);
+  min-width: 0;
+}
+
+.route-card-badges {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.cartographer-stage .route-card-status,
+.cartographer-stage .route-card-rev {
+  background: rgb(180 95 50 / 10%);
+  border: 1px solid rgb(180 95 50 / 24%);
+  border-radius: 999px;
+  color: var(--accent-hover);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  padding: 4px 6px;
+  text-transform: uppercase;
+}
+
+.route-card-metrics {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.route-card-metrics > span,
+.route-summary-grid > span {
+  background: var(--bg-surface);
+  border: 1px solid var(--cloud-border-soft, var(--border));
+  border-radius: 10px;
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 7px 8px;
+}
+
+.route-card-metrics small,
+.route-summary-grid small {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.route-card-metrics strong,
+.route-summary-grid strong {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.2;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cartographer-stage .notebook-entry.active {
+  background: var(--bg-surface);
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 1px rgb(180 95 50 / 18%),
+    0 12px 26px rgb(34 24 15 / 12%);
+}
+
+.cartographer-stage .notebook-entry.active::before {
+  opacity: 1;
+  width: 4px;
+}
+
+.index-card .route-summary-section {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.route-section-heading {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.route-section-heading h3 {
+  margin: 0;
+}
+
+.route-mode-hint {
+  align-items: center;
+  background: var(--accent-soft);
+  border: 1px solid rgb(180 95 50 / 20%);
+  border-radius: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 8px;
+  padding: 9px 10px;
+}
+
+.route-mode-hint .lucide-icon {
+  flex: 0 0 auto;
+}
+
+.route-summary-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.index-card .route-editor-map-section {
+  display: block;
+  padding: 0;
+}
+
+.route-editor-map-section .favorite-picker {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+.route-editor-footer {
+  display: grid;
+  gap: 10px;
+}
+
+.route-save-actions {
+  display: grid;
+  gap: 8px;
+}
+
+.route-save-actions button[type="submit"] {
+  width: 100%;
+}
+
+.route-danger-zone {
+  border-top: 1px solid var(--cloud-border-soft, var(--border));
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 8px;
+}
+
+.route-danger-zone .danger {
+  background: transparent;
+}
+
+.route-marker {
+  position: relative;
+}
+
+.route-marker.route-marker-compact:not(.selected) {
+  color: transparent;
+  font-size: 0;
+  height: 14px;
+  min-width: 14px;
+  width: 14px;
+}
+
+.route-marker.route-marker-compact:not(.selected)::after {
+  background: var(--bg-surface);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  bottom: calc(100% + 6px);
+  color: var(--accent-hover);
+  content: attr(data-label);
+  font-size: 11px;
+  font-weight: 800;
+  left: 50%;
+  opacity: 0;
+  padding: 3px 6px;
+  pointer-events: none;
+  position: absolute;
+  transform: translateX(-50%);
+  transition: opacity var(--transition-fast);
+}
+
+.route-marker.route-marker-compact:not(.selected):hover::after,
+.route-marker.route-marker-compact:not(.selected):focus-visible::after {
+  opacity: 1;
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5955,3 +5955,55 @@ button.is-loading {
 .route-marker.route-marker-compact:not(.selected):focus-visible::after {
   opacity: 1;
 }
+
+/* Keep place actions reachable when accordions expand. */
+.index-card .place-editor-embedded {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.place-editor-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-bottom: 16px;
+  scrollbar-gutter: stable;
+}
+
+.index-card .place-editor-footer {
+  background: var(--overlay-surface);
+  border-top: 1px solid var(--cloud-border-soft, var(--border));
+  box-shadow: 0 -10px 24px rgb(34 24 15 / 7%);
+  flex-shrink: 0;
+  margin: 0;
+  padding: 12px 0 0;
+  position: relative;
+  z-index: 45;
+}
+
+.index-card .place-editor-footer .row {
+  justify-content: space-between;
+}
+
+@media (max-width: 1023px) {
+  .index-card .place-editor-embedded {
+    height: auto;
+    overflow: visible;
+  }
+
+  .place-editor-content {
+    overflow: visible;
+  }
+
+  .index-card .place-editor-footer {
+    bottom: 0;
+    margin-inline: -14px;
+    padding: 12px 14px;
+    position: sticky;
+  }
+}

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -23,6 +23,8 @@ type Props = {
   waypoints: RouteWaypoint[];
 };
 
+const COMPACT_MARKER_COUNT = 8;
+const COMPACT_MARKER_ZOOM = 13;
 const LINE_SOURCE_ID = 'route-line';
 const LINE_LAYER_ID = 'route-line';
 
@@ -81,7 +83,12 @@ export default function RouteMapEditor({
         onSelectWaypoint: onSelectWaypointRef.current,
         waypoints: waypointsRef.current,
       });
-      updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
+      updateMarkerDisplay(
+        markersRef.current,
+        selectedWaypointIndexRef.current,
+        map.getZoom(),
+        waypointsRef.current.length,
+      );
       fitWaypoints(map, waypointsRef.current);
       onReadyRef.current?.({
         fit: () => fitWaypoints(map, waypointsRef.current),
@@ -98,6 +105,14 @@ export default function RouteMapEditor({
         },
       ]);
       onSelectWaypointRef.current?.(waypointsRef.current.length);
+    });
+    map.on('zoom', () => {
+      updateMarkerDisplay(
+        markersRef.current,
+        selectedWaypointIndexRef.current,
+        map.getZoom(),
+        waypointsRef.current.length,
+      );
     });
 
     mapRef.current = map;
@@ -129,7 +144,12 @@ export default function RouteMapEditor({
         onSelectWaypoint,
         waypoints,
       });
-      updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
+      updateMarkerDisplay(
+        markersRef.current,
+        selectedWaypointIndexRef.current,
+        map.getZoom(),
+        waypoints.length,
+      );
     };
 
     if (map.isStyleLoaded()) {
@@ -140,8 +160,19 @@ export default function RouteMapEditor({
   }, [onChange, onSelectWaypoint, waypoints]);
 
   useEffect(() => {
-    updateMarkerSelection(markersRef.current, selectedWaypointIndex);
-  }, [selectedWaypointIndex]);
+    const map = mapRef.current;
+
+    if (map == null) {
+      return;
+    }
+
+    updateMarkerDisplay(
+      markersRef.current,
+      selectedWaypointIndex,
+      map.getZoom(),
+      waypoints.length,
+    );
+  }, [selectedWaypointIndex, waypoints.length]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -189,7 +220,12 @@ export default function RouteMapEditor({
         onSelectWaypoint: onSelectWaypointRef.current,
         waypoints: waypointsRef.current,
       });
-      updateMarkerSelection(markersRef.current, selectedWaypointIndexRef.current);
+      updateMarkerDisplay(
+        markersRef.current,
+        selectedWaypointIndexRef.current,
+        map.getZoom(),
+        waypointsRef.current.length,
+      );
       map.jumpTo({ bearing, center, pitch, zoom });
     });
   }, [styleName]);
@@ -254,29 +290,39 @@ function syncMarkers({
 
 function createMarkerElement({ index, waypointCount }: { index: number; waypointCount: number }) {
   const element = document.createElement('button');
+  const label = getWaypointShortLabel(index);
   const positionClass = getWaypointMarkerPositionClass(index, waypointCount);
   element.className = `route-marker ${positionClass}`;
-  element.textContent = getWaypointShortLabel(index, waypointCount);
+  element.dataset.label = label;
+  element.textContent = label;
   element.type = 'button';
+  element.setAttribute('aria-label', `Waypoint ${label}`);
 
   return element;
 }
 
-function updateMarkerSelection(markers: Marker[], selectedWaypointIndex: number | null) {
+function updateMarkerDisplay(
+  markers: Marker[],
+  selectedWaypointIndex: number | null,
+  zoom: number,
+  waypointCount: number,
+) {
+  const useCompactMarkers = waypointCount >= COMPACT_MARKER_COUNT && zoom < COMPACT_MARKER_ZOOM;
+
   markers.forEach((marker, index) => {
-    marker.getElement().classList.toggle('selected', selectedWaypointIndex === index);
+    const element = marker.getElement();
+    const isSelected = selectedWaypointIndex === index;
+    const isTerminal = index === 0 || index === waypointCount - 1;
+
+    element.classList.toggle('selected', isSelected);
+    element.classList.toggle(
+      'route-marker-compact',
+      useCompactMarkers && !isTerminal && !isSelected,
+    );
   });
 }
 
-function getWaypointShortLabel(index: number, waypointCount: number): string {
-  if (index === 0) {
-    return '1';
-  }
-
-  if (index === waypointCount - 1) {
-    return '⚑';
-  }
-
+function getWaypointShortLabel(index: number): string {
   return `${index + 1}`;
 }
 
@@ -337,8 +383,9 @@ function syncLineLayer(map: MapLibreMap, waypoints: RouteWaypoint[]) {
         'line-join': 'round',
       },
       paint: {
-        'line-color': 'rgba(53, 39, 28, 0.24)',
-        'line-width': 7,
+        'line-color': '#fffaf3',
+        'line-opacity': 0.95,
+        'line-width': 8,
       },
       source: LINE_SOURCE_ID,
       type: 'line',
@@ -353,11 +400,32 @@ function syncLineLayer(map: MapLibreMap, waypoints: RouteWaypoint[]) {
         'line-join': 'round',
       },
       paint: {
-        'line-color': '#d97644',
-        'line-width': 3.5,
+        'line-color': '#f05a28',
+        'line-width': 4.5,
       },
       source: LINE_SOURCE_ID,
       type: 'line',
+    });
+  }
+
+  if (map.getLayer(`${LINE_LAYER_ID}-arrows`) == null) {
+    map.addLayer({
+      id: `${LINE_LAYER_ID}-arrows`,
+      layout: {
+        'symbol-placement': 'line',
+        'symbol-spacing': 96,
+        'text-field': '➜',
+        'text-keep-upright': false,
+        'text-rotation-alignment': 'map',
+        'text-size': 16,
+      },
+      paint: {
+        'text-color': '#7a2f16',
+        'text-halo-color': '#fffaf3',
+        'text-halo-width': 1.5,
+      },
+      source: LINE_SOURCE_ID,
+      type: 'symbol',
     });
   }
 

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -25,31 +25,13 @@ export function FieldNotebook({
   return (
     <aside className="field-notebook" aria-label={`${activeSection} field notebook`}>
       <div aria-hidden className="field-notebook-spine" />
-      <nav aria-label="Cartographer sections" className="notebook-nav">
-        <Link
-          aria-current={activeSection === 'places' ? 'page' : undefined}
-          className={activeSection === 'places' ? 'active' : ''}
-          href="/dashboard/places"
-        >
-          <span>Places</span>
-        </Link>
-        <Link
-          aria-current={activeSection === 'routes' ? 'page' : undefined}
-          className={activeSection === 'routes' ? 'active' : ''}
-          href="/dashboard/routes"
-        >
-          <span>Routes</span>
-        </Link>
-      </nav>
-      <label className="notebook-search font-mono">
-        <span className="sr-only">Search</span>
-        <input
-          ref={searchRef}
-          placeholder={searchPlaceholder}
-          value={searchValue}
-          onChange={(event) => onSearchChange(event.target.value)}
-        />
-      </label>
+      <SidebarTabs activeSection={activeSection} />
+      <SidebarSearch
+        searchPlaceholder={searchPlaceholder}
+        searchRef={searchRef}
+        searchValue={searchValue}
+        onSearchChange={onSearchChange}
+      />
       <button className="notebook-new-entry" type="button" onClick={onNewEntry}>
         <span aria-hidden className="notebook-new-entry-icon">
           +
@@ -65,5 +47,50 @@ export function FieldNotebook({
       </button>
       <div className="notebook-list">{children}</div>
     </aside>
+  );
+}
+
+function SidebarTabs({ activeSection }: { activeSection: 'places' | 'routes' }) {
+  return (
+    <nav aria-label="Cartographer sections" className="sidebar-tabs">
+      <Link
+        aria-current={activeSection === 'places' ? 'page' : undefined}
+        className={activeSection === 'places' ? 'active' : ''}
+        href="/dashboard/places"
+      >
+        <span>Places</span>
+      </Link>
+      <Link
+        aria-current={activeSection === 'routes' ? 'page' : undefined}
+        className={activeSection === 'routes' ? 'active' : ''}
+        href="/dashboard/routes"
+      >
+        <span>Routes</span>
+      </Link>
+    </nav>
+  );
+}
+
+function SidebarSearch({
+  onSearchChange,
+  searchPlaceholder,
+  searchRef,
+  searchValue,
+}: {
+  onSearchChange: (value: string) => void;
+  searchPlaceholder: string;
+  searchRef?: RefObject<HTMLInputElement | null>;
+  searchValue: string;
+}) {
+  return (
+    <label className="sidebar-search font-mono">
+      <span className="sr-only">Search</span>
+      <input
+        ref={searchRef}
+        placeholder={searchPlaceholder}
+        value={searchValue}
+        onChange={(event) => onSearchChange(event.target.value)}
+      />
+    </label>
   );
 }

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -42,7 +42,7 @@ export function FieldNotebook({
         </Link>
       </nav>
       <label className="notebook-search font-mono">
-        Search
+        <span className="sr-only">Search</span>
         <input
           ref={searchRef}
           placeholder={searchPlaceholder}

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -109,59 +109,61 @@ export default function PlaceEditor({
           <h2>{place == null ? 'New place' : place.name}</h2>
         </header>
       ) : null}
-      {error == null ? null : <div className="error">{error}</div>}
-      {showMap ? (
-        <PlaceMapEditor
-          latitude={mapCoords.latitude}
-          longitude={mapCoords.longitude}
-          onChange={(coords) => {
-            setLatitude(formatCoordinateInput(coords.latitude));
-            setLongitude(formatCoordinateInput(coords.longitude));
-          }}
-        />
-      ) : null}
-      <label>
-        Name
-        <input required value={name} onChange={(event) => setName(event.target.value)} />
-      </label>
-      <div className="split">
-        <label>
-          Latitude
-          <input
-            required
-            inputMode="decimal"
-            value={latitude}
-            onChange={(event) => setLatitude(event.target.value)}
+      <div className="place-editor-content stack">
+        {error == null ? null : <div className="error">{error}</div>}
+        {showMap ? (
+          <PlaceMapEditor
+            latitude={mapCoords.latitude}
+            longitude={mapCoords.longitude}
+            onChange={(coords) => {
+              setLatitude(formatCoordinateInput(coords.latitude));
+              setLongitude(formatCoordinateInput(coords.longitude));
+            }}
           />
-        </label>
+        ) : null}
         <label>
-          Longitude
-          <input
-            required
-            inputMode="decimal"
-            value={longitude}
-            onChange={(event) => setLongitude(event.target.value)}
-          />
+          Name
+          <input required value={name} onChange={(event) => setName(event.target.value)} />
         </label>
-      </div>
-      <label>
-        Tags (comma separated)
-        <input value={tags} onChange={(event) => setTags(event.target.value)} />
-      </label>
-      <label>
-        Description
-        <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
-      </label>
-      <PlaceRemoteControlPanel place={place} />
-      <details className="route-editor-section route-editor-collapsible route-editor-secondary-section place-editor-share-section">
-        <summary>
-          <span>Publishing / share</span>
-          <span className="muted">Public link settings</span>
-        </summary>
-        <div className="route-editor-collapsible-content">
-          <PlaceSharePanel place={place} />
+        <div className="split">
+          <label>
+            Latitude
+            <input
+              required
+              inputMode="decimal"
+              value={latitude}
+              onChange={(event) => setLatitude(event.target.value)}
+            />
+          </label>
+          <label>
+            Longitude
+            <input
+              required
+              inputMode="decimal"
+              value={longitude}
+              onChange={(event) => setLongitude(event.target.value)}
+            />
+          </label>
         </div>
-      </details>
+        <label>
+          Tags (comma separated)
+          <input value={tags} onChange={(event) => setTags(event.target.value)} />
+        </label>
+        <label>
+          Description
+          <textarea value={description} onChange={(event) => setDescription(event.target.value)} />
+        </label>
+        <PlaceRemoteControlPanel place={place} />
+        <details className="route-editor-section route-editor-collapsible route-editor-secondary-section place-editor-share-section">
+          <summary>
+            <span>Publishing / share</span>
+            <span className="muted">Public link settings</span>
+          </summary>
+          <div className="route-editor-collapsible-content">
+            <PlaceSharePanel place={place} />
+          </div>
+        </details>
+      </div>
       <footer className="route-editor-footer place-editor-footer">
         <div className="row">
           {onDelete == null ? null : (

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -8,6 +8,7 @@ import { RouteRemoteControlPanel } from '@/components/dashboard/RemoteControlPan
 import {
   formatError,
   formatMode,
+  formatRouteDistanceFromWaypoints,
   normalizeNullable,
   parseNumber,
   toAbsolutePublicUrl,
@@ -83,7 +84,7 @@ export default function RouteEditor({
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
   const revisionLabel =
     route?.currentRevision == null ? 'Draft' : `Revision ${route.currentRevision.revisionNumber}`;
-  const distanceLabel = formatWaypointsDistance(waypoints);
+  const distanceLabel = useMemo(() => formatRouteDistanceFromWaypoints(waypoints), [waypoints]);
 
   const setSelectedWaypointIndex = useCallback(
     (nextIndex: number | null) => {
@@ -690,33 +691,6 @@ function formatFavoritePlaceCoords(place: Place): string {
 
 function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
   return `${waypoint.sequence ?? index}-${waypoint.latitude}-${waypoint.longitude}`;
-}
-
-function formatWaypointsDistance(waypoints: RouteWaypoint[]): string {
-  const distanceKm = waypoints.slice(1).reduce((totalDistance, waypoint, index) => {
-    const previousWaypoint = waypoints[index];
-
-    return totalDistance + getDistanceKm(previousWaypoint, waypoint);
-  }, 0);
-
-  return distanceKm < 10 ? `${distanceKm.toFixed(1)} km` : `${Math.round(distanceKm)} km`;
-}
-
-function getDistanceKm(from: RouteWaypoint, to: RouteWaypoint): number {
-  const earthRadiusKm = 6371;
-  const deltaLatitude = toRadians(to.latitude - from.latitude);
-  const deltaLongitude = toRadians(to.longitude - from.longitude);
-  const fromLatitude = toRadians(from.latitude);
-  const toLatitude = toRadians(to.latitude);
-  const haversine =
-    Math.sin(deltaLatitude / 2) ** 2 +
-    Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.sin(deltaLongitude / 2) ** 2;
-
-  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
-}
-
-function toRadians(degrees: number): number {
-  return (degrees * Math.PI) / 180;
 }
 
 function formatWaypointSummary(waypoints: RouteWaypoint[], places: Place[]): string {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/components/AuthProvider';
 import { RouteRemoteControlPanel } from '@/components/dashboard/RemoteControlPanel';
 import {
   formatError,
+  formatMode,
   normalizeNullable,
   parseNumber,
   toAbsolutePublicUrl,
@@ -80,6 +81,9 @@ export default function RouteEditor({
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length, mapMode);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
+  const revisionLabel =
+    route?.currentRevision == null ? 'Draft' : `Revision ${route.currentRevision.revisionNumber}`;
+  const distanceLabel = formatWaypointsDistance(waypoints);
 
   const setSelectedWaypointIndex = useCallback(
     (nextIndex: number | null) => {
@@ -255,12 +259,41 @@ export default function RouteEditor({
       )}
       {error == null ? null : <div className="error route-editor-error">{error}</div>}
 
+      <section className="route-editor-section route-summary-section">
+        <div className="route-section-heading">
+          <h3>Route summary</h3>
+          <span className="chip rev-chip">{revisionLabel}</span>
+        </div>
+        <div className="route-mode-hint">
+          <InfoIcon />
+          <span>{routeBuilderHint}</span>
+        </div>
+        <div className="route-summary-grid">
+          <span>
+            <small>Waypoints</small>
+            <strong>{waypoints.length}</strong>
+          </span>
+          <span>
+            <small>Distance</small>
+            <strong>{distanceLabel}</strong>
+          </span>
+          <span>
+            <small>Speed</small>
+            <strong>{defaultSpeedKmh || '—'} km/h</strong>
+          </span>
+          <span>
+            <small>Mode</small>
+            <strong>{formatMode(mode)}</strong>
+          </span>
+        </div>
+      </section>
+
       <details
         className="route-editor-section route-editor-collapsible route-editor-details-section"
         open
       >
         <summary>
-          <span>Route details</span>
+          <span>Route settings</span>
           <span className="muted">Name, speed, and playback</span>
         </summary>
         <div className="route-editor-collapsible-content">
@@ -297,53 +330,66 @@ export default function RouteEditor({
         </div>
       </details>
 
-      <section className="route-editor-section route-editor-map-section">
-        {isBackgroundMapMode ? null : (
-          <div>
-            <h3>Route builder</h3>
-            <p className="muted">Add pins on the map or pick from favorites.</p>
-          </div>
-        )}
-        <div className="route-builder-hint">
-          <InfoIcon />
-          {routeBuilderHint}
-        </div>
-        {mapMode === 'embedded' ? (
-          <>
-            <div className="map-builder">
-              <RouteMapEditor
-                fitRequest={fitRequest}
-                focusTarget={focusTarget}
-                selectedWaypointIndex={selectedWaypointIndex}
-                waypoints={waypoints}
-                onChange={setWaypoints}
-                onSelectWaypoint={setSelectedWaypointIndex}
-              />
-              <div className="map-instruction">
-                Click map to add waypoint · Drag markers to adjust
+      <details
+        className="route-editor-section route-editor-collapsible route-editor-map-section"
+        open={waypoints.length === 0}
+      >
+        <summary>
+          <span>Add waypoints</span>
+          <span className="muted">Map clicks or favorites</span>
+        </summary>
+        <div className="route-editor-collapsible-content">
+          {isBackgroundMapMode ? null : (
+            <>
+              <div>
+                <h3>Route builder</h3>
+                <p className="muted">Add pins on the map or pick from favorites.</p>
               </div>
-            </div>
-            <div className="map-action-row">
-              <button
-                className="secondary"
-                disabled={waypoints.length === 0}
-                title="Auto-frame the map to show all waypoints"
-                type="button"
-                onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
-              >
-                Fit route
-              </button>
-              <span className="muted">Use Waypoints below to review, reorder, or edit pins.</span>
-            </div>
-          </>
-        ) : null}
+              <div className="route-builder-hint">
+                <InfoIcon />
+                {routeBuilderHint}
+              </div>
+            </>
+          )}
+          {mapMode === 'embedded' ? (
+            <>
+              <div className="map-builder">
+                <RouteMapEditor
+                  fitRequest={fitRequest}
+                  focusTarget={focusTarget}
+                  selectedWaypointIndex={selectedWaypointIndex}
+                  waypoints={waypoints}
+                  onChange={setWaypoints}
+                  onSelectWaypoint={setSelectedWaypointIndex}
+                />
+                <div className="map-instruction">
+                  Click map to add waypoint · Drag markers to adjust
+                </div>
+              </div>
+              <div className="map-action-row">
+                <button
+                  className="secondary"
+                  disabled={waypoints.length === 0}
+                  title="Auto-frame the map to show all waypoints"
+                  type="button"
+                  onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
+                >
+                  Fit route
+                </button>
+                <span className="muted">
+                  Use Waypoints below to review, reorder, or edit pins.
+                </span>
+              </div>
+            </>
+          ) : null}
 
-        <FavoriteWaypointPicker
-          mode={favoritePickerMode}
-          places={places}
-          onSelect={addFavoriteWaypoint}
-        />
-      </section>
+          <FavoriteWaypointPicker
+            mode={favoritePickerMode}
+            places={places}
+            onSelect={addFavoriteWaypoint}
+          />
+        </div>
+      </details>
 
       <details
         className="route-editor-section route-editor-collapsible route-editor-waypoints-section"
@@ -359,7 +405,7 @@ export default function RouteEditor({
               <MapPinIcon />
               <strong>No waypoints yet</strong>
               <span className="muted">
-                Tap the map to add your first waypoint, or pick from favorites above.
+                Click the map to add your first waypoint, or pick from favorites above.
               </span>
             </div>
           ) : (
@@ -471,7 +517,7 @@ export default function RouteEditor({
 
       <details className="route-editor-section route-editor-collapsible route-editor-secondary-section route-editor-share-section">
         <summary>
-          <span>Publishing / share</span>
+          <span>Publish / share</span>
           <span className="muted">Privacy and public link settings</span>
         </summary>
         <div className="route-editor-collapsible-content">
@@ -489,25 +535,25 @@ export default function RouteEditor({
       </details>
 
       <footer className="route-editor-footer">
-        <div className="stack">
+        <div className="route-save-actions">
           {saveDisabledReason == null ? null : (
             <p className="muted no-margin">{saveDisabledReason}</p>
           )}
-          <div className="row">
-            {onDelete == null ? null : (
-              <button className="danger" disabled={isSaving} type="button" onClick={confirmDelete}>
-                Delete route
-              </button>
-            )}
-            <button
-              className={isSaving ? 'is-loading' : saveNotice == null ? '' : 'is-saved'}
-              disabled={isSaving || saveDisabledReason != null}
-              type="submit"
-            >
-              {isSaving ? 'Saving…' : saveNotice == null ? 'Save route' : 'Saved ✓'}
+          <button
+            className={isSaving ? 'is-loading' : saveNotice == null ? '' : 'is-saved'}
+            disabled={isSaving || saveDisabledReason != null}
+            type="submit"
+          >
+            {isSaving ? 'Saving…' : saveNotice == null ? 'Save route' : 'Saved ✓'}
+          </button>
+        </div>
+        {onDelete == null ? null : (
+          <div className="route-danger-zone">
+            <button className="danger" disabled={isSaving} type="button" onClick={confirmDelete}>
+              Delete route
             </button>
           </div>
-        </div>
+        )}
       </footer>
     </form>
   );
@@ -646,6 +692,33 @@ function getWaypointKey(waypoint: RouteWaypoint, index: number): string {
   return `${waypoint.sequence ?? index}-${waypoint.latitude}-${waypoint.longitude}`;
 }
 
+function formatWaypointsDistance(waypoints: RouteWaypoint[]): string {
+  const distanceKm = waypoints.slice(1).reduce((totalDistance, waypoint, index) => {
+    const previousWaypoint = waypoints[index];
+
+    return totalDistance + getDistanceKm(previousWaypoint, waypoint);
+  }, 0);
+
+  return distanceKm < 10 ? `${distanceKm.toFixed(1)} km` : `${Math.round(distanceKm)} km`;
+}
+
+function getDistanceKm(from: RouteWaypoint, to: RouteWaypoint): number {
+  const earthRadiusKm = 6371;
+  const deltaLatitude = toRadians(to.latitude - from.latitude);
+  const deltaLongitude = toRadians(to.longitude - from.longitude);
+  const fromLatitude = toRadians(from.latitude);
+  const toLatitude = toRadians(to.latitude);
+  const haversine =
+    Math.sin(deltaLatitude / 2) ** 2 +
+    Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.sin(deltaLongitude / 2) ** 2;
+
+  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
 function formatWaypointSummary(waypoints: RouteWaypoint[], places: Place[]): string {
   const firstWaypoint = waypoints[0];
   const lastWaypoint = waypoints.at(-1);
@@ -691,7 +764,7 @@ function getRouteBuilderHint(
   mapMode: 'background' | 'embedded',
 ): string {
   if (mapMode === 'background' && waypointCount >= 2) {
-    return 'Tap the map to add a waypoint · Drag pins to adjust';
+    return 'Click map to add a waypoint · Drag pins to adjust';
   }
 
   if (waypointCount === 0) {
@@ -704,7 +777,7 @@ function getRouteBuilderHint(
     return 'Add at least one more waypoint to save this route.';
   }
 
-  return 'Tap the map to add a waypoint, or drag any pin to nudge the path.';
+  return 'Click the map to add a waypoint, or drag any pin to nudge the path.';
 }
 
 function getSaveDisabledReason(waypointCount: number): string | null {

--- a/web/components/dashboard/utils.ts
+++ b/web/components/dashboard/utils.ts
@@ -1,5 +1,10 @@
 import { ApiError, type RouteMode } from '@/lib/api';
 
+type Coordinate = {
+  latitude: number;
+  longitude: number;
+};
+
 export function parseNumber(value: string, label: string): number {
   const parsedValue = Number(value);
 
@@ -22,6 +27,33 @@ export function formatCoord(value: number): string {
 
 export function formatMode(mode: RouteMode): string {
   return mode === 'PING_PONG' ? 'PingPong' : mode[0] + mode.slice(1).toLowerCase();
+}
+
+export function formatRouteDistanceFromWaypoints(waypoints: Coordinate[]): string {
+  const distanceKm = waypoints.slice(1).reduce((totalDistance, waypoint, index) => {
+    const previousWaypoint = waypoints[index];
+
+    return totalDistance + getDistanceKm(previousWaypoint, waypoint);
+  }, 0);
+
+  return distanceKm < 10 ? `${distanceKm.toFixed(1)} km` : `${Math.round(distanceKm)} km`;
+}
+
+function getDistanceKm(from: Coordinate, to: Coordinate): number {
+  const earthRadiusKm = 6371;
+  const deltaLatitude = toRadians(to.latitude - from.latitude);
+  const deltaLongitude = toRadians(to.longitude - from.longitude);
+  const fromLatitude = toRadians(from.latitude);
+  const toLatitude = toRadians(to.latitude);
+  const haversine =
+    Math.sin(deltaLatitude / 2) ** 2 +
+    Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.sin(deltaLongitude / 2) ** 2;
+
+  return 2 * earthRadiusKm * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
 }
 
 export function formatError(error: unknown): string {


### PR DESCRIPTION
## Summary
- strengthen route list cards and compact search placeholders
- split route inspector into summary/settings/waypoints/publish areas
- improve route map contrast, direction arrows, selected/compact waypoint markers, and editor mode hint

## Verification
- cd web && npm run lint && npm run typecheck