### PR TITLE
fix(web): polish dashboard layout controls

### DIFF
--- a/docs/plans/archived/2026-06-24_web-dashboard-ui-polish-plan.md
+++ b/docs/plans/archived/2026-06-24_web-dashboard-ui-polish-plan.md
@@ -1,0 +1,43 @@
+## Goal
+
+Polish the Web dashboard map/editor layout so controls do not cover editor cards and route forms are not obscured by sticky footers. Success means Places and Routes remain usable at desktop, short desktop, and mobile viewport sizes without changing share, remote-control, or persistence behavior.
+
+## Context
+
+Chrome/CDP review of `compose.webtest.yaml` found these concrete issues:
+
+- Mobile (`390×844`): the horizontal map controls overlapped the editor card header on both `/dashboard/places` and `/dashboard/routes`.
+- Desktop and short desktop: map controls slightly overlapped the right editor widget.
+- Routes desktop (`1440×760`) and short desktop (`1024×600`): sticky footer visually covered route settings content.
+- Mobile: the decorative `index-card-pin` dot looked like a status/control but was not interactive.
+
+## Non-Goals
+
+- Do not change backend APIs, share-link behavior, remote-control behavior, or route/place save behavior.
+- Do not add a UI dependency.
+- Do not redesign the full dashboard; fix the measured layout defects only.
+
+## Plan
+
+- [x] Preserve current evidence by keeping the latest Chrome/CDP screenshots and measurements under `/tmp/kestrel-ui-audit-*.png` and `/tmp/kestrel-web-ui-audit.json`; verified the files include desktop, short desktop, and mobile Places/Routes cases.
+- [x] Update `web/app/globals.css` so desktop `.map-control-stack` is positioned outside the right editor widget using `right: calc(var(--cloud-editor-width) + <gap>)`; verified with Chrome/CDP output in `/tmp/kestrel-web-ui-polish-after.json` that map controls no longer overlap `.index-card` at `1440×760` and `1024×600`.
+- [x] Update mobile `.map-control-stack` CSS to anchor controls inside the map row instead of fixed over the page flow; verified with Chrome/CDP screenshots `/tmp/kestrel-ui-audit-places-mobile.png` and `/tmp/kestrel-ui-audit-routes-mobile.png` that controls stay on the map and no longer cover editor card headers at `390×844`.
+- [x] Hide `.index-card-pin` in the cartographer dashboard so the decorative dot no longer looks interactive; verified with Chrome/CDP output in `/tmp/kestrel-web-ui-polish-interactions.json` (`hasPin: false` for Places and Routes cases) and screenshots.
+- [x] Changed `web/components/dashboard/RouteEditor.tsx` because CSS-only footer fixes kept content under the sticky footer: wrapped route sections in `.route-editor-content` and kept the footer outside that scroll region; verified route content touches but does not sit under the footer at `1440×760` and `1024×600`.
+- [x] Added the smallest CSS needed in `web/app/globals.css` for the route scroll container/footer layout; verified route editor scrolling and visible footer actions with `/tmp/kestrel-ui-audit-routes-desktop.png`, `/tmp/kestrel-ui-audit-routes-short.png`, and `/tmp/kestrel-web-ui-polish-interactions.json`.
+- [x] Run validation; verified with `just web-check`, `cd web && npm run lint`, `cd web && npm run typecheck`, and `git diff --check`.
+- [x] Run visual review on `compose.webtest.yaml`; verified `/dashboard/places` and `/dashboard/routes` at `1440×760`, `1024×600`, and `390×844` with Chrome/CDP screenshots and measured overlap output in `/tmp/kestrel-web-ui-polish-after.json`.
+
+## Risks
+
+- Moving map controls may make them harder to reach on mobile; mitigated by keeping them in the map row bottom-right rather than hiding them.
+- Route footer layout changes can accidentally reduce scrollable form area; mitigated by verifying short desktop and mobile screenshots plus dialog interactions.
+
+## Completion Checklist
+
+- [x] Map controls do not overlap the right editor widget on desktop or short desktop, verified by Chrome/CDP overlap measurements in `/tmp/kestrel-web-ui-polish-after.json` and `/tmp/kestrel-web-ui-polish-interactions.json` (`cardControlOverlap: 0`).
+- [x] Map controls do not overlap editor card headers on mobile Places or Routes, verified by `390×844` screenshots `/tmp/kestrel-ui-audit-places-mobile.png` and `/tmp/kestrel-ui-audit-routes-mobile.png` plus overlap output (`cardControlOverlap: 0`).
+- [x] Route footer no longer obscures route settings content at `1440×760` or `1024×600`, verified by screenshots `/tmp/kestrel-ui-audit-routes-desktop.png` and `/tmp/kestrel-ui-audit-routes-short.png` plus `routeContentTouchesFooter: true` in `/tmp/kestrel-web-ui-polish-interactions.json`.
+- [x] Decorative `index-card-pin` is not visible in dashboard editor cards, verified by desktop/mobile screenshots and `hasPin: false` in `/tmp/kestrel-web-ui-polish-interactions.json`.
+- [x] Places and Routes save/share/device controls remain visible and usable, verified by `/tmp/kestrel-web-ui-polish-dialogs.json` (`shareDialog.open: true`, `deviceDialog.open: true` for both Places and Routes).
+- [x] Web checks pass, verified by `just web-check`, `cd web && npm run lint`, `cd web && npm run typecheck`, and `git diff --check`.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -6154,7 +6154,8 @@ button.is-loading {
     bottom: auto;
     display: flex;
     flex-direction: column;
-    max-height: calc(100dvh - var(--cloud-topbar-height) - 32px);
+    max-height: min(calc(100dvh - 24px), calc(100dvh - var(--cloud-topbar-height) - 32px));
+    overflow: hidden;
   }
 
   .index-card.index-card-place .index-card-body {
@@ -6166,23 +6167,51 @@ button.is-loading {
     flex: 1 1 auto;
     height: auto;
   }
+
+  .index-card.index-card-place .place-editor-footer {
+    bottom: auto;
+    margin: 0;
+    padding: 12px 0 max(12px, env(safe-area-inset-bottom));
+    position: relative;
+    width: 100%;
+  }
 }
 
 @media (max-width: 1023px) {
-  .index-card .place-editor-embedded {
+  .index-card-place {
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100dvh - 24px);
+    overflow: hidden;
+  }
+
+  .index-card.index-card-place .index-card-body {
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .index-card.index-card-place .place-editor-embedded {
+    flex: 1 1 auto;
     height: auto;
-    overflow: visible;
+    min-height: 0;
+    overflow: hidden;
   }
 
-  .place-editor-content {
-    overflow: visible;
+  .index-card.index-card-place .place-editor-content {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 
-  .index-card .place-editor-footer {
-    bottom: 0;
-    margin-inline: -14px;
-    padding: 12px 14px;
-    position: sticky;
+  .index-card.index-card-place .place-editor-footer {
+    bottom: auto;
+    margin: 0;
+    padding: 12px 0 max(12px, env(safe-area-inset-bottom));
+    position: relative;
+    width: 100%;
   }
 }
 
@@ -6195,7 +6224,7 @@ button.is-loading {
     right: calc(var(--cloud-editor-width) + 32px);
   }
 
-  .index-card .route-editor {
+  .index-card-route .route-editor {
     display: flex;
     flex-direction: column;
     gap: 0;
@@ -6203,7 +6232,7 @@ button.is-loading {
     scrollbar-gutter: auto;
   }
 
-  .index-card .route-editor-content {
+  .index-card-route .route-editor-content {
     display: grid;
     flex: 1 1 auto;
     gap: 14px;
@@ -6214,7 +6243,7 @@ button.is-loading {
     scrollbar-gutter: stable;
   }
 
-  .index-card .route-editor-footer {
+  .index-card-route .route-editor-footer {
     bottom: auto;
     flex-shrink: 0;
     margin: 0 -18px -18px;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -6185,3 +6185,74 @@ button.is-loading {
     position: sticky;
   }
 }
+
+.cartographer-stage .index-card-pin {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .map-control-stack {
+    right: calc(var(--cloud-editor-width) + 32px);
+  }
+
+  .index-card .route-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    overflow: hidden;
+    scrollbar-gutter: auto;
+  }
+
+  .index-card .route-editor-content {
+    display: grid;
+    flex: 1 1 auto;
+    gap: 14px;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 0 2px 0 0;
+    scrollbar-gutter: stable;
+  }
+
+  .index-card .route-editor-footer {
+    bottom: auto;
+    flex-shrink: 0;
+    margin: 0 -18px -18px;
+    position: relative;
+    width: auto;
+  }
+}
+
+@media (min-width: 1024px) and (max-width: 1199px) {
+  .map-control-stack {
+    right: calc(var(--cloud-editor-width) + 26px);
+  }
+
+  .map-style-trigger {
+    min-width: 78px;
+  }
+}
+
+@media (max-width: 1023px) {
+  .cartographer-map-layer {
+    grid-column: 1;
+  }
+
+  .map-control-stack {
+    align-self: end;
+    bottom: auto;
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: end;
+    margin: 0 16px 16px 0;
+    position: relative;
+    right: auto;
+    top: auto;
+  }
+}
+
+@media (max-width: 639px) {
+  .map-control-stack {
+    margin: 0 8px 8px 0;
+  }
+}

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -277,262 +277,266 @@ export default function RouteEditor({
           </div>
         </header>
       )}
-      {error == null ? null : <div className="error route-editor-error">{error}</div>}
+      <div className="route-editor-content">
+        {error == null ? null : <div className="error route-editor-error">{error}</div>}
 
-      <section className="route-editor-section route-summary-section">
-        <div className="route-section-heading">
-          <div className="route-section-title">
-            <h3>Route summary</h3>
-            <span className="chip rev-chip">{revisionLabel}</span>
+        <section className="route-editor-section route-summary-section">
+          <div className="route-section-heading">
+            <div className="route-section-title">
+              <h3>Route summary</h3>
+              <span className="chip rev-chip">{revisionLabel}</span>
+            </div>
+            <RouteRemoteControlAction
+              mode={mode}
+              route={route}
+              speedKmh={Number(defaultSpeedKmh)}
+              waypoints={waypoints}
+            />
           </div>
-          <RouteRemoteControlAction
-            mode={mode}
-            route={route}
-            speedKmh={Number(defaultSpeedKmh)}
-            waypoints={waypoints}
-          />
-        </div>
-        <div className="route-mode-hint">
-          <InfoIcon />
-          <span>{routeBuilderHint}</span>
-        </div>
-        <div className="route-summary-grid">
-          <span>
-            <small>Waypoints</small>
-            <strong>{waypoints.length}</strong>
-          </span>
-          <span>
-            <small>Distance</small>
-            <strong>{distanceLabel}</strong>
-          </span>
-          <span>
-            <small>Speed</small>
-            <strong>{defaultSpeedKmh || '—'} km/h</strong>
-          </span>
-          <span>
-            <small>Mode</small>
-            <strong>{formatMode(mode)}</strong>
-          </span>
-        </div>
-      </section>
+          <div className="route-mode-hint">
+            <InfoIcon />
+            <span>{routeBuilderHint}</span>
+          </div>
+          <div className="route-summary-grid">
+            <span>
+              <small>Waypoints</small>
+              <strong>{waypoints.length}</strong>
+            </span>
+            <span>
+              <small>Distance</small>
+              <strong>{distanceLabel}</strong>
+            </span>
+            <span>
+              <small>Speed</small>
+              <strong>{defaultSpeedKmh || '—'} km/h</strong>
+            </span>
+            <span>
+              <small>Mode</small>
+              <strong>{formatMode(mode)}</strong>
+            </span>
+          </div>
+        </section>
 
-      <details
-        className="route-editor-section route-editor-collapsible route-editor-details-section"
-        open
-      >
-        <summary>
-          <span>Route settings</span>
-          <span className="muted">Name, speed, and playback</span>
-        </summary>
-        <div className="route-editor-collapsible-content">
-          <label className="route-title-field">
-            Name
-            <input required value={name} onChange={(event) => setName(event.target.value)} />
-          </label>
-          <div className="split">
+        <details
+          className="route-editor-section route-editor-collapsible route-editor-details-section"
+          open
+        >
+          <summary>
+            <span>Route settings</span>
+            <span className="muted">Name, speed, and playback</span>
+          </summary>
+          <div className="route-editor-collapsible-content">
+            <label className="route-title-field">
+              Name
+              <input required value={name} onChange={(event) => setName(event.target.value)} />
+            </label>
+            <div className="split">
+              <label>
+                Default speed (km/h)
+                <input
+                  required
+                  inputMode="decimal"
+                  value={defaultSpeedKmh}
+                  onChange={(event) => setDefaultSpeedKmh(event.target.value)}
+                />
+              </label>
+              <label>
+                Playback mode
+                <select value={mode} onChange={(event) => setMode(event.target.value as RouteMode)}>
+                  <option value="ONCE">Once</option>
+                  <option value="LOOP">Loop</option>
+                  <option value="PING_PONG">PingPong</option>
+                </select>
+              </label>
+            </div>
             <label>
-              Default speed (km/h)
-              <input
-                required
-                inputMode="decimal"
-                value={defaultSpeedKmh}
-                onChange={(event) => setDefaultSpeedKmh(event.target.value)}
+              Description (optional)
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
               />
             </label>
-            <label>
-              Playback mode
-              <select value={mode} onChange={(event) => setMode(event.target.value as RouteMode)}>
-                <option value="ONCE">Once</option>
-                <option value="LOOP">Loop</option>
-                <option value="PING_PONG">PingPong</option>
-              </select>
-            </label>
           </div>
-          <label>
-            Description (optional)
-            <textarea
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-            />
-          </label>
-        </div>
-      </details>
+        </details>
 
-      <details
-        className="route-editor-section route-editor-collapsible route-editor-map-section"
-        open={waypoints.length === 0}
-      >
-        <summary>
-          <span>Add waypoints</span>
-          <span className="muted">Map clicks or favorites</span>
-        </summary>
-        <div className="route-editor-collapsible-content">
-          {isBackgroundMapMode ? null : (
-            <>
-              <div>
-                <h3>Route builder</h3>
-                <p className="muted">Add pins on the map or pick from favorites.</p>
-              </div>
-              <div className="route-builder-hint">
-                <InfoIcon />
-                {routeBuilderHint}
-              </div>
-            </>
-          )}
-          {mapMode === 'embedded' ? (
-            <>
-              <div className="map-builder">
-                <RouteMapEditor
-                  fitRequest={fitRequest}
-                  focusTarget={focusTarget}
-                  selectedWaypointIndex={selectedWaypointIndex}
-                  waypoints={waypoints}
-                  onChange={setWaypoints}
-                  onSelectWaypoint={setSelectedWaypointIndex}
-                />
-                <div className="map-instruction">
-                  Click map to add waypoint · Drag markers to adjust
+        <details
+          className="route-editor-section route-editor-collapsible route-editor-map-section"
+          open={waypoints.length === 0}
+        >
+          <summary>
+            <span>Add waypoints</span>
+            <span className="muted">Map clicks or favorites</span>
+          </summary>
+          <div className="route-editor-collapsible-content">
+            {isBackgroundMapMode ? null : (
+              <>
+                <div>
+                  <h3>Route builder</h3>
+                  <p className="muted">Add pins on the map or pick from favorites.</p>
                 </div>
-              </div>
-              <div className="map-action-row">
-                <button
-                  className="secondary"
-                  disabled={waypoints.length === 0}
-                  title="Auto-frame the map to show all waypoints"
-                  type="button"
-                  onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
-                >
-                  Fit route
-                </button>
-                <span className="muted">Use Waypoints below to review, reorder, or edit pins.</span>
-              </div>
-            </>
-          ) : null}
-
-          <FavoriteWaypointPicker
-            mode={favoritePickerMode}
-            places={places}
-            onSelect={addFavoriteWaypoint}
-          />
-        </div>
-      </details>
-
-      <details
-        className="route-editor-section route-editor-collapsible route-editor-waypoints-section"
-        open={waypoints.length > 0}
-      >
-        <summary>
-          <span>Waypoints ({waypoints.length})</span>
-          <span className="muted">{formatWaypointSummary(waypoints, places)}</span>
-        </summary>
-        <div className="route-editor-collapsible-content">
-          {waypoints.length === 0 ? (
-            <div className="waypoint-empty-state">
-              <MapPinIcon />
-              <strong>No waypoints yet</strong>
-              <span className="muted">
-                Click the map to add your first waypoint, or pick from favorites above.
-              </span>
-            </div>
-          ) : (
-            <ul className="waypoint-list" aria-label="Route waypoints">
-              {waypoints.map((waypoint, index) => {
-                const waypointName = formatWaypointName(waypoint, places, `Pin ${index + 1}`);
-
-                const waypointRowClassName = [
-                  'waypoint-row',
-                  selectedWaypointIndex === index ? 'selected' : '',
-                  draggedWaypointIndex === index ? 'is-dragging' : '',
-                  dragOverWaypointIndex === index && draggedWaypointIndex !== index
-                    ? 'is-drop-target'
-                    : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ');
-
-                return (
-                  <li
-                    className={waypointRowClassName}
-                    draggable
-                    key={getWaypointKey(waypoint, index)}
-                    onDragEnd={() => {
-                      setDraggedWaypointIndex(null);
-                      setDragOverWaypointIndex(null);
-                    }}
-                    onDragEnter={() => setDragOverWaypointIndex(index)}
-                    onDragOver={(event) => event.preventDefault()}
-                    onDragStart={(event) => {
-                      setDraggedWaypointIndex(index);
-                      event.dataTransfer.effectAllowed = 'move';
-                      event.dataTransfer.setData('text/plain', String(index));
-                    }}
-                    onDrop={(event) => {
-                      event.preventDefault();
-                      const fromIndex = Number(event.dataTransfer.getData('text/plain'));
-
-                      if (Number.isInteger(fromIndex) && fromIndex !== index) {
-                        moveWaypoint(waypoints, setWaypoints, fromIndex, index);
-                        setSelectedWaypointIndex(index);
-                      }
-
-                      setDraggedWaypointIndex(null);
-                      setDragOverWaypointIndex(null);
-                    }}
+                <div className="route-builder-hint">
+                  <InfoIcon />
+                  {routeBuilderHint}
+                </div>
+              </>
+            )}
+            {mapMode === 'embedded' ? (
+              <>
+                <div className="map-builder">
+                  <RouteMapEditor
+                    fitRequest={fitRequest}
+                    focusTarget={focusTarget}
+                    selectedWaypointIndex={selectedWaypointIndex}
+                    waypoints={waypoints}
+                    onChange={setWaypoints}
+                    onSelectWaypoint={setSelectedWaypointIndex}
+                  />
+                  <div className="map-instruction">
+                    Click map to add waypoint · Drag markers to adjust
+                  </div>
+                </div>
+                <div className="map-action-row">
+                  <button
+                    className="secondary"
+                    disabled={waypoints.length === 0}
+                    title="Auto-frame the map to show all waypoints"
+                    type="button"
+                    onClick={() => setFitRequest((currentRequest) => currentRequest + 1)}
                   >
-                    <button
-                      className="waypoint-focus"
-                      type="button"
-                      onClick={() => focusWaypoint(waypoint, index)}
+                    Fit route
+                  </button>
+                  <span className="muted">
+                    Use Waypoints below to review, reorder, or edit pins.
+                  </span>
+                </div>
+              </>
+            ) : null}
+
+            <FavoriteWaypointPicker
+              mode={favoritePickerMode}
+              places={places}
+              onSelect={addFavoriteWaypoint}
+            />
+          </div>
+        </details>
+
+        <details
+          className="route-editor-section route-editor-collapsible route-editor-waypoints-section"
+          open={waypoints.length > 0}
+        >
+          <summary>
+            <span>Waypoints ({waypoints.length})</span>
+            <span className="muted">{formatWaypointSummary(waypoints, places)}</span>
+          </summary>
+          <div className="route-editor-collapsible-content">
+            {waypoints.length === 0 ? (
+              <div className="waypoint-empty-state">
+                <MapPinIcon />
+                <strong>No waypoints yet</strong>
+                <span className="muted">
+                  Click the map to add your first waypoint, or pick from favorites above.
+                </span>
+              </div>
+            ) : (
+              <ul className="waypoint-list" aria-label="Route waypoints">
+                {waypoints.map((waypoint, index) => {
+                  const waypointName = formatWaypointName(waypoint, places, `Pin ${index + 1}`);
+
+                  const waypointRowClassName = [
+                    'waypoint-row',
+                    selectedWaypointIndex === index ? 'selected' : '',
+                    draggedWaypointIndex === index ? 'is-dragging' : '',
+                    dragOverWaypointIndex === index && draggedWaypointIndex !== index
+                      ? 'is-drop-target'
+                      : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
+
+                  return (
+                    <li
+                      className={waypointRowClassName}
+                      draggable
+                      key={getWaypointKey(waypoint, index)}
+                      onDragEnd={() => {
+                        setDraggedWaypointIndex(null);
+                        setDragOverWaypointIndex(null);
+                      }}
+                      onDragEnter={() => setDragOverWaypointIndex(index)}
+                      onDragOver={(event) => event.preventDefault()}
+                      onDragStart={(event) => {
+                        setDraggedWaypointIndex(index);
+                        event.dataTransfer.effectAllowed = 'move';
+                        event.dataTransfer.setData('text/plain', String(index));
+                      }}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        const fromIndex = Number(event.dataTransfer.getData('text/plain'));
+
+                        if (Number.isInteger(fromIndex) && fromIndex !== index) {
+                          moveWaypoint(waypoints, setWaypoints, fromIndex, index);
+                          setSelectedWaypointIndex(index);
+                        }
+
+                        setDraggedWaypointIndex(null);
+                        setDragOverWaypointIndex(null);
+                      }}
                     >
-                      <span className="waypoint-grip" title="Drag to reorder">
-                        <GripVerticalIcon />
-                      </span>
-                      <span className={getWaypointBadgeClassName(index, waypoints.length)}>
-                        {index === waypoints.length - 1 && waypoints.length > 1 ? (
-                          <FlagIcon />
-                        ) : (
-                          index + 1
-                        )}
-                      </span>
-                      <span className="waypoint-name" title={waypointName}>
-                        {waypointName}
-                      </span>
-                      <span className="waypoint-coordinates mono">
-                        {formatWaypointCoords(waypoint)}
-                      </span>
-                    </button>
-                    <details className="waypoint-menu">
-                      <summary aria-label={`More options for ${waypointName}`}>
-                        <MoreHorizontalIcon />
-                      </summary>
-                      <div className="waypoint-menu-content">
-                        <button type="button" onClick={() => removeWaypoint(index)}>
-                          Remove from route
-                        </button>
-                        <button type="button" onClick={() => insertWaypointAfter(index)}>
-                          Insert pin after
-                        </button>
-                        <button type="button" onClick={() => editWaypointCoordinates(index)}>
-                          Edit coordinates
-                        </button>
-                      </div>
-                    </details>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-          <button
-            className="secondary button-icon-label"
-            disabled={waypoints.length === 0}
-            type="button"
-            onClick={duplicateLastWaypoint}
-          >
-            <PlusIcon />
-            Duplicate last waypoint
-          </button>
-        </div>
-      </details>
+                      <button
+                        className="waypoint-focus"
+                        type="button"
+                        onClick={() => focusWaypoint(waypoint, index)}
+                      >
+                        <span className="waypoint-grip" title="Drag to reorder">
+                          <GripVerticalIcon />
+                        </span>
+                        <span className={getWaypointBadgeClassName(index, waypoints.length)}>
+                          {index === waypoints.length - 1 && waypoints.length > 1 ? (
+                            <FlagIcon />
+                          ) : (
+                            index + 1
+                          )}
+                        </span>
+                        <span className="waypoint-name" title={waypointName}>
+                          {waypointName}
+                        </span>
+                        <span className="waypoint-coordinates mono">
+                          {formatWaypointCoords(waypoint)}
+                        </span>
+                      </button>
+                      <details className="waypoint-menu">
+                        <summary aria-label={`More options for ${waypointName}`}>
+                          <MoreHorizontalIcon />
+                        </summary>
+                        <div className="waypoint-menu-content">
+                          <button type="button" onClick={() => removeWaypoint(index)}>
+                            Remove from route
+                          </button>
+                          <button type="button" onClick={() => insertWaypointAfter(index)}>
+                            Insert pin after
+                          </button>
+                          <button type="button" onClick={() => editWaypointCoordinates(index)}>
+                            Edit coordinates
+                          </button>
+                        </div>
+                      </details>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <button
+              className="secondary button-icon-label"
+              disabled={waypoints.length === 0}
+              type="button"
+              onClick={duplicateLastWaypoint}
+            >
+              <PlusIcon />
+              Duplicate last waypoint
+            </button>
+          </div>
+        </details>
+      </div>
 
       <footer className="route-editor-footer">
         <div className="route-editor-footer-actions">


### PR DESCRIPTION
## Summary
- keep dashboard map controls off editor widgets on desktop, short desktop, and mobile
- move route editor scrolling above the footer so route settings are not obscured
- keep the Place detail footer fully inside the panel with a flex body and safe-area-aware footer padding
- hide the decorative index-card pin in dashboard editor cards
- archive the completed UI polish plan

## Verification
- just web-check
- cd web && npm run lint
- cd web && npm run typecheck
- git diff --check
- docker compose -f compose.webtest.yaml up -d --build
- Chrome/CDP visual review: /dashboard/places and /dashboard/routes at 1440x760, 1024x600, and 390x844
- Place footer check: 1792x848 and 576x768 show Delete / Share / Save place fully visible, with form body scrolling
- Chrome/CDP interaction check: Places and Routes Share/Device dialogs open after layout changes