### PR TITLE
fix(web): sync route markers after map load

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,6 +1,7 @@
 ## GOTCHA
 
 - Web route markers are `<button>` MapLibre markers. Symptom: route point labels/dots look vertically stretched or offset, especially compact markers. Cause: global `button { min-height: 36px; }` leaks into `.route-marker`. Fix: keep `button.route-marker { min-height: 0; }`; visual dot is a 14px `::before`, label is `::after`, and the button hit target stays larger.
+- Symptom: Web route summary changes route but map keeps stale markers/line until another interaction. Cause: after initial MapLibre `load`, `isStyleLoaded()` can be false while tiles load, and waiting on already-fired `load` drops the waypoint sync. Fix: if the route source already exists, sync immediately; otherwise wait for `style.load`.
 - Android adaptive launcher icon layers are `108dp × 108dp`; keep important artwork inside the central `66dp × 66dp` safe zone (`x/y = 21..87`) and size the logo about `48..66dp`. Legacy launcher PNG sizes are mdpi 48, hdpi 72, xhdpi 96, xxhdpi 144, xxxhdpi 192 px.
 - Android `:app:assembleRelease` currently produces `app/build/outputs/apk/release/app-release-unsigned.apk` because there is no signing config yet. Any workflow or release docs must call the artifact unsigned until keystore-based signing is added.
 - The auto-tag flow must push tags with `PAT_TOKEN`, not the default `GITHUB_TOKEN`, or the follow-up `push.tags` release workflow will not fire.

--- a/docs/plans/archived/2026-06-27_route-rendering-consistency-plan.md
+++ b/docs/plans/archived/2026-06-27_route-rendering-consistency-plan.md
@@ -1,0 +1,25 @@
+## Goal
+
+Fix route editor rendering so the selected route's polyline, waypoint markers, and summary all use the same waypoint sequence after route load and route switching.
+
+## Context
+
+PR #175 only reduced dense label overlap and clarified straight-segment copy. The reported issue is still a rendering consistency bug: for a reported 30-waypoint route, the summary and map markers can disagree while markers appear spread far from the visible polyline.
+
+Root cause found in `RouteMapEditor`: after initial map load, `map.isStyleLoaded()` can be false while raster tiles are still loading even though the route source/layer already exists. The waypoint effect then registered `map.once('load', update)`, but `load` had already fired, so marker/line sync was dropped while `fitWaypoints()` still moved the viewport to the new route.
+
+## Plan
+
+- [x] Reproduce with browser screenshots and runtime metrics for a reported 30-waypoint route; verified `/tmp/kestrel-switch-current/first.png` and `/tmp/kestrel-switch-current/metrics.json` where a selected 30-waypoint route summary showed 30 waypoints but DOM markers stayed at 12.
+- [x] Trace route selection data flow in `routes/page.tsx` and `RouteMapEditor.tsx`; verified stale route rendering can survive route switches when the waypoint effect waits for already-fired `load`.
+- [x] Apply the smallest root-cause fix so marker sync runs when the route source already exists, and otherwise waits for `style.load`; verified by `web/components/RouteMapEditor.tsx` diff.
+- [x] Switch between multiple routes in the browser and verify old markers/labels disappear and the new marker count matches the selected route summary; verified `/tmp/kestrel-switch-after/metrics.json` shows 30 markers for both 30-waypoint test routes after switching.
+- [x] Run `just web-check` and update a follow-up PR branch with the fix.
+
+## Completion Checklist
+
+- [x] Reported-route browser metrics show selected route, route summary, and marker count all equal 30 in `/tmp/kestrel-switch-after/metrics.json`.
+- [x] Route line and markers are synced from the same `waypoints` array by `syncLineLayer(map, waypoints)` and `syncMarkers(..., waypoints)` in the same update callback.
+- [x] Route switching browser metrics show no stale marker count from the previous route: before fix 12/30 mismatch, after fix 30/30 in `/tmp/kestrel-switch-after/metrics.json`.
+- [x] Visual screenshot `/tmp/kestrel-switch-after/second.png` shows the reported route's pins around the selected route line, not stale pins from the prior route.
+- [x] `just web-check` passes.

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -118,6 +118,11 @@ export default function RouteMapEditor({
   }, []);
 
   useEffect(() => {
+    // Dependencies trigger resync; deferred style.load uses refs to avoid stale route data.
+    void onChange;
+    void onSelectWaypoint;
+    void waypoints;
+
     const map = mapRef.current;
 
     if (map == null) {
@@ -125,22 +130,33 @@ export default function RouteMapEditor({
     }
 
     const update = () => {
-      syncLineLayer(map, waypoints);
+      const currentWaypoints = waypointsRef.current;
+
+      syncLineLayer(map, currentWaypoints);
       syncMarkers({
         existingMarkers: markersRef.current,
         map,
-        onChange,
-        onSelectWaypoint,
-        waypoints,
+        onChange: onChangeRef.current,
+        onSelectWaypoint: onSelectWaypointRef.current,
+        waypoints: currentWaypoints,
       });
-      updateMarkerDisplay(markersRef.current, selectedWaypointIndexRef.current, waypoints.length);
+      updateMarkerDisplay(
+        markersRef.current,
+        selectedWaypointIndexRef.current,
+        currentWaypoints.length,
+      );
     };
 
-    if (map.isStyleLoaded()) {
+    if (canSyncRouteLayer(map)) {
       update();
-    } else {
-      map.once('load', update);
+      return;
     }
+
+    map.once('style.load', update);
+
+    return () => {
+      map.off('style.load', update);
+    };
   }, [onChange, onSelectWaypoint, waypoints]);
 
   useEffect(() => {
@@ -410,6 +426,10 @@ function updateLine(map: MapLibreMap, waypoints: RouteWaypoint[]) {
   const source = map.getSource(LINE_SOURCE_ID) as GeoJSONSource | undefined;
 
   source?.setData(toLineFeature(waypoints));
+}
+
+function canSyncRouteLayer(map: MapLibreMap): boolean {
+  return map.isStyleLoaded() || map.getSource(LINE_SOURCE_ID) != null;
 }
 
 function toLineFeature(waypoints: RouteWaypoint[]): GeoJSON.Feature<GeoJSON.LineString> {


### PR DESCRIPTION
## Summary
- fix dropped route waypoint sync when MapLibre reports style not fully loaded after the one-time load event
- sync immediately once the route source exists; otherwise wait for style.load
- document the MapLibre load/style.load gotcha and archive the completed plan

## Verification
- just web-check
- docker compose -f compose.webtest.yaml up -d --build web
- browser switch repro before fix: /tmp/kestrel-switch-current/metrics.json showed selected 30-waypoint route with 12 stale markers
- browser switch check after fix: /tmp/kestrel-switch-after/metrics.json shows 30 markers for Far stale marker probe and 30 markers for 飛田新地 after switching
- screenshots: /tmp/kestrel-switch-after/first.png and /tmp/kestrel-switch-after/second.png
