### PR TITLE
feat(web): guard unsaved editor changes

### DIFF
--- a/docs/plans/archived/2026-06-28_web-unsaved-changes-plan.md
+++ b/docs/plans/archived/2026-06-28_web-unsaved-changes-plan.md
@@ -1,0 +1,41 @@
+## Goal
+
+Make unsaved edits in the Web Places and Routes editors obvious and hard to lose. Success means users can see when a draft differs from the saved record, get warned before destructive navigation, and receive a clear save confirmation.
+
+## Context
+
+Current Places and Routes pages keep local draft state in `web/app/dashboard/places/page.tsx`, `web/app/dashboard/routes/page.tsx`, `PlaceEditor`, and `RouteEditor`. Save feedback exists in `RouteEditor`, but unsaved state is not exposed consistently across the map, list selection, editor footer, and navigation.
+
+## Non-Goals
+
+- Do not add offline draft persistence in this phase.
+- Do not redesign the editor forms beyond unsaved-state signals and guards.
+- Do not change backend API contracts.
+
+## Plan
+
+- [x] Add dirty-state detection helpers for Place and Route drafts to compare editor state with the selected saved item; verify with focused unit tests or small pure-function tests under `web` plus `npm run typecheck`.
+- [x] Surface dirty state in `PlaceEditor` and `RouteEditor` footer/header copy with an `Unsaved changes` label and save-success toast/notice; verify with Chrome DevTools screenshots of both clean and dirty states.
+- [x] Guard selection changes in `FieldNotebook` entries so switching Places/Routes while dirty asks the user to save, discard, or cancel; verify manually in `just webtest-up` by editing a field and attempting to select another item.
+- [x] Guard browser/tab navigation with `beforeunload` only while dirty; verify manually by editing a field and reloading the page, then confirming no warning appears after saving.
+- [x] Add discard/reset actions that restore the selected saved item or clear a new draft; verify by editing place coordinates and route waypoints, discarding, and checking the map/editor return to saved values.
+- [x] Run quality gates for touched Web code; verify with `just web-check` and `cd web && npm run typecheck`.
+
+## Risks
+
+- Dirty checks can become noisy if derived/default values differ in shape from API payloads; keep comparison helpers small and normalize values before comparing.
+- Native `beforeunload` prompts are browser-controlled and cannot show custom text; do not rely on custom copy there.
+
+## Completion Checklist
+
+- [x] Dirty Places and Routes show visible `Unsaved changes` state, verified by Chrome DevTools screenshots in the dev stack.
+- [x] Switching selected library items while dirty cannot silently discard edits, verified by manual browser smoke in `just webtest-up`.
+- [x] Reloading/closing while dirty triggers a browser warning and does not warn after save/discard, verified by manual browser smoke.
+- [x] Save success and discard/reset behavior are visible and correct for Place and Route editors, verified by manual browser smoke.
+- [x] Web checks pass, verified by `just web-check` and `cd web && npm run typecheck`.
+
+## Completion Evidence
+
+- `just web-check` passed.
+- `cd web && npm run typecheck` passed.
+- Chrome DevTools smoke on `http://localhost:3401/dashboard/routes` verified `Unsaved changes`, `Discard changes`, and `beforeunload` cancellation for dirty route edits.

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -53,6 +53,7 @@ export default function PlacesDashboardPage() {
   const [placeQuery, setPlaceQuery] = useState('');
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [viewportControls, setViewportControls] = useState<PlaceViewportControls | null>(null);
+  const [isPlaceDirty, setIsPlaceDirty] = useState(false);
 
   const selectedPlace = useMemo(
     () => places.find((place) => place.id === selectedPlaceId) ?? null,
@@ -108,19 +109,44 @@ export default function PlacesDashboardPage() {
 
   const selectPlace = useCallback(
     (placeId: string) => {
+      if (!confirmDiscardUnsavedChanges(isPlaceDirty)) {
+        return;
+      }
+
       const place = places.find((currentPlace) => currentPlace.id === placeId);
+      setIsPlaceDirty(false);
       setSelectedPlaceId(placeId);
       setDraftPlaceCoords(
         place == null ? null : { latitude: place.latitude, longitude: place.longitude },
       );
     },
-    [places],
+    [isPlaceDirty, places],
   );
 
   const createNewPlace = useCallback(() => {
+    if (!confirmDiscardUnsavedChanges(isPlaceDirty)) {
+      return;
+    }
+
+    setIsPlaceDirty(false);
     setDraftPlaceCoords(activeCoords);
     setSelectedPlaceId(null);
-  }, [activeCoords]);
+  }, [activeCoords, isPlaceDirty]);
+
+  useEffect(() => {
+    if (!isPlaceDirty) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isPlaceDirty]);
 
   useKeyboardShortcuts({
     onClose: () => setIsHelpOpen(false),
@@ -152,6 +178,7 @@ export default function PlacesDashboardPage() {
           });
 
     await loadPlaces();
+    setIsPlaceDirty(false);
     setSelectedPlaceId(savedPlace.id);
     setDraftPlaceCoords({ latitude: savedPlace.latitude, longitude: savedPlace.longitude });
   }
@@ -253,6 +280,15 @@ export default function PlacesDashboardPage() {
           draftCoords={activeCoords}
           key={selectedPlace?.id ?? 'new-place'}
           onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
+          onDirtyChange={setIsPlaceDirty}
+          onDiscard={() => {
+            setDraftPlaceCoords(
+              selectedPlace == null
+                ? DEFAULT_MAP_CENTER
+                : { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude },
+            );
+            setIsPlaceDirty(false);
+          }}
           onSave={(input) => void savePlace(input)}
           place={selectedPlace}
           showHeader={false}
@@ -268,6 +304,10 @@ export default function PlacesDashboardPage() {
       <KeyboardCheatsheet isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
     </Stage>
   );
+}
+
+function confirmDiscardUnsavedChanges(isDirty: boolean): boolean {
+  return !isDirty || window.confirm('Discard unsaved changes? Save first to keep them.');
 }
 
 function NotebookSkeleton() {

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -54,6 +54,7 @@ export default function PlacesDashboardPage() {
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [viewportControls, setViewportControls] = useState<PlaceViewportControls | null>(null);
   const [isPlaceDirty, setIsPlaceDirty] = useState(false);
+  const [newPlaceDraftNonce, setNewPlaceDraftNonce] = useState(0);
 
   const selectedPlace = useMemo(
     () => places.find((place) => place.id === selectedPlaceId) ?? null,
@@ -135,6 +136,7 @@ export default function PlacesDashboardPage() {
     setIsPlaceDirty(false);
     setDraftPlaceCoords(activeCoords);
     setSelectedPlaceId(null);
+    setNewPlaceDraftNonce((currentNonce) => currentNonce + 1);
   }, [activeCoords, isPlaceDirty]);
 
   useEffect(() => {
@@ -282,7 +284,7 @@ export default function PlacesDashboardPage() {
       >
         <PlaceEditor
           draftCoords={activeCoords}
-          key={selectedPlace?.id ?? 'new-place'}
+          key={selectedPlace?.id ?? `new-place-${newPlaceDraftNonce}`}
           onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
           onDirtyChange={setIsPlaceDirty}
           onDiscard={(coords) => {

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -281,12 +281,8 @@ export default function PlacesDashboardPage() {
           key={selectedPlace?.id ?? 'new-place'}
           onDelete={selectedPlace == null ? undefined : () => void deletePlace(selectedPlace.id)}
           onDirtyChange={setIsPlaceDirty}
-          onDiscard={() => {
-            setDraftPlaceCoords(
-              selectedPlace == null
-                ? DEFAULT_MAP_CENTER
-                : { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude },
-            );
+          onDiscard={(coords) => {
+            setDraftPlaceCoords(coords);
             setIsPlaceDirty(false);
           }}
           onSave={(input) => void savePlace(input)}

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -109,6 +109,10 @@ export default function PlacesDashboardPage() {
 
   const selectPlace = useCallback(
     (placeId: string) => {
+      if (placeId === selectedPlaceId) {
+        return;
+      }
+
       if (!confirmDiscardUnsavedChanges(isPlaceDirty)) {
         return;
       }
@@ -120,7 +124,7 @@ export default function PlacesDashboardPage() {
         place == null ? null : { latitude: place.latitude, longitude: place.longitude },
       );
     },
-    [isPlaceDirty, places],
+    [isPlaceDirty, places, selectedPlaceId],
   );
 
   const createNewPlace = useCallback(() => {

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -117,6 +117,10 @@ export default function RoutesDashboardPage() {
 
   const selectRoute = useCallback(
     (routeId: string) => {
+      if (routeId === selectedRouteId) {
+        return;
+      }
+
       if (!confirmDiscardUnsavedChanges(isRouteDirty)) {
         return;
       }
@@ -124,7 +128,7 @@ export default function RoutesDashboardPage() {
       setIsRouteDirty(false);
       setSelectedRouteId(routeId);
     },
-    [isRouteDirty],
+    [isRouteDirty, selectedRouteId],
   );
 
   const createNewRoute = useCallback(() => {

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -49,6 +49,7 @@ export default function RoutesDashboardPage() {
   const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
   const [isRouteDirty, setIsRouteDirty] = useState(false);
+  const [newRouteDraftNonce, setNewRouteDraftNonce] = useState(0);
 
   const selectedRoute = useMemo(
     () => routes.find((route) => route.id === selectedRouteId) ?? null,
@@ -137,7 +138,11 @@ export default function RoutesDashboardPage() {
     }
 
     setIsRouteDirty(false);
+    setDraftWaypoints([]);
+    setSelectedWaypointIndex(null);
+    setFocusTarget(null);
     setSelectedRouteId(null);
+    setNewRouteDraftNonce((currentNonce) => currentNonce + 1);
   }, [isRouteDirty]);
 
   useEffect(() => {
@@ -293,7 +298,7 @@ export default function RoutesDashboardPage() {
         variant="route"
       >
         <RouteEditor
-          key={selectedRoute?.id ?? 'new-route'}
+          key={selectedRoute?.id ?? `new-route-${newRouteDraftNonce}`}
           onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
           onDirtyChange={setIsRouteDirty}
           mapMode="background"

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -48,6 +48,7 @@ export default function RoutesDashboardPage() {
   const [draftWaypoints, setDraftWaypoints] = useState<RouteWaypoint[]>([]);
   const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
+  const [isRouteDirty, setIsRouteDirty] = useState(false);
 
   const selectedRoute = useMemo(
     () => routes.find((route) => route.id === selectedRouteId) ?? null,
@@ -114,9 +115,41 @@ export default function RoutesDashboardPage() {
     }
   }, [selectedRoute]);
 
+  const selectRoute = useCallback(
+    (routeId: string) => {
+      if (!confirmDiscardUnsavedChanges(isRouteDirty)) {
+        return;
+      }
+
+      setIsRouteDirty(false);
+      setSelectedRouteId(routeId);
+    },
+    [isRouteDirty],
+  );
+
   const createNewRoute = useCallback(() => {
+    if (!confirmDiscardUnsavedChanges(isRouteDirty)) {
+      return;
+    }
+
+    setIsRouteDirty(false);
     setSelectedRouteId(null);
-  }, []);
+  }, [isRouteDirty]);
+
+  useEffect(() => {
+    if (!isRouteDirty) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isRouteDirty]);
 
   useKeyboardShortcuts({
     onClose: () => setIsHelpOpen(false),
@@ -148,6 +181,7 @@ export default function RoutesDashboardPage() {
           });
 
     await loadRoutes();
+    setIsRouteDirty(false);
     setSelectedRouteId(savedRoute.id);
   }
 
@@ -211,7 +245,7 @@ export default function RoutesDashboardPage() {
             className={`notebook-entry route-notebook-entry${selectedRouteId === route.id ? ' active' : ''}`}
             key={route.id}
             type="button"
-            onClick={() => setSelectedRouteId(route.id)}
+            onClick={() => selectRoute(route.id)}
           >
             <span className="route-card-title-row">
               <strong className="route-card-title">{route.name}</strong>
@@ -257,6 +291,7 @@ export default function RoutesDashboardPage() {
         <RouteEditor
           key={selectedRoute?.id ?? 'new-route'}
           onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
+          onDirtyChange={setIsRouteDirty}
           mapMode="background"
           places={places}
           route={selectedRoute}
@@ -277,6 +312,10 @@ export default function RoutesDashboardPage() {
       <KeyboardCheatsheet isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
     </Stage>
   );
+}
+
+function confirmDiscardUnsavedChanges(isDirty: boolean): boolean {
+  return !isDirty || window.confirm('Discard unsaved changes? Save first to keep them.');
 }
 
 function NotebookSkeleton() {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -6062,6 +6062,12 @@ button.route-marker.selected::after {
   justify-items: end;
 }
 
+.unsaved-changes-label {
+  color: var(--accent-hover);
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .route-danger-zone {
   display: flex;
   min-width: 0;

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -19,6 +19,8 @@ const PlaceMapEditor = dynamic(() => import('@/components/PlaceMapEditor'), {
 export default function PlaceEditor({
   draftCoords,
   onDelete,
+  onDirtyChange,
+  onDiscard,
   onSave,
   place,
   showHeader = true,
@@ -26,6 +28,8 @@ export default function PlaceEditor({
 }: {
   draftCoords?: { latitude: number; longitude: number };
   onDelete?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  onDiscard?: () => void;
   onSave: (input: PlaceInput) => void;
   place: Place | null;
   showHeader?: boolean;
@@ -41,10 +45,17 @@ export default function PlaceEditor({
   const [description, setDescription] = useState(place?.description ?? '');
   const [tags, setTags] = useState(place?.tags.join(', ') ?? '');
   const [error, setError] = useState<string | null>(null);
+  const [saveNotice, setSaveNotice] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const shareDialogRef = useRef<HTMLDialogElement | null>(null);
+  const saveNoticeTimeoutRef = useRef<number | null>(null);
+  const initialDraftCoordsRef = useRef({
+    latitude: draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude,
+    longitude: draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
+  });
 
+  const baseline = useMemo(() => getPlaceBaseline(place, initialDraftCoordsRef.current), [place]);
   const mapCoords = useMemo(
     () => ({
       latitude: parseCoordinateOrFallback(
@@ -58,6 +69,16 @@ export default function PlaceEditor({
     }),
     [draftCoords, latitude, longitude, place],
   );
+  const isDirty = !isPlaceDraftEqual(
+    {
+      description,
+      latitude,
+      longitude,
+      name,
+      tags,
+    },
+    baseline,
+  );
 
   useEffect(() => {
     if (draftCoords == null) {
@@ -67,6 +88,21 @@ export default function PlaceEditor({
     setLatitude(formatCoordinateInput(draftCoords.latitude));
     setLongitude(formatCoordinateInput(draftCoords.longitude));
   }, [draftCoords]);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+
+    return () => onDirtyChange?.(false);
+  }, [isDirty, onDirtyChange]);
+
+  useEffect(
+    () => () => {
+      if (saveNoticeTimeoutRef.current != null) {
+        window.clearTimeout(saveNoticeTimeoutRef.current);
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     const dialog = shareDialogRef.current;
@@ -88,6 +124,10 @@ export default function PlaceEditor({
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+    setSaveNotice(null);
+    if (saveNoticeTimeoutRef.current != null) {
+      window.clearTimeout(saveNoticeTimeoutRef.current);
+    }
     setIsSaving(true);
 
     try {
@@ -101,11 +141,27 @@ export default function PlaceEditor({
           .map((tag) => tag.trim())
           .filter(Boolean),
       });
+      setSaveNotice('Saved.');
+      saveNoticeTimeoutRef.current = window.setTimeout(() => {
+        setSaveNotice(null);
+        saveNoticeTimeoutRef.current = null;
+      }, 1000);
     } catch (nextError) {
       setError(formatError(nextError));
     } finally {
       setIsSaving(false);
     }
+  }
+
+  function discardChanges() {
+    setName(baseline.name);
+    setLatitude(baseline.latitude);
+    setLongitude(baseline.longitude);
+    setDescription(baseline.description);
+    setTags(baseline.tags);
+    setError(null);
+    setSaveNotice(null);
+    onDiscard?.();
   }
 
   function confirmDelete() {
@@ -129,6 +185,7 @@ export default function PlaceEditor({
       ) : null}
       <div className="place-editor-content stack">
         {error == null ? null : <div className="error">{error}</div>}
+        {saveNotice == null ? null : <div className="success">{saveNotice}</div>}
         {showMap ? (
           <PlaceMapEditor
             latitude={mapCoords.latitude}
@@ -182,6 +239,17 @@ export default function PlaceEditor({
             )}
           </div>
           <div className="place-editor-save-actions">
+            {isDirty ? <span className="unsaved-changes-label">Unsaved changes</span> : null}
+            {isDirty ? (
+              <button
+                className="secondary"
+                disabled={isSaving}
+                type="button"
+                onClick={discardChanges}
+              >
+                Discard changes
+              </button>
+            ) : null}
             <button
               aria-haspopup="dialog"
               className="secondary"
@@ -191,7 +259,7 @@ export default function PlaceEditor({
               Share
             </button>
             <button disabled={isSaving} type="submit">
-              {isSaving ? 'Saving…' : 'Save place'}
+              {isSaving ? 'Saving…' : saveNotice == null ? 'Save place' : 'Saved ✓'}
             </button>
           </div>
         </div>
@@ -223,6 +291,38 @@ export default function PlaceEditor({
         </dialog>
       </footer>
     </form>
+  );
+}
+
+function getPlaceBaseline(
+  place: Place | null,
+  draftCoords: { latitude: number; longitude: number },
+) {
+  return {
+    description: place?.description ?? '',
+    latitude: formatCoordinateInput(place?.latitude ?? draftCoords.latitude),
+    longitude: formatCoordinateInput(place?.longitude ?? draftCoords.longitude),
+    name: place?.name ?? '',
+    tags: place?.tags.join(', ') ?? '',
+  };
+}
+
+function isPlaceDraftEqual(
+  draft: {
+    description: string;
+    latitude: string;
+    longitude: string;
+    name: string;
+    tags: string;
+  },
+  baseline: ReturnType<typeof getPlaceBaseline>,
+): boolean {
+  return (
+    draft.description === baseline.description &&
+    draft.latitude === baseline.latitude &&
+    draft.longitude === baseline.longitude &&
+    draft.name === baseline.name &&
+    draft.tags === baseline.tags
   );
 }
 

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -50,12 +50,19 @@ export default function PlaceEditor({
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const shareDialogRef = useRef<HTMLDialogElement | null>(null);
   const saveNoticeTimeoutRef = useRef<number | null>(null);
-  const initialDraftCoordsRef = useRef({
-    latitude: draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude,
-    longitude: draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
-  });
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  const draftBaselineCoords = useMemo(
+    () => ({
+      latitude: draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude,
+      longitude: draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
+    }),
+    [draftCoords],
+  );
 
-  const baseline = useMemo(() => getPlaceBaseline(place, initialDraftCoordsRef.current), [place]);
+  const baseline = useMemo(
+    () => getPlaceBaseline(place, draftBaselineCoords),
+    [draftBaselineCoords, place],
+  );
   const mapCoords = useMemo(
     () => ({
       latitude: parseCoordinateOrFallback(
@@ -90,10 +97,14 @@ export default function PlaceEditor({
   }, [draftCoords]);
 
   useEffect(() => {
-    onDirtyChange?.(isDirty);
+    onDirtyChangeRef.current = onDirtyChange;
+  }, [onDirtyChange]);
 
-    return () => onDirtyChange?.(false);
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
   }, [isDirty, onDirtyChange]);
+
+  useEffect(() => () => onDirtyChangeRef.current?.(false), []);
 
   useEffect(
     () => () => {

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -332,12 +332,27 @@ function isPlaceDraftEqual(
   baseline: ReturnType<typeof getPlaceBaseline>,
 ): boolean {
   return (
-    draft.description === baseline.description &&
-    draft.latitude === baseline.latitude &&
-    draft.longitude === baseline.longitude &&
+    normalizeNullable(draft.description) === normalizeNullable(baseline.description) &&
+    numberInputsEqual(draft.latitude, baseline.latitude) &&
+    numberInputsEqual(draft.longitude, baseline.longitude) &&
     draft.name === baseline.name &&
-    draft.tags === baseline.tags
+    normalizeTagsInput(draft.tags) === normalizeTagsInput(baseline.tags)
   );
+}
+
+function numberInputsEqual(left: string, right: string): boolean {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+
+  return Number.isFinite(leftNumber) && Number.isFinite(rightNumber) && leftNumber === rightNumber;
+}
+
+function normalizeTagsInput(value: string): string {
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .join('\n');
 }
 
 function PlaceSharePanel({ place }: { place: Place | null }) {

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -29,18 +29,20 @@ export default function PlaceEditor({
   draftCoords?: { latitude: number; longitude: number };
   onDelete?: () => void;
   onDirtyChange?: (isDirty: boolean) => void;
-  onDiscard?: () => void;
+  onDiscard?: (coords: { latitude: number; longitude: number }) => void;
   onSave: (input: PlaceInput) => void;
   place: Place | null;
   showHeader?: boolean;
   showMap?: boolean;
 }) {
   const [name, setName] = useState(place?.name ?? '');
-  const [latitude, setLatitude] = useState(
-    place?.latitude.toString() ?? `${draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude}`,
+  const [latitude, setLatitude] = useState(() =>
+    formatCoordinateInput(place?.latitude ?? draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude),
   );
-  const [longitude, setLongitude] = useState(
-    place?.longitude.toString() ?? `${draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude}`,
+  const [longitude, setLongitude] = useState(() =>
+    formatCoordinateInput(
+      place?.longitude ?? draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
+    ),
   );
   const [description, setDescription] = useState(place?.description ?? '');
   const [tags, setTags] = useState(place?.tags.join(', ') ?? '');
@@ -51,18 +53,19 @@ export default function PlaceEditor({
   const shareDialogRef = useRef<HTMLDialogElement | null>(null);
   const saveNoticeTimeoutRef = useRef<number | null>(null);
   const onDirtyChangeRef = useRef(onDirtyChange);
-  const draftBaselineCoords = useMemo(
-    () => ({
-      latitude: draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude,
-      longitude: draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
-    }),
-    [draftCoords],
+  const [newPlaceBaselineCoords] = useState(() => ({
+    latitude: draftCoords?.latitude ?? DEFAULT_MAP_CENTER.latitude,
+    longitude: draftCoords?.longitude ?? DEFAULT_MAP_CENTER.longitude,
+  }));
+  const baselineCoords = useMemo(
+    () =>
+      place == null
+        ? newPlaceBaselineCoords
+        : { latitude: place.latitude, longitude: place.longitude },
+    [newPlaceBaselineCoords, place],
   );
 
-  const baseline = useMemo(
-    () => getPlaceBaseline(place, draftBaselineCoords),
-    [draftBaselineCoords, place],
-  );
+  const baseline = useMemo(() => getPlaceBaseline(place, baselineCoords), [baselineCoords, place]);
   const mapCoords = useMemo(
     () => ({
       latitude: parseCoordinateOrFallback(
@@ -172,7 +175,7 @@ export default function PlaceEditor({
     setTags(baseline.tags);
     setError(null);
     setSaveNotice(null);
-    onDiscard?.();
+    onDiscard?.(baselineCoords);
   }
 
   function confirmDelete() {

--- a/web/components/dashboard/PlaceEditor.tsx
+++ b/web/components/dashboard/PlaceEditor.tsx
@@ -335,7 +335,7 @@ function isPlaceDraftEqual(
     normalizeNullable(draft.description) === normalizeNullable(baseline.description) &&
     numberInputsEqual(draft.latitude, baseline.latitude) &&
     numberInputsEqual(draft.longitude, baseline.longitude) &&
-    draft.name === baseline.name &&
+    draft.name.trim() === baseline.name.trim() &&
     normalizeTagsInput(draft.tags) === normalizeTagsInput(baseline.tags)
   );
 }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -30,6 +30,7 @@ const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
 export default function RouteEditor({
   mapMode = 'embedded',
   onDelete,
+  onDirtyChange,
   onFocusTargetChange,
   onSave,
   onSelectedWaypointIndexChange,
@@ -41,6 +42,7 @@ export default function RouteEditor({
 }: {
   mapMode?: 'background' | 'embedded';
   onDelete?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
   onFocusTargetChange?: (waypoint: RouteWaypoint | null) => void;
   onSave: (input: RouteInput) => void;
   onSelectedWaypointIndexChange?: (index: number | null) => void;
@@ -84,6 +86,18 @@ export default function RouteEditor({
   const routeBuilderHint = getRouteBuilderHint(waypoints.length, places.length, mapMode);
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
+  const baseline = useMemo(() => getRouteBaseline(route), [route]);
+  const isDirty = !isRouteDraftEqual(
+    {
+      defaultSpeedKmh,
+      description,
+      isPublic,
+      mode,
+      name,
+      waypoints,
+    },
+    baseline,
+  );
   const revisionLabel =
     route?.currentRevision == null ? 'Draft' : `Revision ${route.currentRevision.revisionNumber}`;
   const distanceLabel = useMemo(() => formatRouteDistanceFromWaypoints(waypoints), [waypoints]);
@@ -109,6 +123,12 @@ export default function RouteEditor({
       setSelectedWaypointIndex(null);
     }
   }, [selectedWaypointIndex, setSelectedWaypointIndex, waypoints.length]);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+
+    return () => onDirtyChange?.(false);
+  }, [isDirty, onDirtyChange]);
 
   useEffect(
     () => () => {
@@ -252,6 +272,19 @@ export default function RouteEditor({
   function focusWaypoint(waypoint: RouteWaypoint, index: number) {
     setSelectedWaypointIndex(index);
     setRouteFocusTarget(waypoint);
+  }
+
+  function discardChanges() {
+    setName(baseline.name);
+    setDescription(baseline.description);
+    setDefaultSpeedKmh(baseline.defaultSpeedKmh);
+    setMode(baseline.mode);
+    setIsPublic(baseline.isPublic);
+    setWaypoints(baseline.waypoints);
+    setSelectedWaypointIndex(null);
+    setRouteFocusTarget(null);
+    setError(null);
+    setSaveNotice(null);
   }
 
   function confirmDelete() {
@@ -548,10 +581,21 @@ export default function RouteEditor({
             )}
           </div>
           <div className="route-save-actions">
+            {isDirty ? <span className="unsaved-changes-label">Unsaved changes</span> : null}
             {saveDisabledReason == null ? null : (
               <p className="muted no-margin">{saveDisabledReason}</p>
             )}
             <div className="route-editor-save-buttons">
+              {isDirty ? (
+                <button
+                  className="secondary"
+                  disabled={isSaving}
+                  type="button"
+                  onClick={discardChanges}
+                >
+                  Discard changes
+                </button>
+              ) : null}
               <button
                 aria-haspopup="dialog"
                 className="secondary"
@@ -607,6 +651,53 @@ export default function RouteEditor({
         </dialog>
       </footer>
     </form>
+  );
+}
+
+function getRouteBaseline(route: Route | null) {
+  return {
+    defaultSpeedKmh: route?.defaultSpeedKmh.toString() ?? '5',
+    description: route?.description ?? '',
+    isPublic: route?.isPublic ?? false,
+    mode: route?.mode ?? ('ONCE' as RouteMode),
+    name: route?.name ?? '',
+    waypoints:
+      route?.currentRevision?.waypoints.map((waypoint) => ({
+        latitude: waypoint.latitude,
+        longitude: waypoint.longitude,
+      })) ?? [],
+  };
+}
+
+function isRouteDraftEqual(
+  draft: {
+    defaultSpeedKmh: string;
+    description: string;
+    isPublic: boolean;
+    mode: RouteMode;
+    name: string;
+    waypoints: RouteWaypoint[];
+  },
+  baseline: ReturnType<typeof getRouteBaseline>,
+): boolean {
+  return (
+    draft.defaultSpeedKmh === baseline.defaultSpeedKmh &&
+    draft.description === baseline.description &&
+    draft.isPublic === baseline.isPublic &&
+    draft.mode === baseline.mode &&
+    draft.name === baseline.name &&
+    waypointsEqual(draft.waypoints, baseline.waypoints)
+  );
+}
+
+function waypointsEqual(left: RouteWaypoint[], right: RouteWaypoint[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (waypoint, index) =>
+        waypoint.latitude === right[index]?.latitude &&
+        waypoint.longitude === right[index]?.longitude,
+    )
   );
 }
 

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -694,7 +694,7 @@ function isRouteDraftEqual(
     normalizeNullable(draft.description) === normalizeNullable(baseline.description) &&
     draft.isPublic === baseline.isPublic &&
     draft.mode === baseline.mode &&
-    draft.name === baseline.name &&
+    draft.name.trim() === baseline.name.trim() &&
     waypointsEqual(draft.waypoints, baseline.waypoints)
   );
 }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -690,13 +690,20 @@ function isRouteDraftEqual(
   baseline: ReturnType<typeof getRouteBaseline>,
 ): boolean {
   return (
-    draft.defaultSpeedKmh === baseline.defaultSpeedKmh &&
-    draft.description === baseline.description &&
+    numberInputsEqual(draft.defaultSpeedKmh, baseline.defaultSpeedKmh) &&
+    normalizeNullable(draft.description) === normalizeNullable(baseline.description) &&
     draft.isPublic === baseline.isPublic &&
     draft.mode === baseline.mode &&
     draft.name === baseline.name &&
     waypointsEqual(draft.waypoints, baseline.waypoints)
   );
+}
+
+function numberInputsEqual(left: string, right: string): boolean {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+
+  return Number.isFinite(leftNumber) && Number.isFinite(rightNumber) && leftNumber === rightNumber;
 }
 
 function waypointsEqual(left: RouteWaypoint[], right: RouteWaypoint[]): boolean {

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -76,6 +76,7 @@ export default function RouteEditor({
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const saveNoticeTimeoutRef = useRef<number | null>(null);
   const shareDialogRef = useRef<HTMLDialogElement | null>(null);
+  const onDirtyChangeRef = useRef(onDirtyChange);
   const waypoints = controlledWaypoints ?? internalWaypoints;
   const selectedWaypointIndex =
     controlledSelectedWaypointIndex === undefined
@@ -87,16 +88,20 @@ export default function RouteEditor({
   const saveDisabledReason = getSaveDisabledReason(waypoints.length);
   const favoritePickerMode = waypoints.length === 0 ? 'start' : 'append';
   const baseline = useMemo(() => getRouteBaseline(route), [route]);
-  const isDirty = !isRouteDraftEqual(
-    {
-      defaultSpeedKmh,
-      description,
-      isPublic,
-      mode,
-      name,
-      waypoints,
-    },
-    baseline,
+  const isDirty = useMemo(
+    () =>
+      !isRouteDraftEqual(
+        {
+          defaultSpeedKmh,
+          description,
+          isPublic,
+          mode,
+          name,
+          waypoints,
+        },
+        baseline,
+      ),
+    [baseline, defaultSpeedKmh, description, isPublic, mode, name, waypoints],
   );
   const revisionLabel =
     route?.currentRevision == null ? 'Draft' : `Revision ${route.currentRevision.revisionNumber}`;
@@ -125,10 +130,14 @@ export default function RouteEditor({
   }, [selectedWaypointIndex, setSelectedWaypointIndex, waypoints.length]);
 
   useEffect(() => {
-    onDirtyChange?.(isDirty);
+    onDirtyChangeRef.current = onDirtyChange;
+  }, [onDirtyChange]);
 
-    return () => onDirtyChange?.(false);
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
   }, [isDirty, onDirtyChange]);
+
+  useEffect(() => () => onDirtyChangeRef.current?.(false), []);
 
   useEffect(
     () => () => {


### PR DESCRIPTION
## Summary
- show unsaved-change state in Place and Route editors
- add discard actions and beforeunload protection while drafts are dirty
- guard list/new-entry navigation from silently dropping edits
- archive the completed unsaved-changes plan

## Verification
- `just web-check`
- `cd web && npm run typecheck`
- Chrome DevTools smoke on `http://localhost:3401/dashboard/routes` verified `Unsaved changes`, `Discard changes`, and dirty `beforeunload` cancellation