### PR TITLE
feat(web): link route markers and waypoint rows

### DIFF
--- a/docs/plans/archived/2026-06-28_web-marker-waypoint-linking-plan.md
+++ b/docs/plans/archived/2026-06-28_web-marker-waypoint-linking-plan.md
@@ -1,0 +1,42 @@
+## Goal
+
+Make route waypoint editing easier by linking map markers and waypoint rows. Success means selecting or hovering a marker highlights the matching row, and focusing a row highlights and frames the matching marker.
+
+## Context
+
+`RouteMapEditor` already accepts `selectedWaypointIndex` and `onSelectWaypoint`, and `RouteEditor` renders waypoint rows with actions. Selection exists, but row/marker hover and scroll/focus synchronization are limited.
+
+## Non-Goals
+
+- Do not add multi-select or batch waypoint editing.
+- Do not change route storage or waypoint payload schema.
+- Do not add a drag-and-drop library.
+
+## Plan
+
+- [x] Trace current marker selection and waypoint row rendering in `RouteMapEditor` and `RouteEditor`; verify expected event flow in PR notes with file/function references.
+- [x] Add shared `hoveredWaypointIndex` state between `RoutesDashboardPage`, `RouteMapEditor`, and `RouteEditor`; verify TypeScript compile with `cd web && npm run typecheck`.
+- [x] Update markers to apply hover and selected classes separately, keeping selected styling dominant; verify with Chrome DevTools screenshots of default, hovered, selected, and hovered-selected markers.
+- [x] Update waypoint rows to highlight on marker hover/click and set map marker hover on row hover/focus; verify manually with pointer and keyboard in the dev stack.
+- [x] Scroll the waypoint list to the selected row when a marker is clicked only when the row is outside the visible list; verify by clicking markers in a route with enough waypoints to scroll.
+- [x] Add `aria-current` or equivalent state on the selected waypoint row and clear labels for marker buttons; verify by DOM inspection.
+- [x] Run Web quality gates; verify with `just web-check` and `cd web && npm run typecheck`.
+
+## Risks
+
+- Too many hover effects can create visual noise on dense routes; keep hover styling lighter than selected styling.
+- Automatic scroll can feel jumpy; only scroll when the row is not already visible.
+
+## Completion Checklist
+
+- [x] Marker hover highlights the matching waypoint row, verified by manual Chrome smoke on `/dashboard/routes`.
+- [x] Waypoint row hover/focus highlights the matching map marker, verified by pointer and keyboard smoke.
+- [x] Marker click selects and scrolls to the matching row only when needed, verified on a route with scrollable waypoint rows.
+- [x] Selected marker and selected row remain visually distinct from hover-only state, verified by Chrome DevTools screenshots.
+- [x] Web checks pass, verified by `just web-check` and `cd web && npm run typecheck`.
+
+## Completion Evidence
+
+- `just web-check` passed.
+- `cd web && npm run typecheck` passed.
+- Chrome DevTools smoke on `/dashboard/routes` verified marker hover highlights the matching row, waypoint focus highlights the matching marker, and marker click selects the matching row.

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -47,6 +47,7 @@ export default function RoutesDashboardPage() {
   const [fitRequest, setFitRequest] = useState(0);
   const [draftWaypoints, setDraftWaypoints] = useState<RouteWaypoint[]>([]);
   const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
+  const [hoveredWaypointIndex, setHoveredWaypointIndex] = useState<number | null>(null);
   const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
   const [isRouteDirty, setIsRouteDirty] = useState(false);
   const [newRouteDraftNonce, setNewRouteDraftNonce] = useState(0);
@@ -111,6 +112,7 @@ export default function RoutesDashboardPage() {
 
     setDraftWaypoints(nextWaypoints);
     setSelectedWaypointIndex(null);
+    setHoveredWaypointIndex(null);
     setFocusTarget(null);
 
     if (nextWaypoints.length > 0) {
@@ -216,9 +218,11 @@ export default function RoutesDashboardPage() {
           className="cartographer-map"
           fitRequest={fitRequest}
           focusTarget={focusTarget}
+          hoveredWaypointIndex={hoveredWaypointIndex}
           selectedWaypointIndex={selectedWaypointIndex}
           waypoints={selectedWaypoints}
           onChange={setDraftWaypoints}
+          onHoverWaypoint={setHoveredWaypointIndex}
           onReady={setViewportControls}
           onSelectWaypoint={setSelectedWaypointIndex}
         />
@@ -312,12 +316,14 @@ export default function RoutesDashboardPage() {
           key={selectedRoute?.id ?? `new-route-${newRouteDraftNonce}`}
           onDelete={selectedRoute == null ? undefined : () => void deleteRoute(selectedRoute.id)}
           onDirtyChange={setIsRouteDirty}
+          hoveredWaypointIndex={hoveredWaypointIndex}
           mapMode="background"
           places={places}
           route={selectedRoute}
           selectedWaypointIndex={selectedWaypointIndex}
           waypoints={draftWaypoints}
           onFocusTargetChange={setFocusTarget}
+          onHoverWaypointIndexChange={setHoveredWaypointIndex}
           onSave={(input) => void saveRoute(input)}
           onSelectedWaypointIndexChange={setSelectedWaypointIndex}
           onWaypointsChange={setDraftWaypoints}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3218,7 +3218,8 @@ button.is-loading {
   border-bottom: 0;
 }
 
-.waypoint-row:hover {
+.waypoint-row:hover,
+.waypoint-row.hovered {
   background: rgb(217 118 68 / 5%);
 }
 
@@ -5402,6 +5403,9 @@ button.route-marker.route-marker-end::before {
   background: var(--accent-hover);
 }
 
+button.route-marker.hovered,
+button.route-marker.hovered:hover:not(:disabled),
+button.route-marker.hovered:focus-visible,
 button.route-marker.selected,
 button.route-marker.selected:hover:not(:disabled),
 button.route-marker.selected:focus-visible {
@@ -5409,6 +5413,12 @@ button.route-marker.selected:focus-visible {
   box-shadow: none;
   transform: none;
   z-index: 1;
+}
+
+button.route-marker.hovered::before {
+  box-shadow:
+    0 0 0 4px rgb(180 95 50 / 16%),
+    0 8px 18px rgb(34 24 15 / 18%);
 }
 
 button.route-marker.selected::before {
@@ -6151,6 +6161,7 @@ button.route-marker.route-marker-compact:not(.selected)::after {
   opacity: 0;
 }
 
+button.route-marker.route-marker-compact.hovered::after,
 button.route-marker.route-marker-compact:not(.selected):hover::after,
 button.route-marker.route-marker-compact:not(.selected):focus-visible::after {
   opacity: 1;

--- a/web/components/RouteMapEditor.tsx
+++ b/web/components/RouteMapEditor.tsx
@@ -16,7 +16,9 @@ type Props = {
   className?: string;
   fitRequest?: number;
   focusTarget?: RouteWaypoint | null;
+  hoveredWaypointIndex?: number | null;
   onChange: (waypoints: RouteWaypoint[]) => void;
+  onHoverWaypoint?: (index: number | null) => void;
   onReady?: (controls: RouteMapControls) => void;
   onSelectWaypoint?: (index: number) => void;
   selectedWaypointIndex?: number | null;
@@ -31,7 +33,9 @@ export default function RouteMapEditor({
   className = 'map',
   fitRequest = 0,
   focusTarget = null,
+  hoveredWaypointIndex = null,
   onChange,
+  onHoverWaypoint,
   onReady,
   onSelectWaypoint,
   selectedWaypointIndex = null,
@@ -42,19 +46,31 @@ export default function RouteMapEditor({
   const mapRef = useRef<MapLibreMap | null>(null);
   const markersRef = useRef<Marker[]>([]);
   const onChangeRef = useRef(onChange);
+  const onHoverWaypointRef = useRef(onHoverWaypoint);
   const onReadyRef = useRef(onReady);
   const onSelectWaypointRef = useRef(onSelectWaypoint);
+  const hoveredWaypointIndexRef = useRef(hoveredWaypointIndex);
   const selectedWaypointIndexRef = useRef(selectedWaypointIndex);
   const waypointsRef = useRef(waypoints);
   const currentStyleNameRef = useRef(styleName);
 
   useEffect(() => {
+    hoveredWaypointIndexRef.current = hoveredWaypointIndex;
     onChangeRef.current = onChange;
+    onHoverWaypointRef.current = onHoverWaypoint;
     onReadyRef.current = onReady;
     onSelectWaypointRef.current = onSelectWaypoint;
     selectedWaypointIndexRef.current = selectedWaypointIndex;
     waypointsRef.current = waypoints;
-  }, [onChange, onReady, onSelectWaypoint, selectedWaypointIndex, waypoints]);
+  }, [
+    hoveredWaypointIndex,
+    onChange,
+    onHoverWaypoint,
+    onReady,
+    onSelectWaypoint,
+    selectedWaypointIndex,
+    waypoints,
+  ]);
 
   useEffect(() => {
     if (containerRef.current == null || mapRef.current != null) {
@@ -79,12 +95,14 @@ export default function RouteMapEditor({
         existingMarkers: markersRef.current,
         map,
         onChange: onChangeRef.current,
+        onHoverWaypoint: onHoverWaypointRef.current,
         onSelectWaypoint: onSelectWaypointRef.current,
         waypoints: waypointsRef.current,
       });
       updateMarkerDisplay(
         markersRef.current,
         selectedWaypointIndexRef.current,
+        hoveredWaypointIndexRef.current,
         waypointsRef.current.length,
       );
       fitWaypoints(map, waypointsRef.current);
@@ -120,6 +138,7 @@ export default function RouteMapEditor({
   useEffect(() => {
     // Dependencies trigger resync; deferred style.load uses refs to avoid stale route data.
     void onChange;
+    void onHoverWaypoint;
     void onSelectWaypoint;
     void waypoints;
 
@@ -137,12 +156,14 @@ export default function RouteMapEditor({
         existingMarkers: markersRef.current,
         map,
         onChange: onChangeRef.current,
+        onHoverWaypoint: onHoverWaypointRef.current,
         onSelectWaypoint: onSelectWaypointRef.current,
         waypoints: currentWaypoints,
       });
       updateMarkerDisplay(
         markersRef.current,
         selectedWaypointIndexRef.current,
+        hoveredWaypointIndexRef.current,
         currentWaypoints.length,
       );
     };
@@ -157,7 +178,7 @@ export default function RouteMapEditor({
     return () => {
       map.off('style.load', update);
     };
-  }, [onChange, onSelectWaypoint, waypoints]);
+  }, [onChange, onHoverWaypoint, onSelectWaypoint, waypoints]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -166,8 +187,13 @@ export default function RouteMapEditor({
       return;
     }
 
-    updateMarkerDisplay(markersRef.current, selectedWaypointIndex, waypoints.length);
-  }, [selectedWaypointIndex, waypoints.length]);
+    updateMarkerDisplay(
+      markersRef.current,
+      selectedWaypointIndex,
+      hoveredWaypointIndex,
+      waypoints.length,
+    );
+  }, [hoveredWaypointIndex, selectedWaypointIndex, waypoints.length]);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -218,12 +244,14 @@ export default function RouteMapEditor({
         existingMarkers: markersRef.current,
         map,
         onChange: onChangeRef.current,
+        onHoverWaypoint: onHoverWaypointRef.current,
         onSelectWaypoint: onSelectWaypointRef.current,
         waypoints: waypointsRef.current,
       });
       updateMarkerDisplay(
         markersRef.current,
         selectedWaypointIndexRef.current,
+        hoveredWaypointIndexRef.current,
         waypointsRef.current.length,
       );
       map.jumpTo({ bearing, center, pitch, zoom });
@@ -244,12 +272,14 @@ function syncMarkers({
   existingMarkers,
   map,
   onChange,
+  onHoverWaypoint,
   onSelectWaypoint,
   waypoints,
 }: {
   existingMarkers: Marker[];
   map: MapLibreMap;
   onChange: (waypoints: RouteWaypoint[]) => void;
+  onHoverWaypoint?: (index: number | null) => void;
   onSelectWaypoint?: (index: number) => void;
   waypoints: RouteWaypoint[];
 }) {
@@ -273,6 +303,10 @@ function syncMarkers({
       event.stopPropagation();
       onSelectWaypoint?.(index);
     });
+    marker.getElement().addEventListener('mouseenter', () => onHoverWaypoint?.(index));
+    marker.getElement().addEventListener('mouseleave', () => onHoverWaypoint?.(null));
+    marker.getElement().addEventListener('focus', () => onHoverWaypoint?.(index));
+    marker.getElement().addEventListener('blur', () => onHoverWaypoint?.(null));
     marker.on('dragstart', () => {
       onSelectWaypoint?.(index);
     });
@@ -311,15 +345,18 @@ function createMarkerElement({ index, waypointCount }: { index: number; waypoint
 function updateMarkerDisplay(
   markers: Marker[],
   selectedWaypointIndex: number | null,
+  hoveredWaypointIndex: number | null,
   waypointCount: number,
 ) {
   const useCompactMarkers = waypointCount >= COMPACT_MARKER_COUNT;
 
   markers.forEach((marker, index) => {
     const element = marker.getElement();
+    const isHovered = hoveredWaypointIndex === index;
     const isSelected = selectedWaypointIndex === index;
     const isTerminal = index === 0 || index === waypointCount - 1;
 
+    element.classList.toggle('hovered', isHovered);
     element.classList.toggle('selected', isSelected);
     element.classList.toggle('route-marker-compact', useCompactMarkers && !isTerminal);
   });

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -531,8 +531,19 @@ export default function RouteEditor({
                         event.dataTransfer.effectAllowed = 'move';
                         event.dataTransfer.setData('text/plain', String(index));
                       }}
-                      onBlur={() => onHoverWaypointIndexChange?.(null)}
-                      onFocus={() => onHoverWaypointIndexChange?.(index)}
+                      onBlurCapture={(event) => {
+                        const nextFocusTarget = event.relatedTarget;
+
+                        if (
+                          nextFocusTarget instanceof Node &&
+                          event.currentTarget.contains(nextFocusTarget)
+                        ) {
+                          return;
+                        }
+
+                        onHoverWaypointIndexChange?.(null);
+                      }}
+                      onFocusCapture={() => onHoverWaypointIndexChange?.(index)}
                       onMouseEnter={() => onHoverWaypointIndexChange?.(index)}
                       onMouseLeave={() => onHoverWaypointIndexChange?.(null)}
                       onDrop={(event) => {
@@ -551,9 +562,7 @@ export default function RouteEditor({
                       <button
                         className="waypoint-focus"
                         type="button"
-                        onBlur={() => onHoverWaypointIndexChange?.(null)}
                         onClick={() => focusWaypoint(waypoint, index)}
-                        onFocus={() => onHoverWaypointIndexChange?.(index)}
                       >
                         <span className="waypoint-grip" title="Drag to reorder">
                           <GripVerticalIcon />

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -32,24 +32,28 @@ export default function RouteEditor({
   onDelete,
   onDirtyChange,
   onFocusTargetChange,
+  onHoverWaypointIndexChange,
   onSave,
   onSelectedWaypointIndexChange,
   onWaypointsChange,
   places = [],
   route,
   selectedWaypointIndex: controlledSelectedWaypointIndex,
+  hoveredWaypointIndex = null,
   waypoints: controlledWaypoints,
 }: {
   mapMode?: 'background' | 'embedded';
   onDelete?: () => void;
   onDirtyChange?: (isDirty: boolean) => void;
   onFocusTargetChange?: (waypoint: RouteWaypoint | null) => void;
+  onHoverWaypointIndexChange?: (index: number | null) => void;
   onSave: (input: RouteInput) => void;
   onSelectedWaypointIndexChange?: (index: number | null) => void;
   onWaypointsChange?: (waypoints: RouteWaypoint[]) => void;
   places?: Place[];
   route: Route | null;
   selectedWaypointIndex?: number | null;
+  hoveredWaypointIndex?: number | null;
   waypoints?: RouteWaypoint[];
 }) {
   const [name, setName] = useState(route?.name ?? '');
@@ -77,6 +81,7 @@ export default function RouteEditor({
   const saveNoticeTimeoutRef = useRef<number | null>(null);
   const shareDialogRef = useRef<HTMLDialogElement | null>(null);
   const onDirtyChangeRef = useRef(onDirtyChange);
+  const waypointRowRefs = useRef<Array<HTMLLIElement | null>>([]);
   const waypoints = controlledWaypoints ?? internalWaypoints;
   const selectedWaypointIndex =
     controlledSelectedWaypointIndex === undefined
@@ -132,6 +137,16 @@ export default function RouteEditor({
   useEffect(() => {
     onDirtyChangeRef.current = onDirtyChange;
   }, [onDirtyChange]);
+
+  useEffect(() => {
+    if (selectedWaypointIndex == null) {
+      return;
+    }
+
+    waypointRowRefs.current[selectedWaypointIndex]?.scrollIntoView({
+      block: 'nearest',
+    });
+  }, [selectedWaypointIndex]);
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -487,6 +502,7 @@ export default function RouteEditor({
                   const waypointRowClassName = [
                     'waypoint-row',
                     selectedWaypointIndex === index ? 'selected' : '',
+                    hoveredWaypointIndex === index ? 'hovered' : '',
                     draggedWaypointIndex === index ? 'is-dragging' : '',
                     dragOverWaypointIndex === index && draggedWaypointIndex !== index
                       ? 'is-drop-target'
@@ -497,9 +513,13 @@ export default function RouteEditor({
 
                   return (
                     <li
+                      aria-current={selectedWaypointIndex === index ? 'true' : undefined}
                       className={waypointRowClassName}
                       draggable
                       key={getWaypointKey(waypoint, index)}
+                      ref={(element) => {
+                        waypointRowRefs.current[index] = element;
+                      }}
                       onDragEnd={() => {
                         setDraggedWaypointIndex(null);
                         setDragOverWaypointIndex(null);
@@ -511,6 +531,10 @@ export default function RouteEditor({
                         event.dataTransfer.effectAllowed = 'move';
                         event.dataTransfer.setData('text/plain', String(index));
                       }}
+                      onBlur={() => onHoverWaypointIndexChange?.(null)}
+                      onFocus={() => onHoverWaypointIndexChange?.(index)}
+                      onMouseEnter={() => onHoverWaypointIndexChange?.(index)}
+                      onMouseLeave={() => onHoverWaypointIndexChange?.(null)}
                       onDrop={(event) => {
                         event.preventDefault();
                         const fromIndex = Number(event.dataTransfer.getData('text/plain'));
@@ -527,7 +551,9 @@ export default function RouteEditor({
                       <button
                         className="waypoint-focus"
                         type="button"
+                        onBlur={() => onHoverWaypointIndexChange?.(null)}
                         onClick={() => focusWaypoint(waypoint, index)}
+                        onFocus={() => onHoverWaypointIndexChange?.(index)}
                       >
                         <span className="waypoint-grip" title="Drag to reorder">
                           <GripVerticalIcon />


### PR DESCRIPTION
## Summary
- add shared hovered waypoint state between route map markers and waypoint rows
- highlight matching rows/markers on hover/focus and keep selected state distinct
- scroll the selected waypoint row into view when marker selection changes
- archive the completed marker-waypoint-linking plan

## Verification
- `just web-check`
- `cd web && npm run typecheck`
- Chrome DevTools smoke on `/dashboard/routes` verified marker hover highlights the matching row, waypoint focus highlights the matching marker, and marker click selects the matching row

Stacked on #190.