### PR TITLE
feat(web): split map and library navigation

### DIFF
--- a/docs/plans/archived/2026-06-28_web-map-library-navigation-plan.md
+++ b/docs/plans/archived/2026-06-28_web-map-library-navigation-plan.md
@@ -1,0 +1,63 @@
+## Goal
+
+Split the Web UI into clearer top-level work modes: `Map` for spatial preview/control and `Library` for managing Places and Routes. Success means users can understand where to browse/edit saved items versus where to inspect them on the map, while existing `/dashboard/places` and `/dashboard/routes` links keep working.
+
+## Context
+
+The current dashboard has top tabs for Places and Routes, and each page combines map, notebook, editor, sharing, and remote-control actions. The next IA should avoid adding many speculative tabs; start with the smallest useful split: `Map` and `Library`.
+
+## Architecture
+
+- Add top-level routes under the existing authenticated dashboard shell, likely:
+  - `/dashboard/map`
+  - `/dashboard/library`
+- Keep redirects or compatibility routes from existing `/dashboard/places` and `/dashboard/routes` until bookmarks and docs are updated.
+- Prefer extracting shared library data loading/hooks instead of duplicating Places/Routes fetch logic across Map and Library pages.
+
+## Non-Goals
+
+- Do not add Devices, Shares, Activity, or Settings top-level tabs in this phase.
+- Do not redesign backend APIs.
+- Do not remove existing Places/Routes functionality until replacement flows are verified.
+
+## Plan
+
+- [x] Define the `Map` and `Library` information architecture in a short design note inside this plan or the implementation PR: what each tab owns, what stays shared, and which old URLs redirect; verify with explicit user acceptance before large code movement.
+- [x] Extract shared dashboard data loading for places/routes into a small hook or helper that returns items, selected IDs, loading/error state, and refresh; verify with `cd web && npm run typecheck` and unchanged API calls in browser network logs.
+- [x] Add a `Map` tab that focuses on the map, selected item preview, and quick actions like send-to-device/share/open-in-library; verify by selecting an existing place and route and seeing the map frame the item.
+- [x] Add a `Library` tab with internal Places/Routes switching, search, create/edit/delete, and existing editor flows; verify all current Place and Route CRUD actions still work in `just webtest-up`.
+- [x] Update dashboard navigation copy/icons so top-level tabs are `Map` and `Library`, not separate Places and Routes; verify `just --list` is unaffected and Chrome screenshots show the new navigation.
+- [x] Preserve or redirect `/dashboard`, `/dashboard/places`, and `/dashboard/routes` to the new IA; verify with direct URL navigation in Chrome and expected final paths.
+- [x] Update keyboard shortcuts so existing Places/Routes shortcuts still work inside Library, and add a shortcut for Map if useful; verify with manual keyboard smoke and the cheatsheet copy.
+- [x] Run Web quality gates and visual smoke; verify with `just web-check`, `cd web && npm run typecheck`, and Chrome screenshots for Map and Library at desktop and phone widths.
+
+## Design Note
+
+- `Map` owns spatial preview: browse saved Places/Routes, frame them on MapLibre, and jump to Library for editing.
+- `Library` owns management: Places/Routes search, create, edit, delete, share, and remote-control actions.
+- Shared loading for the Map view lives in `useDashboardLibraryData`; existing Library CRUD pages keep their current focused loaders.
+- `/dashboard` redirects to `/dashboard/map`; `/dashboard/library` redirects to `/dashboard/library/routes`; old `/dashboard/places` and `/dashboard/routes` remain compatibility routes that render the Library experience.
+
+## Risks
+
+- Moving too much UI at once can create regressions in CRUD and route editing; keep old pages or redirects until Map and Library smoke tests pass.
+- A Map tab without enough actions can feel like a read-only duplicate; include only quick actions that reuse existing components.
+
+## Completion Checklist
+
+- [x] The top-level dashboard navigation shows `Map` and `Library`, verified by Chrome screenshot and route paths.
+- [x] Existing `/dashboard/places` and `/dashboard/routes` URLs do not 404 and land on the intended new experience, verified by direct URL navigation.
+- [x] Library supports existing Place and Route CRUD flows, verified by manual browser smoke against the dev seed account.
+- [x] Map can display and frame selected Places and Routes and expose at least one useful quick action, verified by manual browser smoke.
+- [x] Keyboard shortcuts and cheatsheet copy match the new IA, verified by keyboard smoke.
+- [x] Web checks pass, verified by `just web-check` and `cd web && npm run typecheck`.
+
+## Completion Evidence
+
+- `just web-check` passed.
+- `cd web && npm run typecheck` passed.
+- `just --list` completed; recipe list remains available.
+- Chrome DevTools smoke verified `/dashboard/map`, `/dashboard/library/routes`, `/dashboard/places`, and `/dashboard/routes`; screenshots saved to `/tmp/kestrel-map-library-map-desktop.png`, `/tmp/kestrel-map-library-library-desktop.png`, `/tmp/kestrel-map-library-map-phone.png`, and `/tmp/kestrel-map-library-library-phone.png`.
+- Chrome DevTools keyboard smoke verified `g l` navigates Map → Library and `g m` navigates Library → Map.
+- Chrome DevTools Map smoke verified selected route and selected place previews render with map markers.
+- Chrome DevTools Library CRUD smoke created and deleted one Place and one Route through the UI against the dev seed account.

--- a/web/app/dashboard/library/page.tsx
+++ b/web/app/dashboard/library/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LibraryPage() {
+  redirect('/dashboard/library/routes');
+}

--- a/web/app/dashboard/library/places/page.tsx
+++ b/web/app/dashboard/library/places/page.tsx
@@ -1,1 +1,3 @@
+'use client';
+
 export { default } from '../../places/page';

--- a/web/app/dashboard/library/places/page.tsx
+++ b/web/app/dashboard/library/places/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../places/page';

--- a/web/app/dashboard/library/routes/page.tsx
+++ b/web/app/dashboard/library/routes/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../routes/page';

--- a/web/app/dashboard/library/routes/page.tsx
+++ b/web/app/dashboard/library/routes/page.tsx
@@ -1,1 +1,3 @@
+'use client';
+
 export { default } from '../../routes/page';

--- a/web/app/dashboard/map/page.tsx
+++ b/web/app/dashboard/map/page.tsx
@@ -16,7 +16,6 @@ import {
   formatMode,
   formatRouteDistanceFromWaypoints,
 } from '@/components/dashboard/utils';
-import { DEFAULT_MAP_CENTER } from '@/components/mapStyle';
 import type { Place, Route } from '@/lib/api';
 
 const CartographerPlaceMap = dynamic(
@@ -123,17 +122,12 @@ export default function DashboardMapPage() {
       latitude: waypoint.latitude,
       longitude: waypoint.longitude,
     })) ?? [];
-  const placeDraftCoords =
-    selectedPlace == null
-      ? DEFAULT_MAP_CENTER
-      : { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude };
   const map =
     activeKind === 'places' ? (
       <CartographerPlaceMap
-        draftCoords={placeDraftCoords}
+        draftCoords={null}
         places={places}
         selectedPlaceId={selectedPlaceId}
-        onChangeDraftCoords={() => undefined}
         onReady={setViewportControls}
         onSelectPlace={(placeId) => {
           setActiveKind('places');
@@ -219,14 +213,19 @@ export default function DashboardMapPage() {
             <p>{subtitle}</p>
           </div>
           <div className="index-card-actions">
-            <Link
+            <button
               className="secondary"
-              href={
-                activeKind === 'places' ? '/dashboard/library/places' : '/dashboard/library/routes'
+              type="button"
+              onClick={() =>
+                router.push(
+                  activeKind === 'places'
+                    ? '/dashboard/library/places'
+                    : '/dashboard/library/routes',
+                )
               }
             >
               Open in Library
-            </Link>
+            </button>
           </div>
         </header>
         <div className="index-card-body stack">

--- a/web/app/dashboard/map/page.tsx
+++ b/web/app/dashboard/map/page.tsx
@@ -1,0 +1,404 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { KeyboardCheatsheet } from '@/components/cartographer/KeyboardCheatsheet';
+import { ScaleBar } from '@/components/cartographer/ScaleBar';
+import { Stage } from '@/components/cartographer/Stage';
+import { StatusStrip } from '@/components/cartographer/StatusStrip';
+import { UserMark } from '@/components/cartographer/UserMark';
+import { useKeyboardShortcuts } from '@/components/cartographer/useKeyboardShortcuts';
+import { useDashboardLibraryData } from '@/components/dashboard/useDashboardLibraryData';
+import {
+  formatCoord,
+  formatMode,
+  formatRouteDistanceFromWaypoints,
+} from '@/components/dashboard/utils';
+import { DEFAULT_MAP_CENTER } from '@/components/mapStyle';
+import type { Place, Route } from '@/lib/api';
+
+const CartographerPlaceMap = dynamic(
+  () => import('@/components/cartographer/CartographerPlaceMap'),
+  { ssr: false },
+);
+const RouteMapPreview = dynamic(() => import('@/components/RouteMapPreview'), { ssr: false });
+const ZoomStack = dynamic(
+  () => import('@/components/cartographer/ZoomStack').then((module) => module.ZoomStack),
+  { ssr: false },
+);
+
+type MapKind = 'places' | 'routes';
+type ViewportControls = {
+  fit: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};
+
+export default function DashboardMapPage() {
+  const {
+    auth,
+    error,
+    isLoading,
+    lastLoadedAt,
+    places,
+    refresh,
+    routes,
+    selectedPlaceId,
+    selectedRouteId,
+    setSelectedPlaceId,
+    setSelectedRouteId,
+  } = useDashboardLibraryData();
+  const router = useRouter();
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const [activeKind, setActiveKind] = useState<MapKind>('routes');
+  const [query, setQuery] = useState('');
+  const [viewportControls, setViewportControls] = useState<ViewportControls | null>(null);
+  const [isLibraryCollapsed, setIsLibraryCollapsed] = useState(false);
+  const [isPreviewCollapsed, setIsPreviewCollapsed] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+
+  const selectedPlace = useMemo(
+    () => places.find((place) => place.id === selectedPlaceId) ?? null,
+    [places, selectedPlaceId],
+  );
+  const selectedRoute = useMemo(
+    () => routes.find((route) => route.id === selectedRouteId) ?? null,
+    [routes, selectedRouteId],
+  );
+  const filteredPlaces = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return normalizedQuery.length === 0
+      ? places
+      : places.filter((place) =>
+          [place.name, place.description ?? '', ...place.tags]
+            .join(' ')
+            .toLowerCase()
+            .includes(normalizedQuery),
+        );
+  }, [places, query]);
+  const filteredRoutes = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+
+    return normalizedQuery.length === 0
+      ? routes
+      : routes.filter((route) =>
+          [route.name, route.description ?? '', formatMode(route.mode)]
+            .join(' ')
+            .toLowerCase()
+            .includes(normalizedQuery),
+        );
+  }, [query, routes]);
+  const lastUpdatedLabel = useRelativeUpdatedLabel(lastLoadedAt);
+
+  useKeyboardShortcuts({
+    onClose: () => setIsHelpOpen(false),
+    onFocusSearch: () => searchRef.current?.focus(),
+    onGoLibrary: () => router.push('/dashboard/library'),
+    onGoMap: () => router.push('/dashboard/map'),
+    onGoPlaces: () => router.push('/dashboard/library/places'),
+    onGoRoutes: () => router.push('/dashboard/library/routes'),
+    onToggleHelp: () => setIsHelpOpen((current) => !current),
+  });
+
+  if (!auth.isHydrated || !auth.isAuthenticated || auth.session == null) {
+    return (
+      <main className="shell">
+        <p className="muted">Loading session…</p>
+      </main>
+    );
+  }
+
+  async function changePassword(input: { currentPassword: string; newPassword: string }) {
+    await auth.apiRequest('/auth/password/change', {
+      body: JSON.stringify(input),
+      method: 'POST',
+    });
+  }
+
+  const routeWaypoints =
+    selectedRoute?.currentRevision?.waypoints.map((waypoint) => ({
+      latitude: waypoint.latitude,
+      longitude: waypoint.longitude,
+    })) ?? [];
+  const placeDraftCoords =
+    selectedPlace == null
+      ? DEFAULT_MAP_CENTER
+      : { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude };
+  const map =
+    activeKind === 'places' ? (
+      <CartographerPlaceMap
+        draftCoords={placeDraftCoords}
+        places={places}
+        selectedPlaceId={selectedPlaceId}
+        onChangeDraftCoords={() => undefined}
+        onReady={setViewportControls}
+        onSelectPlace={(placeId) => {
+          setActiveKind('places');
+          setSelectedPlaceId(placeId);
+        }}
+      />
+    ) : (
+      <RouteMapPreview
+        className="cartographer-map"
+        interactive
+        waypoints={routeWaypoints}
+        onReady={setViewportControls}
+      />
+    );
+  const title =
+    activeKind === 'places'
+      ? (selectedPlace?.name ?? 'Places map')
+      : (selectedRoute?.name ?? 'Routes map');
+  const subtitle =
+    activeKind === 'places'
+      ? selectedPlace == null
+        ? 'Pick a place to frame it on the map.'
+        : `${formatCoord(selectedPlace.latitude)}, ${formatCoord(selectedPlace.longitude)}`
+      : selectedRoute == null
+        ? 'Pick a route to frame its latest revision.'
+        : `${formatRouteDistanceFromWaypoints(routeWaypoints)} · ${selectedRoute.defaultSpeedKmh} km/h · ${formatMode(selectedRoute.mode)}`;
+
+  return (
+    <Stage
+      isLeftPanelCollapsed={isLibraryCollapsed}
+      isRightPanelCollapsed={isPreviewCollapsed}
+      map={map}
+      mode={activeKind}
+      onToggleLeftPanel={() => setIsLibraryCollapsed((current) => !current)}
+      onToggleMapFocus={() => {
+        const shouldRestorePanels = isLibraryCollapsed && isPreviewCollapsed;
+        setIsLibraryCollapsed(!shouldRestorePanels);
+        setIsPreviewCollapsed(!shouldRestorePanels);
+      }}
+      onToggleRightPanel={() => setIsPreviewCollapsed((current) => !current)}
+      workspace="map"
+    >
+      <StatusStrip
+        error={error}
+        isRefreshing={isLoading}
+        lastUpdatedLabel={lastUpdatedLabel}
+        onRefresh={() => void refresh()}
+      />
+      <UserMark
+        username={auth.session.user.username}
+        onChangePassword={changePassword}
+        onLogout={auth.logout}
+      />
+      <MapLibraryPanel
+        activeKind={activeKind}
+        filteredPlaces={filteredPlaces}
+        filteredRoutes={filteredRoutes}
+        isLoading={isLoading}
+        query={query}
+        searchRef={searchRef}
+        selectedPlaceId={selectedPlaceId}
+        selectedRouteId={selectedRouteId}
+        onQueryChange={setQuery}
+        onSelectKind={setActiveKind}
+        onSelectPlace={(placeId) => {
+          setActiveKind('places');
+          setSelectedPlaceId(placeId);
+        }}
+        onSelectRoute={(routeId) => {
+          setActiveKind('routes');
+          setSelectedRouteId(routeId);
+        }}
+      />
+      <section className="index-card" aria-label="Map selection preview">
+        <span aria-hidden className="index-card-pin" />
+        <div className="index-card-breadcrumb breadcrumb">
+          Map / <span>{activeKind === 'places' ? 'Places' : 'Routes'}</span>
+        </div>
+        <header className="index-card-header">
+          <div>
+            <p className="index-card-stamp font-mono">Map view</p>
+            <h2 className="font-serif">{title}</h2>
+            <p>{subtitle}</p>
+          </div>
+          <div className="index-card-actions">
+            <Link
+              className="secondary"
+              href={
+                activeKind === 'places' ? '/dashboard/library/places' : '/dashboard/library/routes'
+              }
+            >
+              Open in Library
+            </Link>
+          </div>
+        </header>
+        <div className="index-card-body stack">
+          <p className="muted no-margin">
+            Use Map for spatial review and quick device-ready context. Use Library for editing,
+            sharing, and cleanup.
+          </p>
+        </div>
+      </section>
+      <ZoomStack
+        onFit={() => viewportControls?.fit()}
+        onZoomIn={() => viewportControls?.zoomIn()}
+        onZoomOut={() => viewportControls?.zoomOut()}
+      />
+      <ScaleBar />
+      <KeyboardCheatsheet isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+    </Stage>
+  );
+}
+
+function MapLibraryPanel({
+  activeKind,
+  filteredPlaces,
+  filteredRoutes,
+  isLoading,
+  onQueryChange,
+  onSelectKind,
+  onSelectPlace,
+  onSelectRoute,
+  query,
+  searchRef,
+  selectedPlaceId,
+  selectedRouteId,
+}: {
+  activeKind: MapKind;
+  filteredPlaces: Place[];
+  filteredRoutes: Route[];
+  isLoading: boolean;
+  onQueryChange: (query: string) => void;
+  onSelectKind: (kind: MapKind) => void;
+  onSelectPlace: (placeId: string) => void;
+  onSelectRoute: (routeId: string) => void;
+  query: string;
+  searchRef: RefObject<HTMLInputElement | null>;
+  selectedPlaceId: string | null;
+  selectedRouteId: string | null;
+}) {
+  const activeItems = activeKind === 'places' ? filteredPlaces : filteredRoutes;
+
+  return (
+    <aside className="field-notebook" aria-label="Map library">
+      <div aria-hidden className="field-notebook-spine" />
+      <nav aria-label="Map item type" className="sidebar-tabs">
+        <button
+          className={activeKind === 'places' ? 'active' : ''}
+          type="button"
+          onClick={() => onSelectKind('places')}
+        >
+          <span>Places</span>
+        </button>
+        <button
+          className={activeKind === 'routes' ? 'active' : ''}
+          type="button"
+          onClick={() => onSelectKind('routes')}
+        >
+          <span>Routes</span>
+        </button>
+      </nav>
+      <label className="sidebar-search font-mono">
+        <span className="sr-only">Search map items</span>
+        <input
+          ref={searchRef}
+          placeholder={`Search ${activeKind}...`}
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+        />
+      </label>
+      <Link
+        className="notebook-new-entry"
+        href={activeKind === 'places' ? '/dashboard/library/places' : '/dashboard/library/routes'}
+      >
+        <span aria-hidden className="notebook-new-entry-icon">
+          ↗
+        </span>
+        <span>
+          <strong>Open Library</strong>
+          <small>Edit, share, and organize {activeKind}</small>
+        </span>
+      </Link>
+      <div className="notebook-list">
+        {isLoading ? <NotebookSkeleton /> : null}
+        {activeKind === 'places'
+          ? filteredPlaces.map((place) => (
+              <button
+                className={`notebook-entry${selectedPlaceId === place.id ? ' active' : ''}`}
+                key={place.id}
+                type="button"
+                onClick={() => onSelectPlace(place.id)}
+              >
+                <strong>{place.name}</strong>
+                <span className="font-mono">
+                  {formatCoord(place.latitude)}, {formatCoord(place.longitude)}
+                </span>
+              </button>
+            ))
+          : filteredRoutes.map((route) => (
+              <button
+                className={`notebook-entry route-notebook-entry${selectedRouteId === route.id ? ' active' : ''}`}
+                key={route.id}
+                type="button"
+                onClick={() => onSelectRoute(route.id)}
+              >
+                <strong className="route-card-title">{route.name}</strong>
+                <span className="route-card-meta-line">
+                  {formatRouteDistanceFromWaypoints(route.currentRevision?.waypoints ?? [])} ·{' '}
+                  {formatMode(route.mode)}
+                </span>
+              </button>
+            ))}
+        {activeItems.length === 0 && !isLoading ? (
+          <div className="notebook-empty">
+            <p className="muted no-margin">No {activeKind} match this search.</p>
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  );
+}
+
+function NotebookSkeleton() {
+  return (
+    <div aria-label="Loading map items" className="skeleton-list" role="status">
+      <span className="skeleton-line wide" />
+      <span className="skeleton-line" />
+      <span className="skeleton-line short" />
+    </div>
+  );
+}
+
+function useRelativeUpdatedLabel(lastUpdatedAt: Date | null): string | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (lastUpdatedAt == null) {
+      return;
+    }
+
+    setNow(Date.now());
+    const intervalId = window.setInterval(() => setNow(Date.now()), 30_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [lastUpdatedAt]);
+
+  if (lastUpdatedAt == null) {
+    return null;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((now - lastUpdatedAt.getTime()) / 1000));
+
+  if (elapsedSeconds < 10) {
+    return 'just now';
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s ago`;
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+
+  if (elapsedMinutes < 60) {
+    return `${elapsedMinutes}m ago`;
+  }
+
+  return lastUpdatedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function DashboardPage() {
-  redirect('/dashboard/routes');
+  redirect('/dashboard/map');
 }

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -159,8 +159,10 @@ export default function PlacesDashboardPage() {
   useKeyboardShortcuts({
     onClose: () => setIsHelpOpen(false),
     onFocusSearch: () => searchRef.current?.focus(),
-    onGoPlaces: () => router.push('/dashboard/places'),
-    onGoRoutes: () => router.push('/dashboard/routes'),
+    onGoLibrary: () => router.push('/dashboard/library'),
+    onGoMap: () => router.push('/dashboard/map'),
+    onGoPlaces: () => router.push('/dashboard/library/places'),
+    onGoRoutes: () => router.push('/dashboard/library/routes'),
     onNew: createNewPlace,
     onToggleHelp: () => setIsHelpOpen((current) => !current),
   });
@@ -227,6 +229,7 @@ export default function PlacesDashboardPage() {
         setIsEditorCollapsed(!shouldRestorePanels);
       }}
       onToggleRightPanel={() => setIsEditorCollapsed((current) => !current)}
+      workspace="library"
     >
       <StatusStrip
         error={error}

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -167,8 +167,10 @@ export default function RoutesDashboardPage() {
   useKeyboardShortcuts({
     onClose: () => setIsHelpOpen(false),
     onFocusSearch: () => searchRef.current?.focus(),
-    onGoPlaces: () => router.push('/dashboard/places'),
-    onGoRoutes: () => router.push('/dashboard/routes'),
+    onGoLibrary: () => router.push('/dashboard/library'),
+    onGoMap: () => router.push('/dashboard/map'),
+    onGoPlaces: () => router.push('/dashboard/library/places'),
+    onGoRoutes: () => router.push('/dashboard/library/routes'),
     onNew: createNewRoute,
     onToggleHelp: () => setIsHelpOpen((current) => !current),
   });
@@ -237,6 +239,7 @@ export default function RoutesDashboardPage() {
         setIsEditorCollapsed(!shouldRestorePanels);
       }}
       onToggleRightPanel={() => setIsEditorCollapsed((current) => !current)}
+      workspace="library"
     >
       <StatusStrip
         error={error}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3523,6 +3523,35 @@ button.is-loading {
   width: 100%;
 }
 
+.workspace-tabs {
+  align-items: center;
+  background: var(--overlay-surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: var(--shadow-xs);
+  display: flex;
+  gap: 4px;
+  left: 24px;
+  padding: 4px;
+  position: absolute;
+  top: 16px;
+  z-index: 16;
+}
+
+.workspace-tabs a {
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 800;
+  padding: 7px 12px;
+  text-decoration: none;
+}
+
+.workspace-tabs a.active {
+  background: var(--accent);
+  color: #ffffff;
+}
+
 .cartographer-paper-vignette {
   background:
     linear-gradient(
@@ -5866,8 +5895,11 @@ button.route-marker.selected::after {
   padding: 3px;
 }
 
-.sidebar-tabs a {
+.sidebar-tabs a,
+.sidebar-tabs button {
   align-items: center;
+  background: transparent;
+  border: 0;
   border-radius: 9px;
   color: var(--text-secondary);
   display: inline-flex;
@@ -5879,7 +5911,9 @@ button.route-marker.selected::after {
 }
 
 .sidebar-tabs a.active,
-.sidebar-tabs a:hover {
+.sidebar-tabs a:hover,
+.sidebar-tabs button.active,
+.sidebar-tabs button:hover:not(:disabled) {
   background: var(--bg-surface);
   box-shadow: 0 1px 2px rgb(34 24 15 / 6%);
   color: var(--accent-hover);

--- a/web/components/cartographer/CartographerPlaceMap.tsx
+++ b/web/components/cartographer/CartographerPlaceMap.tsx
@@ -15,7 +15,7 @@ export type PlaceViewportControls = {
 type Props = {
   className?: string;
   draftCoords: { latitude: number; longitude: number } | null;
-  onChangeDraftCoords: (coords: { latitude: number; longitude: number }) => void;
+  onChangeDraftCoords?: (coords: { latitude: number; longitude: number }) => void;
   onReady?: (controls: PlaceViewportControls) => void;
   onSelectPlace: (placeId: string) => void;
   places: Place[];
@@ -87,11 +87,14 @@ export default function CartographerPlaceMap({
     });
 
     map.on('click', (event) => {
-      const nextCoords = {
+      if (callbacksRef.current.onChangeDraftCoords == null) {
+        return;
+      }
+
+      callbacksRef.current.onChangeDraftCoords({
         latitude: roundCoord(event.lngLat.lat),
         longitude: roundCoord(event.lngLat.lng),
-      };
-      callbacksRef.current.onChangeDraftCoords(nextCoords);
+      });
     });
 
     mapRef.current = map;
@@ -183,7 +186,7 @@ function syncPlaceMarkers({
   draftMarkerRef: MutableRefObject<Marker | null>;
   markersRef: Marker[];
   map: MapLibreMap;
-  onChangeDraftCoords: (coords: { latitude: number; longitude: number }) => void;
+  onChangeDraftCoords?: (coords: { latitude: number; longitude: number }) => void;
   onSelectPlace: (placeId: string) => void;
   places: Place[];
   selectedPlaceId: string | null;
@@ -228,7 +231,7 @@ function syncPlaceMarkers({
         return;
       }
 
-      onChangeDraftCoords({
+      onChangeDraftCoords?.({
         latitude: roundCoord(lngLat.lat),
         longitude: roundCoord(lngLat.lng),
       });

--- a/web/components/cartographer/FieldNotebook.tsx
+++ b/web/components/cartographer/FieldNotebook.tsx
@@ -56,14 +56,14 @@ function SidebarTabs({ activeSection }: { activeSection: 'places' | 'routes' }) 
       <Link
         aria-current={activeSection === 'places' ? 'page' : undefined}
         className={activeSection === 'places' ? 'active' : ''}
-        href="/dashboard/places"
+        href="/dashboard/library/places"
       >
         <span>Places</span>
       </Link>
       <Link
         aria-current={activeSection === 'routes' ? 'page' : undefined}
         className={activeSection === 'routes' ? 'active' : ''}
-        href="/dashboard/routes"
+        href="/dashboard/library/routes"
       >
         <span>Routes</span>
       </Link>

--- a/web/components/cartographer/KeyboardCheatsheet.tsx
+++ b/web/components/cartographer/KeyboardCheatsheet.tsx
@@ -4,8 +4,10 @@ type KeyboardCheatsheetProps = {
 };
 
 const shortcuts = [
-  ['g p', 'Go to Places'],
-  ['g r', 'Go to Routes'],
+  ['g m', 'Go to Map'],
+  ['g l', 'Go to Library'],
+  ['g p', 'Go to Library / Places'],
+  ['g r', 'Go to Library / Routes'],
   ['n', 'Create a new entry'],
   ['/', 'Focus notebook search'],
   ['?', 'Show or hide this sheet'],

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -35,6 +35,7 @@ export function Stage({
     .filter(Boolean)
     .join(' ');
   const isMapFocused = isLeftPanelCollapsed && isRightPanelCollapsed;
+  const libraryHref = `/dashboard/library/${mode}`;
 
   return (
     <main className={className}>
@@ -51,7 +52,7 @@ export function Stage({
         <Link
           aria-current={workspace === 'library' ? 'page' : undefined}
           className={workspace === 'library' ? 'active' : ''}
-          href="/dashboard/library"
+          href={libraryHref}
         >
           Library
         </Link>

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { ReactNode } from 'react';
 
 type StageProps = {
@@ -6,6 +7,7 @@ type StageProps = {
   isRightPanelCollapsed?: boolean;
   map: ReactNode;
   mode: 'places' | 'routes';
+  workspace?: 'library' | 'map';
   onToggleLeftPanel?: () => void;
   onToggleMapFocus?: () => void;
   onToggleRightPanel?: () => void;
@@ -20,6 +22,7 @@ export function Stage({
   onToggleLeftPanel,
   onToggleMapFocus,
   onToggleRightPanel,
+  workspace = 'library',
 }: StageProps) {
   const className = [
     'cartographer-stage',
@@ -35,6 +38,14 @@ export function Stage({
     <main className={className}>
       <div className="cartographer-map-layer">{map}</div>
       <div aria-hidden className="cartographer-paper-vignette" />
+      <nav className="workspace-tabs" aria-label="Workspace tabs">
+        <Link className={workspace === 'map' ? 'active' : ''} href="/dashboard/map">
+          Map
+        </Link>
+        <Link className={workspace === 'library' ? 'active' : ''} href="/dashboard/library">
+          Library
+        </Link>
+      </nav>
       {onToggleLeftPanel == null &&
       onToggleRightPanel == null &&
       onToggleMapFocus == null ? null : (

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 
@@ -39,10 +41,18 @@ export function Stage({
       <div className="cartographer-map-layer">{map}</div>
       <div aria-hidden className="cartographer-paper-vignette" />
       <nav className="workspace-tabs" aria-label="Workspace tabs">
-        <Link className={workspace === 'map' ? 'active' : ''} href="/dashboard/map">
+        <Link
+          aria-current={workspace === 'map' ? 'page' : undefined}
+          className={workspace === 'map' ? 'active' : ''}
+          href="/dashboard/map"
+        >
           Map
         </Link>
-        <Link className={workspace === 'library' ? 'active' : ''} href="/dashboard/library">
+        <Link
+          aria-current={workspace === 'library' ? 'page' : undefined}
+          className={workspace === 'library' ? 'active' : ''}
+          href="/dashboard/library"
+        >
           Library
         </Link>
       </nav>

--- a/web/components/cartographer/useKeyboardShortcuts.ts
+++ b/web/components/cartographer/useKeyboardShortcuts.ts
@@ -5,6 +5,8 @@ import { useEffect, useRef } from 'react';
 type ShortcutHandlers = {
   onClose?: () => void;
   onFocusSearch?: () => void;
+  onGoLibrary?: () => void;
+  onGoMap?: () => void;
   onGoPlaces?: () => void;
   onGoRoutes?: () => void;
   onNew?: () => void;
@@ -16,6 +18,8 @@ const SEQUENCE_TIMEOUT_MS = 900;
 export function useKeyboardShortcuts({
   onClose,
   onFocusSearch,
+  onGoLibrary,
+  onGoMap,
   onGoPlaces,
   onGoRoutes,
   onNew,
@@ -80,6 +84,20 @@ export function useKeyboardShortcuts({
       if (sequenceRef.current === 'g') {
         const key = event.key.toLowerCase();
 
+        if (key === 'l') {
+          event.preventDefault();
+          clearSequence();
+          onGoLibrary?.();
+          return;
+        }
+
+        if (key === 'm') {
+          event.preventDefault();
+          clearSequence();
+          onGoMap?.();
+          return;
+        }
+
         if (key === 'p') {
           event.preventDefault();
           clearSequence();
@@ -102,7 +120,7 @@ export function useKeyboardShortcuts({
       clearSequence();
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onClose, onFocusSearch, onGoPlaces, onGoRoutes, onNew, onToggleHelp]);
+  }, [onClose, onFocusSearch, onGoLibrary, onGoMap, onGoPlaces, onGoRoutes, onNew, onToggleHelp]);
 }
 
 function isEditableTarget(target: EventTarget | null): boolean {

--- a/web/components/dashboard/DashboardShell.tsx
+++ b/web/components/dashboard/DashboardShell.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/components/AuthProvider';
 import { formatError } from '@/components/dashboard/utils';
 import { useTheme } from '@/components/ThemeProvider';
 
-type DashboardSection = 'places' | 'routes';
+type DashboardSection = 'library' | 'map';
 
 type Props = {
   activeSection: DashboardSection;
@@ -19,8 +19,8 @@ type Props = {
 };
 
 const sections: Array<{ href: string; icon: ReactNode; key: DashboardSection; label: string }> = [
-  { href: '/dashboard/places', icon: <MapPinIcon />, key: 'places', label: 'Places' },
-  { href: '/dashboard/routes', icon: <RouteIcon />, key: 'routes', label: 'Routes' },
+  { href: '/dashboard/map', icon: <MapPinIcon />, key: 'map', label: 'Map' },
+  { href: '/dashboard/library', icon: <RouteIcon />, key: 'library', label: 'Library' },
 ];
 
 export default function DashboardShell({

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -807,7 +807,7 @@ function FavoriteWaypointPicker({
     return (
       <div className="favorite-picker empty-state">
         <p className="muted">No favorite places yet.</p>
-        <Link href="/dashboard/places">Create a favorite place first</Link>
+        <Link href="/dashboard/library/places">Create a favorite place first</Link>
       </div>
     );
   }

--- a/web/components/dashboard/useDashboardLibraryData.ts
+++ b/web/components/dashboard/useDashboardLibraryData.ts
@@ -26,8 +26,12 @@ export function useDashboardLibraryData() {
       ]);
       setPlaces(nextPlaces);
       setRoutes(nextRoutes);
-      setSelectedPlaceId((current) => current ?? nextPlaces[0]?.id ?? null);
-      setSelectedRouteId((current) => current ?? nextRoutes[0]?.id ?? null);
+      setSelectedPlaceId((current) =>
+        nextPlaces.some((place) => place.id === current) ? current : (nextPlaces[0]?.id ?? null),
+      );
+      setSelectedRouteId((current) =>
+        nextRoutes.some((route) => route.id === current) ? current : (nextRoutes[0]?.id ?? null),
+      );
       setLastLoadedAt(new Date());
     } catch (nextError) {
       setError(formatError(nextError));

--- a/web/components/dashboard/useDashboardLibraryData.ts
+++ b/web/components/dashboard/useDashboardLibraryData.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { Place, Route } from '@/lib/api';
+import { useDashboardAuth } from './useDashboardAuth';
+import { formatError } from './utils';
+
+export function useDashboardLibraryData() {
+  const auth = useDashboardAuth();
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [routes, setRoutes] = useState<Route[]>([]);
+  const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
+  const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [lastLoadedAt, setLastLoadedAt] = useState<Date | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const [nextPlaces, nextRoutes] = await Promise.all([
+        auth.apiRequest<Place[]>('/places'),
+        auth.apiRequest<Route[]>('/routes'),
+      ]);
+      setPlaces(nextPlaces);
+      setRoutes(nextRoutes);
+      setSelectedPlaceId((current) => current ?? nextPlaces[0]?.id ?? null);
+      setSelectedRouteId((current) => current ?? nextRoutes[0]?.id ?? null);
+      setLastLoadedAt(new Date());
+    } catch (nextError) {
+      setError(formatError(nextError));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [auth]);
+
+  useEffect(() => {
+    if (!auth.isHydrated || !auth.isAuthenticated) {
+      return;
+    }
+
+    void refresh();
+  }, [auth.isAuthenticated, auth.isHydrated, refresh]);
+
+  return {
+    auth,
+    error,
+    isLoading,
+    lastLoadedAt,
+    places,
+    refresh,
+    routes,
+    selectedPlaceId,
+    selectedRouteId,
+    setSelectedPlaceId,
+    setSelectedRouteId,
+  };
+}


### PR DESCRIPTION
## Summary
- add top-level Map and Library workspace navigation
- add `/dashboard/map` plus `/dashboard/library` compatibility routes for existing editors
- add shared Map data loading and update keyboard shortcuts/cheatsheet for the new IA
- archive the completed map-library-navigation plan

## Verification
- `just web-check`
- `cd web && npm run typecheck`
- `just --list`
- Chrome DevTools smoke verified `/dashboard/map`, `/dashboard/library/routes`, `/dashboard/places`, and `/dashboard/routes`
- Chrome DevTools screenshots: `/tmp/kestrel-map-library-map-desktop.png`, `/tmp/kestrel-map-library-library-desktop.png`, `/tmp/kestrel-map-library-map-phone.png`, `/tmp/kestrel-map-library-library-phone.png`
- Chrome DevTools keyboard smoke verified `g l` and `g m` navigation
- Chrome DevTools UI CRUD smoke created/deleted one Place and one Route against the dev seed account

Stacked on #191.