### PR TITLE
fix(web): prevent route toolbar overlap

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -5978,6 +5978,38 @@ button.route-marker.selected::after {
     right: calc(var(--cloud-editor-width, 440px) + 80px);
     top: calc(var(--cloud-topbar-height, 56px) + 16px);
   }
+
+  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls {
+    justify-content: center;
+    left: calc(var(--cloud-sidebar-width, 320px) + 32px);
+    right: calc(var(--cloud-editor-width, 440px) + 80px);
+    top: calc(var(--cloud-topbar-height, 56px) + 88px);
+    transform: none;
+  }
+}
+
+@media (min-width: 1536px) {
+  .cartographer-stage-library.cartographer-stage-routes .route-mode-bar {
+    right: calc(var(--cloud-editor-width, 440px) + 360px);
+  }
+
+  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls {
+    justify-content: flex-end;
+    left: auto;
+    max-width: 320px;
+    right: calc(var(--cloud-editor-width, 440px) + 32px);
+    top: calc(var(--cloud-topbar-height, 56px) + 16px);
+  }
+}
+
+@media (min-width: 1024px) and (max-width: 1279px) {
+  .route-mode-bar span:last-child {
+    display: none;
+  }
+
+  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls {
+    top: calc(var(--cloud-topbar-height, 56px) + 136px);
+  }
 }
 
 @media (max-width: 1023px) {

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -29,6 +29,7 @@ export function Stage({
   const className = [
     'cartographer-stage',
     `cartographer-stage-${mode}`,
+    `cartographer-stage-${workspace}`,
     isLeftPanelCollapsed ? 'cartographer-stage-left-collapsed' : '',
     isRightPanelCollapsed ? 'cartographer-stage-right-collapsed' : '',
   ]


### PR DESCRIPTION
## Summary
- add workspace-scoped Stage class for targeted map overlay styling
- move route panel controls away from the route status pill across desktop breakpoints
- shorten the route hint only on narrow desktop widths to avoid overlap

## Tests
- just web-check
- cd web && npm run typecheck