### PR TITLE
feat(web): add panel icon map controls

### DIFF
--- a/docs/plans/archived/2026-06-28_web-map-panel-icon-controls-plan.md
+++ b/docs/plans/archived/2026-06-28_web-map-panel-icon-controls-plan.md
@@ -1,0 +1,47 @@
+## Goal
+
+Replace the bulky route map panel toolbar with panel-edge mini controls that are compact, legible, and discoverable. Success means expanded Library/Editor panels have small `−` collapse controls attached to their panel chrome, collapsed panels restore through edge tabs labeled `L` / `E`, Focus map uses a standalone `F` map control, and all controls show their meaning on hover/focus without covering the route status pill.
+
+## Context
+
+The current `map-panel-controls` group avoids overlap but still reads as a heavy floating toolbar. The better UI should make panel controls feel physically attached to the panels, while keeping map focus as a separate map-level action.
+
+## Non-Goals
+
+- Do not change route editing behavior, waypoint state, saving, or MapLibre route interactions.
+- Do not add a tooltip dependency; use existing CSS plus `aria-label`/`data-label`/`title` as needed.
+- Do not redesign mobile navigation beyond keeping controls usable and non-overlapping.
+
+## Plan
+
+- [x] Update `web/components/cartographer/Stage.tsx` to split controls by role: Library collapse/restore, Editor collapse/restore, and Focus map; verified by DOM inspection that buttons have stable classes, `aria-label`, `title`, and correct `aria-expanded` on Library/Editor.
+- [x] Define explicit control behavior in `Stage`: expanded Library shows a `−` button that only collapses Library; collapsed Library shows an `L` edge tab that only restores Library; expanded Editor shows `−`; collapsed Editor shows `E`; `F` collapses both panels and, when both are collapsed, restores both; verified by browser clicks in Chrome.
+- [x] Replace the bulky toolbar CSS in `web/app/globals.css` with panel-edge positioning: Library `−` attaches to the left panel top-right, Editor `−` attaches to the right panel top-right, `L` sits on the left hidden-panel edge, `E` sits on the right hidden-panel edge, and `F` stays as a small map-level button near the top overlay area; verified with Chrome screenshots at `1024x900`, `1265x900`, `1440x900`, and `1600x900`.
+- [x] Style controls with a small visual footprint but a usable hit target (`36–40px` minimum): circular or pill buttons, visible focus ring, no text overflow, and no overlap with route status; verified with DOM bounding boxes and browser screenshots.
+- [x] Add lightweight CSS tooltips for `L`, `E`, and `F` (and optionally the `−` controls) on hover and keyboard focus; verified hover/focus reveals `Library`, `Editor`, and `Focus map` text without relying only on native `title`.
+- [x] Smoke-test interactions in the browser on `http://localhost:3401/dashboard/library/routes`: collapse/restore Library, collapse/restore Editor, focus/restore map, then edit/select a waypoint to confirm route state remains intact.
+- [x] Run web checks; verified with `just web-check` and `cd web && npm run typecheck`.
+
+## Risks
+
+- Absolute/fixed positioning can drift from panel corners if desktop panel dimensions change; mitigated with scoped selectors and browser verification at multiple widths.
+- Icon-only controls can be unclear; mitigated with visible single-letter tabs, hover/focus tooltips, `title`, and `aria-label`.
+- Tiny visual buttons can be hard to click; mitigated by keeping the hit target at `38px`.
+
+## Completion Checklist
+
+- [x] Route status and panel controls do not overlap, verified in Chrome at `1024x900`, `1265x900`, `1440x900`, and `1600x900` with DOM bounding boxes and screenshots.
+- [x] Library `−` / `L` controls collapse and restore only Library while preserving route draft state, verified by browser clicks on `/dashboard/library/routes`.
+- [x] Editor `−` / `E` controls collapse and restore only Editor while preserving route draft state, verified by browser clicks on `/dashboard/library/routes`.
+- [x] Focus `F` collapses both panels and restores both when already focused, verified by browser clicks on `/dashboard/library/routes`.
+- [x] Hover and keyboard focus reveal meanings for `Library`, `Editor`, and `Focus map`, verified by browser inspection.
+- [x] Accessibility labels exist for Library, Editor, and Focus map controls, verified by DOM inspection.
+- [x] Web quality gates pass, verified by `just web-check` and `cd web && npm run typecheck`.
+
+## Completion Evidence
+
+- Chrome URL: `http://localhost:3401/dashboard/library/routes`.
+- Chrome screenshots: `/tmp/kestrel-panel-icon-controls-1024.png`, `/tmp/kestrel-panel-icon-controls-1265.png`, `/tmp/kestrel-panel-icon-controls-1440.png`, `/tmp/kestrel-panel-icon-controls-1600.png`, `/tmp/kestrel-panel-icon-controls-tooltip.png`.
+- DOM interaction smoke verified initial, Library collapse/restore, Editor collapse/restore, Focus map collapse/restore, labels, tooltip content, waypoint selection, and panel visibility.
+- `just web-check` passed.
+- `cd web && npm run typecheck` passed.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3726,7 +3726,7 @@ button.is-loading {
 
 .map-panel-controls {
   border: 0;
-  display: contents;
+  height: 0;
   margin: 0;
   padding: 0;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3725,26 +3725,101 @@ button.is-loading {
 }
 
 .map-panel-controls {
+  border: 0;
+  display: contents;
+  margin: 0;
+  padding: 0;
+}
+
+.map-panel-control {
   align-items: center;
+  backdrop-filter: blur(14px);
   background: var(--overlay-surface);
   border: 1px solid var(--border);
   border-radius: 999px;
   box-shadow: var(--shadow-xs);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  left: 50%;
-  margin: 0;
-  padding: 6px;
+  color: var(--accent-hover);
+  display: inline-flex;
+  font-size: 16px;
+  font-weight: 900;
+  height: 38px;
+  justify-content: center;
+  line-height: 1;
+  min-height: 38px;
+  min-width: 38px;
+  padding: 0 12px;
   position: absolute;
-  top: 68px;
-  transform: translateX(-50%);
-  z-index: 15;
+  z-index: 18;
 }
 
-.map-panel-controls button {
-  min-height: 30px;
-  padding: 5px 10px;
+.map-panel-control:hover:not(:disabled) {
+  background: var(--paper-card);
+  border-color: var(--accent);
+  box-shadow: 0 10px 24px rgb(34 24 15 / 14%);
+  transform: none;
+}
+
+.map-panel-control:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.map-panel-control::after {
+  background: var(--ink-black, #22180f);
+  border-radius: 999px;
+  bottom: calc(100% + 8px);
+  color: #fffaf3;
+  content: attr(data-label);
+  font-size: 11px;
+  font-weight: 800;
+  left: 50%;
+  letter-spacing: 0.04em;
+  opacity: 0;
+  padding: 5px 8px;
+  pointer-events: none;
+  position: absolute;
+  text-transform: uppercase;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+  white-space: nowrap;
+}
+
+.map-panel-control:hover::after,
+.map-panel-control:focus::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.map-panel-control-library::after {
+  left: 0;
+  transform: translateY(4px);
+}
+
+.map-panel-control-library:hover::after,
+.map-panel-control-library:focus::after {
+  transform: translateY(0);
+}
+
+.map-panel-control-editor::after,
+.map-panel-control-focus::after {
+  left: auto;
+  right: 0;
+  transform: translateY(4px);
+}
+
+.map-panel-control-editor:hover::after,
+.map-panel-control-editor:focus::after,
+.map-panel-control-focus:hover::after,
+.map-panel-control-focus:focus::after {
+  transform: translateY(0);
+}
+
+.map-panel-control.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fffaf3;
 }
 
 .cartographer-stage-left-collapsed .field-notebook {
@@ -5975,55 +6050,47 @@ button.route-marker.selected::after {
 @media (min-width: 1024px) {
   .route-mode-bar {
     left: calc(var(--cloud-sidebar-width, 320px) + 32px);
-    right: calc(var(--cloud-editor-width, 440px) + 80px);
+    right: calc(var(--cloud-editor-width, 440px) + 96px);
     top: calc(var(--cloud-topbar-height, 56px) + 16px);
   }
 
-  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls {
-    justify-content: center;
-    left: calc(var(--cloud-sidebar-width, 320px) + 32px);
+  .map-panel-control-library.is-collapse {
+    left: calc(16px + var(--cloud-sidebar-width, 320px) - 30px);
+    top: calc(var(--cloud-topbar-height, 56px) + 8px);
+  }
+
+  .map-panel-control-library.is-restore {
+    left: 16px;
+    top: calc(var(--cloud-topbar-height, 56px) + 24px);
+  }
+
+  .map-panel-control-editor.is-collapse {
+    right: 28px;
+    top: calc(var(--cloud-topbar-height, 56px) + 8px);
+  }
+
+  .map-panel-control-editor.is-restore {
+    right: 16px;
+    top: calc(var(--cloud-topbar-height, 56px) + 76px);
+  }
+
+  .map-panel-control-focus {
     right: calc(var(--cloud-editor-width, 440px) + 32px);
-    top: calc(var(--cloud-topbar-height, 56px) + 116px);
-    transform: none;
+    top: calc(var(--cloud-topbar-height, 56px) + 24px);
+  }
+
+  .cartographer-stage-right-collapsed .map-panel-control-focus {
+    right: 64px;
   }
 }
 
-@media (min-width: 1200px) {
-  .cartographer-stage-library.cartographer-stage-routes .route-mode-bar {
-    right: calc(var(--cloud-editor-width, 440px) + 176px);
-  }
-
-  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls {
-    align-items: stretch;
-    border-radius: 16px;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    left: auto;
-    right: calc(var(--cloud-editor-width, 440px) + 32px);
-    top: calc(var(--cloud-topbar-height, 56px) + 16px);
-  }
-
-  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls button {
-    justify-content: center;
-    white-space: nowrap;
+@media (min-width: 1024px) and (max-width: 1199px) {
+  .route-mode-bar span {
+    display: none;
   }
 }
 
-@media (min-width: 1536px) {
-  .cartographer-stage-library.cartographer-stage-routes .route-mode-bar {
-    right: calc(var(--cloud-editor-width, 440px) + 400px);
-  }
-
-  .cartographer-stage-library.cartographer-stage-routes .map-panel-controls {
-    align-items: center;
-    border-radius: 999px;
-    flex-direction: row;
-    justify-content: flex-end;
-  }
-}
-
-@media (min-width: 1024px) and (max-width: 1279px) {
+@media (min-width: 1200px) and (max-width: 1279px) {
   .route-mode-bar span:last-child {
     display: none;
   }
@@ -6032,6 +6099,23 @@ button.route-marker.selected::after {
 @media (max-width: 1023px) {
   .route-mode-bar {
     display: none;
+  }
+
+  .map-panel-control {
+    position: fixed;
+    top: 112px;
+  }
+
+  .map-panel-control-library {
+    right: 108px;
+  }
+
+  .map-panel-control-editor {
+    right: 60px;
+  }
+
+  .map-panel-control-focus {
+    right: 12px;
   }
 }
 

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -61,31 +61,49 @@ export function Stage({
       {onToggleLeftPanel == null &&
       onToggleRightPanel == null &&
       onToggleMapFocus == null ? null : (
-        <fieldset className="map-panel-controls">
+        <fieldset className="map-panel-controls map-panel-icon-controls">
           <legend className="sr-only">Map panel controls</legend>
           {onToggleLeftPanel == null ? null : (
             <button
               aria-expanded={!isLeftPanelCollapsed}
-              className="secondary"
+              aria-label={isLeftPanelCollapsed ? 'Show Library' : 'Hide Library'}
+              className={`map-panel-control map-panel-control-library ${
+                isLeftPanelCollapsed ? 'is-restore' : 'is-collapse'
+              }`}
+              data-label="Library"
+              title={isLeftPanelCollapsed ? 'Show Library' : 'Hide Library'}
               type="button"
               onClick={onToggleLeftPanel}
             >
-              {isLeftPanelCollapsed ? 'Show library' : 'Hide library'}
+              {isLeftPanelCollapsed ? 'L' : '−'}
             </button>
           )}
           {onToggleRightPanel == null ? null : (
             <button
               aria-expanded={!isRightPanelCollapsed}
-              className="secondary"
+              aria-label={isRightPanelCollapsed ? 'Show Editor' : 'Hide Editor'}
+              className={`map-panel-control map-panel-control-editor ${
+                isRightPanelCollapsed ? 'is-restore' : 'is-collapse'
+              }`}
+              data-label="Editor"
+              title={isRightPanelCollapsed ? 'Show Editor' : 'Hide Editor'}
               type="button"
               onClick={onToggleRightPanel}
             >
-              {isRightPanelCollapsed ? 'Show editor' : 'Hide editor'}
+              {isRightPanelCollapsed ? 'E' : '−'}
             </button>
           )}
           {onToggleMapFocus == null ? null : (
-            <button className="secondary" type="button" onClick={onToggleMapFocus}>
-              {isMapFocused ? 'Show panels' : 'Focus map'}
+            <button
+              aria-label={isMapFocused ? 'Show panels' : 'Focus map'}
+              aria-pressed={isMapFocused}
+              className={`map-panel-control map-panel-control-focus ${isMapFocused ? 'active' : ''}`}
+              data-label="Focus map"
+              title={isMapFocused ? 'Show panels' : 'Focus map'}
+              type="button"
+              onClick={onToggleMapFocus}
+            >
+              F
             </button>
           )}
         </fieldset>


### PR DESCRIPTION
## Summary
- replace the bulky map panel toolbar with panel-edge icon controls
- add Library/Editor collapse buttons plus L/E restore tabs and an F focus-map control
- add hover/focus labels, accessible names, and scoped responsive positioning
- archive the completed implementation plan

## Browser validation
- Opened http://localhost:3401/dashboard/library/routes in Chrome
- Checked non-overlap and layout at 1024x900, 1265x900, 1440x900, and 1600x900
- Click-smoked Library collapse/restore, Editor collapse/restore, Focus map collapse/restore, and waypoint selection
- Verified tooltip labels for Library, Editor, and Focus map
- Screenshots: /tmp/kestrel-panel-icon-controls-1024.png, /tmp/kestrel-panel-icon-controls-1265.png, /tmp/kestrel-panel-icon-controls-1440.png, /tmp/kestrel-panel-icon-controls-1600.png, /tmp/kestrel-panel-icon-controls-tooltip.png

## Tests
- git diff --check
- just web-check
- cd web && npm run typecheck