### PR TITLE
Match place markers to route markers

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4194,35 +4194,46 @@ button.is-loading {
 }
 
 .place-marker {
-  background: var(--paper-card);
-  border: 2px solid var(--accent-hover);
-  border-radius: 999px 999px 999px 0;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  align-items: center;
+  background: var(--accent);
+  border: 2px solid var(--bg-surface);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-sm);
+  color: #fff;
   cursor: pointer;
-  height: 24px;
-  transform: rotate(-45deg);
-  width: 24px;
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 800;
+  height: 2rem;
+  justify-content: center;
+  line-height: 1;
+  min-height: 0;
+  min-width: 2rem;
+  padding: 0;
+  transition:
+    background var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+  width: 2rem;
 }
 
-.place-marker::after {
-  background: var(--accent);
-  border-radius: 999px;
-  content: "";
-  height: 8px;
-  left: 6px;
-  position: absolute;
-  top: 6px;
-  width: 8px;
+.place-marker:hover:not(:disabled),
+.place-marker:focus-visible,
+.place-marker.active {
+  background: var(--accent-hover);
+  color: #fff;
+}
+
+.place-marker:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .place-marker.active {
-  background: var(--accent);
-  border-color: var(--paper-card);
-  transform: rotate(-45deg) scale(1.15);
-}
-
-.place-marker.active::after {
-  background: var(--paper-card);
+  box-shadow:
+    0 0 0 4px rgb(180 95 50 / 24%),
+    var(--shadow-md);
+  transform: scale(1.16);
 }
 
 .place-marker.preview {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4212,8 +4212,7 @@ button.is-loading {
   padding: 0;
   transition:
     background var(--transition-fast),
-    box-shadow var(--transition-fast),
-    transform var(--transition-fast);
+    box-shadow var(--transition-fast);
   width: 2rem;
 }
 
@@ -4233,7 +4232,6 @@ button.is-loading {
   box-shadow:
     0 0 0 4px rgb(180 95 50 / 24%),
     var(--shadow-md);
-  transform: scale(1.16);
 }
 
 .place-marker.preview {

--- a/web/components/PlaceMapEditor.tsx
+++ b/web/components/PlaceMapEditor.tsx
@@ -111,10 +111,11 @@ export default function PlaceMapEditor({
 }
 
 function createPlaceMarkerElement({ active, label }: { active: boolean; label: string }) {
+  const markerLabel = label.trim() || 'Place';
   const element = document.createElement('button');
-  element.ariaLabel = label;
+  element.ariaLabel = markerLabel;
   element.className = `place-marker${active ? ' active' : ''}`;
-  element.textContent = label.trim().charAt(0).toUpperCase() || 'P';
+  element.textContent = markerLabel.charAt(0).toUpperCase();
   element.type = 'button';
 
   return element;

--- a/web/components/PlaceMapEditor.tsx
+++ b/web/components/PlaceMapEditor.tsx
@@ -114,6 +114,7 @@ function createPlaceMarkerElement({ active, label }: { active: boolean; label: s
   const element = document.createElement('button');
   element.ariaLabel = label;
   element.className = `place-marker${active ? ' active' : ''}`;
+  element.textContent = label.trim().charAt(0).toUpperCase() || 'P';
   element.type = 'button';
 
   return element;

--- a/web/components/PlaceMapPreview.tsx
+++ b/web/components/PlaceMapPreview.tsx
@@ -83,6 +83,7 @@ export default function PlaceMapPreview({ className = 'map-mini', latitude, long
 function createPreviewMarkerElement() {
   const element = document.createElement('span');
   element.className = 'place-marker active preview';
+  element.textContent = 'P';
 
   return element;
 }

--- a/web/components/cartographer/CartographerPlaceMap.tsx
+++ b/web/components/cartographer/CartographerPlaceMap.tsx
@@ -242,10 +242,11 @@ function syncPlaceMarkers({
 }
 
 function createPlaceMarkerElement({ active, label }: { active: boolean; label: string }) {
+  const markerLabel = label.trim() || 'Place';
   const element = document.createElement('button');
-  element.ariaLabel = label;
+  element.ariaLabel = markerLabel;
   element.className = `place-marker${active ? ' active' : ''}`;
-  element.textContent = label.trim().charAt(0).toUpperCase() || 'P';
+  element.textContent = markerLabel.charAt(0).toUpperCase();
   element.type = 'button';
 
   return element;

--- a/web/components/cartographer/CartographerPlaceMap.tsx
+++ b/web/components/cartographer/CartographerPlaceMap.tsx
@@ -245,6 +245,7 @@ function createPlaceMarkerElement({ active, label }: { active: boolean; label: s
   const element = document.createElement('button');
   element.ariaLabel = label;
   element.className = `place-marker${active ? ' active' : ''}`;
+  element.textContent = label.trim().charAt(0).toUpperCase() || 'P';
   element.type = 'button';
 
   return element;


### PR DESCRIPTION
## Summary
- restyle place map markers as the same orange circular badges used by routes
- show a short marker letter for place editor, preview, and cartographer maps

## Verification
- cd web && npm run lint
- cd web && npm run typecheck
- just web-check
- Browser smoke: http://localhost:3401/dashboard/map at 1600x913, screenshot /tmp/kestrel-place-markers.png