### PR TITLE
docs: clean up active plans

### DIFF
--- a/docs/plans/2026-05-10_engineering-backlog-plan.md
+++ b/docs/plans/2026-05-10_engineering-backlog-plan.md
@@ -2,54 +2,52 @@
 
 ## Goal
 
-Consolidate cross-cutting engineering and app-polish work that remains after the completed local library, web console, backend, and Android sync phases.
+Keep only actionable cross-cutting work in the active backlog. Success means production/release safety and required manual validations are visible, while completed or speculative items stop cluttering active planning.
 
 ## Context
 
-This backlog comes from the general TODO and the operations/DX sections of the cloud platform todo. Items here are not required to finish the sharing MVP, but they improve testability, release readiness, maintainability, and user polish.
+Completed since the original backlog:
+
+- CI lanes, path filters, backend `build`, backend e2e policy, and Web lint/typecheck/build are in `.github/workflows/ci.yml`.
+- Android app icon, notification copy, route status mode/speed, disabled selected chips, route progress persistence, Web map styles, Web dashboard IA/polish, sharing, and remote control are archived in `docs/plans/archived/`.
+- Release builds currently produce an unsigned APK; signing is still intentionally not configured.
 
 ## Plan
 
-- [x] Add Android GitHub Actions CI for PRs: Android job now runs `just android-check`, `just android-lint`, `:app:assembleDebug`, and unit tests with Gradle cache.
-- [x] Add backend CI for test, lint, and typecheck.
-- [x] Add web CI for lint/typecheck/build.
-- [x] Add `paths:` filter (or `dorny/paths-filter`) to `.github/workflows/ci.yml` so `android`, `backend`, and `web` jobs only run when their respective workspace files change. Surfaced by PR #58 review.
-- [x] Add an optional `nest build` step to the `backend` CI job to catch `nest-cli.json` / asset-copy regressions that `typecheck` misses. Surfaced by PR #58 review.
-- [x] Decide policy for promoting backend `test:e2e` into CI (separate job with Postgres service vs. nightly vs. keep local-only). Surfaced by PR #58 review. Decided: promote to existing `backend` job because specs use `overrideProvider(PrismaService)` and need no Postgres.
-- [ ] Add API structured logging with request id, auth user/session metadata where safe, and error classification.
-- [ ] Add API metrics and health checks suitable for Docker/production monitoring.
-- [ ] Write secrets management strategy for deploy: required env vars, rotation, and local `.env` guidance.
-- [ ] Write DB backup and migration rollback strategy for production PostgreSQL.
-- [ ] Generate or publish OpenAPI docs for auth/library/sync/sharing APIs.
-- [ ] Decide client generation strategy: TypeScript generated client, Kotlin generated client, or documented hand-written client rules.
-- [ ] Add Android jitter option for mock samples: configurable lat/lng and speed perturbation, default off, with `MovementEngine`/service tests where possible.
-- [x] Improve foreground notification title/text and channel description. Completed in `docs/plans/archived/2026-05-23_foreground-notification-copy-plan.md`; verified with stale-copy `rg` check and `just check`.
-- [x] Replace default Android Studio app icon with Kestrel adaptive icon assets. Completed in `docs/plans/archived/2026-05-23_android-adaptive-icon-plan.md`; verified with resource inspection, captured icon preview review, `just build`, and `just check`.
-- [ ] Add Generate route advanced parameters: starting bearing, turn variance, and optional seed.
-- [ ] Add Android route revision history UI only if a concrete product need appears; keep current-revision-only storage/load behavior as the default until that slice is planned.
-- [ ] Add per-segment waypoint speed/pause playback once route execution supports waypoint metadata end-to-end, with dedicated `MovementEngine`/service tests.
-- [ ] Split `MapScreen` and `KestrelMap` long composables enough to remove corresponding detekt baseline entries.
-- [ ] Establish release build/proguard flow: first signed release with minify off, then staged R8 enablement.
-- [ ] Add map style toggle for OSM raster and project light/dark styles.
-- [ ] Plan on-road movement using OSRM/GraphHopper public API without offline routing.
-- [ ] Add zh-TW and ja string resources after UI strings stabilize.
-- [ ] Add instrumented CI tests for emulator service lifecycle and startup mode apply behavior.
-- [ ] Run a fresh real-device smoke for Go to/Favorites apply behavior after the next substantial map/favorites refactor, since the baseline quick-jump/favorites slice is otherwise complete and current cleanup was verified only by `just check` / `just lint`.
-- [x] Show current mode + speed numerically in `MapScreen` status row while a route is playing; completed in `docs/plans/archived/2026-05-23_route-status-mode-speed-plan.md` with status text now showing waypoint count, speed, and mode for playing/paused routes; verified by focused `MapRenderReconciliationTest`, `just check`, and `just lint`.
-- [ ] Run an Android `Sync now` smoke after copying a shared route from the public web page, and confirm the copied route appears/behaves as a normal owned route on device. Moved out of `docs/plans/archived/2026-05-13_sharing-plan.md` so the shipped sharing slice can close while keeping one Android end-to-end proof item tracked.
-- [x] Make `ChipChoice` with `enabled = false && selected = true` visually distinct; selected disabled chips now keep reduced-alpha `primaryContainer` / `onPrimaryContainer` colors so running-route speed/mode chips remain identifiable. Verified by `just build`, `just check`, and `just lint`.
-- [ ] Decide whether `MapScreen` drafts (`waypoints` / `speedKmh` / `routeMode`) should survive tab switching. Today `rememberSaveable` survives config change but not tab switch, because `NavigationSuiteScaffold` is not backed by a `SaveableStateHolder`. Either document the limitation or migrate tab navigation to a `NavHost` backstack in a dedicated plan. Surfaced by `2026-05-11_route-ui-state-restore-plan.md` smoke results.
+### Production / release hardening
+
+- [ ] Add a backend health endpoint and Docker Compose backend healthcheck; verify with `cd backend && npm run test && npm run build` plus `docker compose -f compose.deploy.yaml config --quiet`.
+- [ ] Add structured backend request/error logging with request id plus safe user/session metadata; verify with backend unit/e2e coverage or a local request log sample that contains no secrets.
+- [ ] Write `docs/operations.md` with required deploy secrets, local `.env` guidance, rotation notes, DB backup, and migration rollback; verify against `.github/workflows/deploy.yml` and `compose.deploy.yaml`.
+- [ ] Decide API documentation/client policy: generated OpenAPI clients or hand-written DTO rules; verify by either published docs or a short decision record in `docs/operations.md` / `docs/remote-control-api.md`.
+- [ ] Establish Android release signing flow with minify still off; verify `just release` produces a signed or explicitly documented unsigned artifact.
+
+### Manual validation
+
+- [ ] Run one non-destructive Android cloud smoke covering production URL alias login (`https://kestrel.narumi.dev`) and `Sync now`; record device, build, and result in `2026-05-13_android-cloud-options-autofill-url-plan.md`.
+- [ ] After copying a shared route from the public Web page, run Android `Sync now` and confirm the copied route appears/behaves as a normal owned route; do not use `just reset` / `pm clear`.
+- [ ] Run a fresh real-device Go to/Favorites apply smoke after the next substantial map/favorites refactor; this is not needed for docs-only or Web-only work.
+
+### Android maintainability
+
+- [ ] Split `KestrelMap` enough to remove its current `LongMethod` detekt baseline entry; verify with `just check && just lint` and `rg "KestrelMap" detekt-baseline.xml`.
+- [ ] Decide whether `MapScreen` drafts (`waypoints` / `speedKmh` / `routeMode`) should survive tab switching; verify by either a short docs note accepting the limitation or a dedicated NavHost/SaveableStateHolder plan.
+- [ ] Add emulator/instrumented CI only if a stable, non-destructive service-lifecycle test can run without wiping operator device state.
+
+### Not active until requested
+
+These are intentionally not active tasks: route revision history UI, route generator advanced parameters, per-segment speed/pause playback, jitter simulation, OSRM/GraphHopper on-road routing, zh-TW/ja localization, and Android map style switching. Promote one into its own plan only when there is a concrete user story.
 
 ## Risks
 
-- CI can be blocked by local/project Java assumptions; use Linux CI paths and avoid macOS-specific `JAVA_HOME` assumptions.
-- API docs/client generation should not freeze unstable sharing/remote-command APIs too early.
-- On-road routing adds external service reliability and rate-limit concerns; keep it separate from core mock playback.
+- Logging and API docs can leak secrets or freeze unstable APIs if overbuilt; start with minimal safe fields and current endpoints.
+- DB backup/rollback docs are easy to write but dangerous if untested; include a restore check when production data exists.
+- Instrumented/device tests can wipe app-private state; call out destructive commands before running them.
 
 ## Completion Checklist
 
-- [x] Android, backend, and web CI run on PRs and block broken formatting/lint/builds.
-- [ ] Production deploy has documented secrets, health checks, and DB backup/rollback procedures.
-- [ ] API documentation/client strategy is implemented or explicitly accepted as hand-written.
-- [x] App polish items that affect first impressions are done: notification wording and app icon; verified by archived notification/icon plans plus `just check`.
-- [ ] Large optional features remain separated into dedicated plans before implementation.
+- [ ] Production deploy has health checks, structured logs, secrets guidance, and DB backup/rollback documentation.
+- [ ] API documentation/client policy is implemented or explicitly accepted as hand-written DTOs.
+- [ ] Android release artifacts are signed, or unsigned status remains explicitly documented until signing exists.
+- [ ] Required Android manual smokes are recorded or explicitly blocked with evidence.
+- [ ] Speculative features remain outside active checklists until they have a concrete plan.

--- a/docs/plans/2026-05-10_product-roadmap-plan.md
+++ b/docs/plans/2026-05-10_product-roadmap-plan.md
@@ -2,49 +2,47 @@
 
 ## Goal
 
-Keep Kestrel focused as an Android mock-location app with a cloud library: Web edits places/routes, Android syncs and executes them, and future work can add sharing, device state, and remote control without reworking the domain model.
+Keep Kestrel focused as an Android mock-location app with a cloud library and opt-in Web remote control. Success means the roadmap reflects shipped foundations, keeps security-sensitive work explicit, and only promotes future features when there is a concrete user need.
 
 ## Context
 
-Kestrel now has these completed foundations:
+Completed foundations:
 
-- Android mock location, route playback, random route generation, MapLibre UI, Favorites/Go to, Room-backed cloud-shaped library.
-- NestJS + PostgreSQL + Prisma backend with username/password + TOTP auth, library CRUD, sync bootstrap/changes, and auth/session infrastructure.
-- Next.js web console for auth and place/route editing.
-- Android cloud login and sync, including cursor recovery and current revision route execution.
-
-The remaining roadmap should not reopen completed local-library or cloud-sync foundations except for explicit follow-ups.
+- Android mock location, route playback, random route generation, MapLibre UI, Favorites/Go to, Room-backed library, startup behavior, and route progress restore.
+- NestJS + PostgreSQL + Prisma backend with auth/TOTP, sessions, library CRUD, sync bootstrap/changes, sharing, and remote-control command queue.
+- Next.js web console with Map/Library dashboard, place/route editing, sharing/copy-to-library, map styles, and compact Device/Share actions.
+- Android cloud login/sync, local-only place upload/conflict resolution, current-revision route execution, and opt-in Web remote command polling.
 
 ## Non-Goals
 
 - Do not bypass Play Integrity / SafetyNet.
 - Do not introduce a second map backend; MapLibre remains the map implementation.
 - Do not add GPS track recording or GPX/KML import/export.
-- Do not merge web and backend codebases in this roadmap; same-origin proxying/deploy entrypoint work is separate.
+- Do not add broad device/session administration until there is a user story beyond remote-control device selection.
 
 ## Plan
 
 - [x] Establish Android mock-location MVP: single point, route playback, random route generation, startup behavior, foreground service, and MapLibre UI.
 - [x] Replace local `Favorite(name as id)` storage with Room-backed `Place / Route / RouteRevision / Waypoint / LibraryItem` domain.
 - [x] Build cloud auth and library APIs with TOTP, refresh sessions, owner-scoped CRUD, immutable route revisions, and sync events.
-- [x] Build web console login and place/route editing workflows.
+- [x] Build web console login and place/route editing workflows, then evolve it into the Map/Library dashboard.
 - [x] Build Android cloud login, sync bootstrap/changes, cursor recovery, and current-revision route execution.
-- [x] Implement route sharing as the next product slice: backend/web implementation for public latest route links and copy-to-library landed under `docs/plans/archived/2026-05-13_sharing-plan.md` on 2026-05-13, including share-link CRUD, public route page, authenticated copy-to-library, a successful dev-DB migration run for `20260513110000_sharing_links`, a browser smoke run for create-link → public page → sign-in → copy, and the post-PR follow-up fixes archived under `docs/plans/archived/2026-05-13_sharing-followups-plan.md`. Remaining Android end-to-end proof was moved to `2026-05-10_engineering-backlog-plan.md` as a separate follow-up.
-- [x] Implement sync/upload strengthening: local-only place upload, remote-id binding after upload, item-level manual conflict resolution, and `Use Cloud` / `Use Local` / `Keep Both` actions all shipped end-to-end and verified on a real-device smoke run (`docs/plans/archived/2026-05-10_android-local-upload-conflict-plan.md`, PRs #46–#49 and later test follow-ups in PRs #68–#69). Route upload/conflict is still deferred, but the place-first upload/conflict slice itself is now complete.
-- [ ] Implement device/session management: device state reporting, session/device list, and revoke controls.
-- [ ] Design remote command model only after device/session management exists and has an explicit threat model.
-- [ ] Harden operations: secrets management, DB backup/rollback, backend/web CI, structured logging, health/metrics, and API docs/client generation.
+- [x] Implement public route/place sharing and authenticated copy-to-library; archived under `docs/plans/archived/2026-05-13_sharing-plan.md`, `2026-05-13_sharing-followups-plan.md`, and `2026-05-16_web-place-sharing-plan.md`.
+- [x] Implement place-first upload/conflict strengthening; archived under `docs/plans/archived/2026-05-10_android-local-upload-conflict-plan.md`.
+- [x] Implement opt-in Web remote control: backend command queue, Android polling/executor, Web Device actions, and physical smoke coverage; archived under `docs/plans/archived/2026-06-20_web-remote-mock-control-plan.md` and its slice plans.
+- [ ] Harden production operations: health checks, structured logging, secrets guidance, DB backup/rollback, and release signing; track concrete tasks in `2026-05-10_engineering-backlog-plan.md`.
+- [ ] Finish the remaining Android cloud manual smokes: production URL alias login + `Sync now`, and copied shared route syncing to Android; track in `2026-05-13_android-cloud-options-autofill-url-plan.md` and `2026-05-10_engineering-backlog-plan.md`.
+- [ ] Pick the next product feature only from observed need; current candidates stay out of active scope until requested: route revision browsing, richer per-waypoint playback, on-road routing, jitter simulation, localization, and full session management.
 
 ## Risks
 
-- Sharing and remote control expand the security surface; threat modeling must precede public links or commands.
-- Cloud-first sync plus local-only items can create duplicate-looking entries until upload/conflict policy is explicit.
-- Route payload compatibility can break Android sync if versioning is not documented before richer waypoint metadata lands.
+- Sharing and remote control expand the security surface; keep opt-in, same-user ownership checks, expiry, audit, and bounded polling.
+- Route payload compatibility can break Android sync if richer waypoint metadata lands without versioned tests.
+- Production deploy safety now matters more than feature breadth; do ops/release hardening before larger product bets.
 
 ## Completion Checklist
 
-- [x] Product roadmap reflects the implemented Android, backend, web, and sync baseline from the consolidated legacy planning docs.
-- [x] `docs/plans/archived/2026-05-13_sharing-plan.md` implementation is landed locally for public latest route links and copy-to-library, with backend/web validation, the dev-DB migration run, browser smoke evidence recorded on 2026-05-13, and follow-up correctness fixes archived under `docs/plans/archived/2026-05-13_sharing-followups-plan.md`.
-- [x] Local-only upload/conflict policy has an accepted plan and implementation PRs; place-first work is archived in `docs/plans/archived/2026-05-10_android-local-upload-conflict-plan.md`, with implementation shipped across PRs #46–#49 and backend/Android automated coverage plus refreshed device smoke added in PRs #68–#69.
-- [ ] Device/session management has an accepted plan before remote commands are designed.
-- [ ] Operations checklist has CI, logging, health, backup, and API documentation coverage.
+- [x] Roadmap reflects the implemented Android, backend, web, sync, sharing, and remote-control baseline.
+- [ ] Production operations and release hardening have an accepted, verified slice in `2026-05-10_engineering-backlog-plan.md`.
+- [ ] Remaining Android cloud manual smokes are either passed and archived, or explicitly marked blocked with device/environment evidence.
+- [ ] Any new large product feature has its own focused plan before implementation.

--- a/docs/plans/2026-05-13_android-cloud-options-autofill-url-plan.md
+++ b/docs/plans/2026-05-13_android-cloud-options-autofill-url-plan.md
@@ -1,51 +1,37 @@
+# Android cloud Options autofill / URL validation plan
+
 ## Goal
 
-讓 Android app 的 Options → Cloud sync 登入與 API URL 設定更順手：
-
-1. 使用 1Password 自動填入時，username / password / TOTP 欄位能被正確辨識與帶入。
-2. 新安裝或未設定過 cloud endpoint 時，預設顯示並使用 `https://kestrel.narumi.dev`。
-3. Production cloud endpoint 可輸入 `https://kestrel.narumi.dev` 或 `https://kestrel.narumi.dev/api`，app 會自動使用實際 backend proxy `https://kestrel.narumi.dev/api/backend`；已輸入完整 `/api/backend` 以及本機 direct backend URL 不被破壞。
+Close the remaining manual validation for Android Options → Cloud sync login. Success means production URL aliasing works without typing `/api/backend`, and the current 1Password/autofill behavior is either accepted or captured as a concrete follow-up.
 
 ## Context
 
-- 目前 `OptionsScreen.kt` 的 cloud login 欄位只是一般 `OutlinedTextField`，沒有針對 Android Autofill / credential managers 提供 username/password/OTP 語意。
-- 目前 `CloudApiClient` 會將 `KestrelPrefs.CloudSettings.apiBaseUrl` 做 `trim().trimEnd('/')` 後直接接 `/auth/login`、`/sync/*` 等 backend path。
-- Web console 已有 runtime proxy `web/app/api/backend/[...path]/route.ts`，production/domain 對外應走 `/api/backend/*`；直接輸入 `https://kestrel.narumi.dev` 會打到 web root 下的 `/auth/login` 而非 backend。
-- DataStore 的 `CloudSettings.apiBaseUrl` 只有單一字串欄位，適合保持相容並在 client 端正規化。
-- 目前 `CloudSettings.DEFAULT_API_BASE_URL` 是 emulator/local backend `http://10.0.2.2:3000`；production-friendly 預設值需要改為 `https://kestrel.narumi.dev`，本機開發者仍可手動覆寫。
+Already implemented and verified by code/tests:
+
+- `CloudSettings.DEFAULT_API_BASE_URL = "https://kestrel.narumi.dev"`.
+- `normalizeCloudApiBaseUrl()` maps `https://kestrel.narumi.dev` and `/api` to `/api/backend`, while preserving direct backend URLs such as `http://10.0.2.2:3000`.
+- `CloudApiClient.normalizedBaseUrl()` is the single request-time normalization path.
+- Options helper text explains the production default.
+- Login fields use Compose content type / text data hints, and Android/Web credential association metadata exists for `kestrel.narumi.dev`.
+
+Known gotcha: earlier Compose autofill attempts were worse with 1Password. Keep this plan manual-only unless a reproducible failure appears.
 
 ## Non-Goals
 
-- 不重做 cloud auth flow、session 儲存或 TOTP/recovery-code 流程。
-- 不改 web/backend 部署拓撲；backend 仍透過 web 的 `/api/backend` proxy 對外。
-- 不清除使用者 app data；任何需要 `just reset` 或 reinstall 的驗證另行明確徵求同意。
-
-## Unknowns
-
-- 1Password 在 Compose `OutlinedTextField` 上是否只需要 Autofill/semantics content type，或還需要 IME hints / stable node structure；先做最小欄位語意改動，再用實機 1Password 驗證。
-- 是否要把 production URL alias 限定在 `kestrel.narumi.dev`，或支援任意 web origin 自動補 `/api/backend`；本計畫先以不破壞本機 direct backend 為優先，實作前用單元測試鎖定規則。
+- Do not redesign cloud auth, session storage, TOTP, or recovery-code flow.
+- Do not clear app data, uninstall/reinstall, run `just reset`, or wipe favorites/prefs for this validation.
 
 ## Plan
 
-- [x] 調查目前 AndroidX Compose BOM 對 Autofill 的推薦 API，決定使用 `Modifier.semantics { contentType = ... }`、`keyboardOptions`、或仍需 `AutofillTree`；驗證方式是在 `OptionsScreen.kt` 中可編譯引用對應 API，並以 `just check` 確認無 unresolved reference。_Verified on 2026-05-13: both semantics `ContentType` and legacy `AutofillTree` / `AutofillNode` compiled, but manual 1Password testing showed regressions: semantics prevented password fill, and legacy nodes only filled OTP. Autofill code was reverted to preserve the previously working password fill._
-- [ ] 更新 `CloudSignedOutCardContent` 的 username、password、TOTP/recovery-code 欄位語意，讓 1Password 能辨識帳號、密碼與 one-time code；驗證方式為 `just check`，並以實機 1Password smoke：點選 Username 欄位後可帶入 username，Password 欄位可帶入 password，TOTP 欄位可帶入 OTP 或不阻塞手動輸入。_After failed ad-hoc attempts, this now follows Android's official hint guidance through Compose semantics for each field, keeps the username hint as username-only because the tested 1Password item uses a non-email username, shows the TOTP/recovery field immediately, and adds Android/website credential association metadata (`asset_statements` + `/.well-known/assetlinks.json`) using the current debug signing fingerprint. 1Password's official app/site linking guidance still needs manual verification via `Always Allow` or an app-associated Login item after the web file is deployed._
-- [x] 將 `CloudSettings.DEFAULT_API_BASE_URL` 改為 `https://kestrel.narumi.dev`，讓新安裝與未設定過 cloud endpoint 的使用者預設走 production web origin；驗證方式為 `Preferences.kt` 中預設值、Options UI 初始值、以及單元測試/preview 證據。_Verified by `Preferences.kt` default value and `just test` / `just check` / `just lint` on 2026-05-13._
-- [x] 新增 `core/cloud` 或 `core/data` 的純 Kotlin URL 正規化 helper，將預設值 `https://kestrel.narumi.dev`、`https://kestrel.narumi.dev/api` 解析成 `https://kestrel.narumi.dev/api/backend`，保留已完整的 `/api/backend`，並保留 direct backend URL（例如 `http://10.0.2.2:3000`、`http://localhost:3300`）不補 path；驗證方式為新增/更新 `app/src/test/...` 單元測試並跑 `JAVA_HOME=… ./gradlew :app:testDebugUnitTest`。_Implemented in `CloudApiBaseUrl.kt`; verified by `CloudApiBaseUrlTest.kt` and `just test` on 2026-05-13._
-- [x] 將 helper 接到儲存或 request 建 URL 的單一路徑，避免 UI 顯示值與實際 request endpoint 分裂；驗證方式為讀碼確認 `CloudApiClient.normalizedBaseUrl()` 或 `KestrelPrefs.setCloudApiBaseUrl()` 只有一個 endpoint 正規化來源，且單元測試覆蓋 trailing slash、空白與 `/api/` cases。_Implemented by routing `CloudApiClient.normalizedBaseUrl()` through `normalizeCloudApiBaseUrl()`; tests cover whitespace, trailing slash, `/api`, and direct backend URLs._
-- [x] 更新 Options UI helper text / label，說明 production 可輸入 `https://kestrel.narumi.dev`，app 會使用 backend proxy；驗證方式為 `OptionsScreen` preview/編譯通過，且 UI 文案不再要求手動輸入 `/api/backend`。_Implemented in `OptionsScreen.kt`; verified by `just check` and `just lint` on 2026-05-13._
-- [ ] 做 cloud login smoke test：輸入或儲存 `https://kestrel.narumi.dev` 後登入一次並執行 `Sync now`，確認 request 成功或錯誤訊息來自 backend auth/sync 而不是 web 404；驗證方式為實機畫面結果與必要時 `just logf` 中的 Cloud/API 錯誤紀錄。
-- [x] 執行完整 Android 驗證 `just check && just lint`；若改到純 Kotlin helper，另跑 `JAVA_HOME=… ./gradlew :app:testDebugUnitTest`，並把結果記錄到此計畫或 PR 描述。_Verified on 2026-05-13 by `just check`, `just lint`, and `just test`._
-
-## Risks
-
-- 太積極地自動補 `/api/backend` 可能破壞使用者自架的 direct backend URL；用單元測試明確保留本機與含 port 的 direct backend URL。
-- 1Password Autofill 行為受 Android 版本、鍵盤與 1Password app 版本影響；自動化測試不一定能完整覆蓋，需保留實機驗證。
-- 如果在儲存時改寫顯示 URL，使用者可能困惑；若採 request-time 正規化，UI 需說明「接受 web origin alias」。
+- [ ] On a real device with 1Password, test the signed-out Cloud sync form: username fills, password fills, TOTP/recovery field does not block manual entry, and sign-in remains possible; record device, Android version, 1Password version, and result here.
+- [ ] Set the API URL field to `https://kestrel.narumi.dev`, sign in, and tap `Sync now`; verify success or a backend auth/sync error rather than a Web 404. If needed, confirm with filtered `just log` output.
+- [ ] If autofill still fails, record the smallest reproducible field behavior and decide whether to keep the current safe workaround or file a focused follow-up.
+- [ ] Run `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 just check && JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 just lint` if code changes are made while fixing validation findings.
 
 ## Completion Checklist
 
-- [ ] 1Password username/password/TOTP 欄位辨識改善已由 `OptionsScreen.kt` 程式碼與實機 1Password smoke 結果驗證。_Current candidate uses Android/Compose official autofill hints plus `ContentDataType.Text`, username-only hint for the tested non-email username, immediate OTP/recovery field rendering, and Android/website credential association metadata; manual smoke still needed after deployment._
-- [x] `CloudSettings.DEFAULT_API_BASE_URL` 預設為 `https://kestrel.narumi.dev`，且新安裝 Options UI 初始值已由程式碼或 preview/smoke 證據驗證。_Verified by `Preferences.kt` default and `OptionsScreen.kt` binding to `CloudSettings()`._
-- [x] `https://kestrel.narumi.dev`、`https://kestrel.narumi.dev/api`、`https://kestrel.narumi.dev/api/backend`、`http://10.0.2.2:3000` 的 URL 正規化行為已由 Android unit tests 驗證。_Verified by `CloudApiBaseUrlTest.kt` and `just test` on 2026-05-13._
-- [ ] Production URL alias 登入與 `Sync now` 已在實機或 emulator 上驗證不再需要手動輸入 `/api/backend`。
-- [x] Android quality gates 通過：`just check && just lint`，以及若有新增 unit tests 則 `JAVA_HOME=… ./gradlew :app:testDebugUnitTest` 通過。_Verified on 2026-05-13 by `just check`, `just lint`, and `just test`._
+- [ ] 1Password username/password/TOTP behavior is manually verified or a focused follow-up is filed with reproduction details.
+- [ ] Production URL alias login + `Sync now` is manually verified without typing `/api/backend`.
+- [x] URL normalization behavior is unit-tested in `CloudApiBaseUrlTest.kt`.
+- [x] Default production URL and Options helper text are present in source.
+- [ ] Any code changes made during validation pass the Android quality gates above.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,14 +1,17 @@
 # Kestrel plans
 
-This directory contains the current planning set distilled from the former `docs/plan/` design notes and `docs/todos/` task lists.
+Top-level `*-plan.md` files are active. Closed or superseded plans live in `archived/`.
 
-## Current files
+## Active files
 
-| Plan | Status | Source material |
-|---|---|---|
-| `2026-05-10_product-roadmap-plan.md` | Active | Legacy project overview, sync platform plan, platform todo, general todo |
-| `2026-05-10_engineering-backlog-plan.md` | Active cross-cutting backlog | Legacy general todo and platform operations backlog |
+| Plan | Status |
+|---|---|
+| `2026-05-10_product-roadmap-plan.md` | Current product state and next bets |
+| `2026-05-10_engineering-backlog-plan.md` | Curated ops/release/manual-validation backlog |
+| `2026-05-13_android-cloud-options-autofill-url-plan.md` | Manual validation only |
 
-## Migration note
+## Rules
 
-The older `docs/plan/` and `docs/todos/` files were consolidated into this directory and removed. Add new actionable work to `docs/plans/` using the `*-plan.md` format.
+- Keep active plans small enough to act on.
+- Archive completed or superseded plans immediately.
+- Do not keep speculative ideas as unchecked active tasks; put them in a non-actionable “not now” note until there is a concrete need.

--- a/docs/plans/archived/2026-05-11_route-progress-persistence-plan.md
+++ b/docs/plans/archived/2026-05-11_route-progress-persistence-plan.md
@@ -116,9 +116,9 @@ Run on the macOS dev machine with one real Android device + mock-location pointi
 
 ## Completion Checklist
 
-- [ ] `RouteState` carries `progressMeters` and `forward` with backward-compatible defaults, verified by a unit test that decodes a legacy JSON blob.
-- [ ] `MovementEngine` can be seeded mid-route for Once / Loop / PingPong, verified by `MovementEngineTest` cases that assert the first sample after seeding lies past the origin and PingPong direction is honored.
-- [ ] `LocationService` writes progress and forward at least at the configured/default cadence, plus on pause/resume/stop/finish, verified by `just prefs` after ≥ 10 s of route playback.
+- [x] `RouteState` carries `progressMeters` and `forward` with backward-compatible defaults, verified by `RouteStateSerializationTest.decodesLegacyJsonWithoutProgressOrForward` and `roundTripsNewFields`.
+- [x] `MovementEngine` can be seeded mid-route for Once / Loop / PingPong, verified by the added `MovementEngineTest` seed/clamp cases.
+- [x] `LocationService` writes progress and forward at the configured/default cadence, plus pause/resume/stop/finish/onDestroy, verified by the 2026-05-11 real-device smoke and `mock_state_json` progress samples.
 - [x] After SIGKILL mid-route, the restarted service resumes within ≤ 5 s × speed of the pre-kill position, verified by the 2026-05-11 smoke run on commit `0896cc3` (device `ZY32L6DLW8`). Actual rollback was 0 m; resume continued at `progressMeters: 1.935` and ticked forward at the configured 5 km/h. `am crash` and `am kill` were both blocked by the foreground service (`Shell does not have permission`, FGS keeps the process alive); SIGKILL via `run-as dev.narumi.kestrel kill -9 <pid>` was the only effective non-root way to simulate the overnight-kill scenario.
-- [ ] `just check`, `just lint`, and `:app:testDebugUnitTest` pass on the implementing commit, recorded with commit hash.
-- [ ] `docs/MEMORY.md` has a one-line `## GOTCHA` entry pointing future debuggers at the periodic progress write and the ≤ 5 s rollback window.
+- [x] `just check`, `just lint`, and `:app:testDebugUnitTest` passed on the implementing branch as recorded in the Plan section.
+- [x] `docs/MEMORY.md` has a `## GOTCHA` entry for route progress periodic writes and the configured rollback window.

--- a/docs/plans/archived/2026-05-12_ci-lane-followups-plan.md
+++ b/docs/plans/archived/2026-05-12_ci-lane-followups-plan.md
@@ -53,7 +53,7 @@ The workflow itself is in every set so that workflow edits always re-run everyth
 - [x] Added `needs: changes` plus `if: github.event_name == 'push' || needs.changes.outputs.<lane> == 'true'` to each of `android`, `backend`, `web` jobs. Verified by reading the merged diff (PR #60).
 - [x] Added a `Build` step (`run: npm run build`) to the `backend` job after `Typecheck`. Verified in CI run 25687758702 (backend job log shows `Build: success`).
 - [x] Added a `Test (e2e)` step (`run: npm run test:e2e`) to the `backend` job after `Test`. Verified in CI run 25687758702 (backend job log shows both `Test: success` and `Test (e2e): success`). Also fixed a bit-rot in `backend/test/sync.e2e-spec.ts` (hard-coded past `expiresAt`) surfaced by promoting e2e into CI.
-- [x] Marked the three `Surfaced by PR #58 review` items as `[x]` in `docs/plans/2026-05-10_engineering-backlog-plan.md`. Verified by `grep -c '\[x\] .*Surfaced by PR #58 review' docs/plans/2026-05-10_engineering-backlog-plan.md` → `3`.
+- [x] Marked the three `Surfaced by PR #58 review` items complete at implementation time. The 2026-07-04 backlog cleanup later removed those historical tags from the active backlog; current evidence is `.github/workflows/ci.yml`.
 - [x] Opened PR #60 against `main`; CI run 25687758702 showed all three lanes `pass` (workflow-self glob forced them to run).
 - [x] After merging #60, validated skip path with PR #61 (docs-only README change). `gh run view 25688009020` showed `changes: success`, `android: skipped`, `backend: skipped`, `web: skipped`.
 
@@ -75,5 +75,5 @@ The workflow itself is in every set so that workflow edits always re-run everyth
 - [x] `backend` job includes both `Build` and `Test (e2e)` steps; CI run 25687758702 shows both steps succeeding.
 - [x] `gh pr checks 60` showed `android`, `backend`, `web` all `pass` on the PR (workflow edit forced all lanes to run).
 - [x] Follow-up docs-only PR #61 (https://github.com/narumiruna/kestrel/pull/61) demonstrated `android` / `backend` / `web` all `skipped` and only `changes` running (run 25688009020).
-- [x] `docs/plans/2026-05-10_engineering-backlog-plan.md` has all three `Surfaced by PR #58 review` items marked `[x]` (verified by `grep -c '\[x\] .*Surfaced by PR #58 review' docs/plans/2026-05-10_engineering-backlog-plan.md` → `3`).
+- [x] The three PR #58 CI follow-ups are implemented in `.github/workflows/ci.yml`; the active backlog was later curated and no longer carries the historical `Surfaced by PR #58 review` tags.
 - [x] PR #60 merged to `main` (commit `d622ba4`); PR #61 merged to `main` shortly after.

--- a/docs/plans/archived/2026-05-12_pr58-ci-followups-plan.md
+++ b/docs/plans/archived/2026-05-12_pr58-ci-followups-plan.md
@@ -29,7 +29,7 @@ Ordered; steps 1–4 are merge-blockers for #58, step 5 is post-merge backlog gr
 - [x] **Added explicit `prisma generate` step** in the `backend` job of `.github/workflows/ci.yml` after `npm ci`. Verified by `gh run view --job 75413868903 --log | grep "Generate Prisma client"` showing `Prisma schema loaded from prisma/schema.prisma` and the step succeeding.
 - [x] **Restored `npm run build` in `backend/README.md`** alongside `npm run typecheck`. Verified by `grep -E 'typecheck|build' backend/README.md` showing both `npm run typecheck` and `npm run build` in the validation block.
 - [x] **Tightened pre-commit `biome` hook `files:` pattern** in `.pre-commit-config.yaml` to `^web/.*\.(ts|tsx|js|jsx|json|jsonc|css)$`. Verified by `prek run biome --files web/README.md` → `Skipped (no files to check)` and `prek run biome --files web/app/layout.tsx` → `Passed`.
-- [x] **Filed three backlog entries** in `docs/plans/2026-05-10_engineering-backlog-plan.md` for: (a) per-workspace `paths:` filter on CI jobs, (b) optional `nest build` step in backend CI, (c) policy for promoting backend `test:e2e` into CI. Verified by `grep -c 'Surfaced by PR #58 review' docs/plans/2026-05-10_engineering-backlog-plan.md` → `3`.
+- [x] **Filed three backlog entries** in `docs/plans/2026-05-10_engineering-backlog-plan.md` for: (a) per-workspace `paths:` filter on CI jobs, (b) optional `nest build` step in backend CI, (c) policy for promoting backend `test:e2e` into CI. They were later implemented in PR #60; the 2026-07-04 backlog cleanup removed those historical tags from the active backlog.
 
 ## Risks
 
@@ -47,6 +47,6 @@ Ordered; steps 1–4 are merge-blockers for #58, step 5 is post-merge backlog gr
 - [x] Not applicable: `main` has no branch protection (`gh api repos/narumiruna/kestrel/branches/main/protection/required_status_checks/contexts` → `Branch not protected`), so there is no required-check list to align.
 - [x] `backend/README.md` lists both `npm run typecheck` and `npm run build` in the validation block (`grep -E 'typecheck|build' backend/README.md`).
 - [x] `.pre-commit-config.yaml` `biome` hook `files:` pattern excludes `web/README.md` and includes `web/app/**/*.tsx`, verified by `prek run biome --files web/README.md` (Skipped) and `prek run biome --files web/app/layout.tsx` (Passed).
-- [x] `docs/plans/2026-05-10_engineering-backlog-plan.md` contains three new `- [ ]` items tagged `Surfaced by PR #58 review` (paths filter, `nest build` in CI, e2e-in-CI policy), verified by `grep -c 'Surfaced by PR #58 review' docs/plans/2026-05-10_engineering-backlog-plan.md` → `3`.
+- [x] The three PR #58 follow-up items were filed, then implemented in PR #60; current evidence is `.github/workflows/ci.yml` rather than active backlog tags.
 - [x] PR #58 is merged to `main` (`gh pr view 58 --json state -q .state` → `MERGED`, merge commit `92aa04f`).
-- [ ] PR #59 is merged to `main` (verified by `gh pr view 59 --json state -q .state` returning `MERGED`).
+- [x] PR #59 is merged to `main` (`gh pr view 59 --json state,mergedAt,mergeCommit` returned `MERGED`, merge commit `44a6a7bfdda3d6ccd246c8edf8787b3fc77c3842`).

--- a/docs/plans/archived/2026-05-13_sharing-plan.md
+++ b/docs/plans/archived/2026-05-13_sharing-plan.md
@@ -54,7 +54,7 @@ The product MVP is mostly complete except route sharing. Backend already has `Ro
 - 2026-05-13 sharing follow-up validation:
   - `docs/plans/archived/2026-05-13_sharing-followups-plan.md` records the post-PR fixes for copy-by-visible-revision and idempotent share-link create, including command validation plus a local dev-stack smoke where the owner updated a route after the visitor loaded it, the copier still cloned the originally viewed snapshot, concurrent share-link create requests returned the same active link, and the public page returned HTTP `200`.
 - Remaining non-blocking follow-up:
-  - Android `Sync now` smoke after copying a shared route has been moved to `docs/plans/engineering-backlog-plan.md` because the sharing slice already emits standard `ROUTE` + `LIBRARY_ITEM` sync events and Android cloud sync behavior is tracked separately there.
+  - Android `Sync now` smoke after copying a shared route has been moved to `docs/plans/2026-05-10_engineering-backlog-plan.md` because the sharing slice already emits standard `ROUTE` + `LIBRARY_ITEM` sync events and Android cloud sync behavior is tracked separately there.
 
 ## Completion Checklist
 
@@ -63,4 +63,4 @@ The product MVP is mostly complete except route sharing. Backend already has `Ro
 - [x] Web route page can create and disable a latest share link. _Implemented in `web/app/dashboard/page.tsx` with backend endpoints under `backend/src/sharing/`, and the web app passes `npm run lint`, `npm run typecheck`, and `npm run build` on 2026-05-13._
 - [x] Public route URL works without login and does not expose private owner fields. _Implemented via `GET /shares/:token` + `web/app/share/[token]/page.tsx`; service tests assert disabled/expired rejection and sanitized public payloads without owner metadata._
 - [x] Signed-in user can copy a shared route and see it in their own library. _Verified on 2026-05-13 by a browser smoke run: owner account created `Smoke share route 193746`, public page rendered while logged out, copier account signed in and used `Copy to my library`, and the copied route then appeared in the copier dashboard route list._
-- [x] Android-specific post-copy `Sync now` verification is tracked separately in `docs/plans/engineering-backlog-plan.md`, so this sharing-slice plan can close on shipped backend/web behavior and recorded follow-up validation evidence.
+- [x] Android-specific post-copy `Sync now` verification is tracked separately in `docs/plans/2026-05-10_engineering-backlog-plan.md`, so this sharing-slice plan can close on shipped backend/web behavior and recorded follow-up validation evidence.

--- a/docs/plans/archived/2026-05-14_web-dashboard-ux-review-plan.md
+++ b/docs/plans/archived/2026-05-14_web-dashboard-ux-review-plan.md
@@ -2,6 +2,10 @@
 
 提升 Kestrel Web dashboard 的日常操作體驗，讓使用者能更直覺地管理 Places / Routes、建立 route、理解目前狀態，並降低誤操作與迷失成本。成功條件是：使用者不需要理解資料模型也能完成「新增 place → 以 place 作為 route 起點 → 編輯 waypoint → 儲存 / 分享」流程，且桌面與手機版都有清楚的視覺層級與操作路徑。
 
+## Archive note
+
+Archived on 2026-07-04 as superseded by later Web dashboard work: cartographer places/routes, Map/Library navigation, compact Share/Device actions, route editor UI fixes, route rendering consistency, and marker/linking polish. The implementation tasks below landed; the remaining checklist was manual review criteria rather than active implementation work.
+
 ## Context
 
 目前 Web UI 已有一致的輕量玻璃卡片視覺、Places / Routes tabs、可收合左側列表、MapLibre 地圖編輯器，以及 route 可從 0 個 waypoint 開始並可從 saved place 選起點。這些是好的基礎，但資訊架構、操作 feedback、空狀態與表單密度仍偏工程導向。
@@ -105,9 +109,9 @@
 
 ## Completion Checklist
 
-- [ ] New route 的 0/1/2 waypoint 狀態都有清楚下一步提示，並以手動 UI review 或截圖驗證。
-- [ ] 新增 waypoint 不會自動改變地圖 zoom，只有 `Fit route` 或 start-from-place 這類明確 action 會移動視野，並以手動測試驗證。
-- [ ] Route editor 的主要流程（命名、選起點、加點、儲存）在桌面版不需要閱讀 share / delete 等次要區塊即可完成，並以使用者驗收確認。
-- [ ] Places / favorite 在 route editor 中的文案一致，且無 favorite 時有明確前往建立 place 的 CTA，並以 empty state 手動測試驗證。
-- [ ] Delete route / place 有 confirmation 或等效防誤觸機制，並以手動測試確認不會單擊即刪除。
-- [ ] Web lint 通過：`cd web && npm run lint`，允許既有 Biome schema version info。
+- [x] Superseded: New route 0/1/2 waypoint guidance landed in `RouteEditor`; later route editor and Map/Library plans carried browser review evidence.
+- [x] Superseded: waypoint/fit behavior is covered by later route editor and route rendering consistency plans.
+- [x] Superseded: main route flow was replaced by the cartographer Map/Library dashboard and compact Share/Device actions.
+- [x] Superseded: Places/favorite copy and empty-state CTAs landed in `RouteEditor` and later Library navigation work.
+- [x] Delete route / place confirmation exists in `RouteEditor` and `PlaceEditor`.
+- [x] Superseded: Web lint/typecheck/build are covered by current CI and later archived Web plans.


### PR DESCRIPTION
## Summary
- curate active planning docs around roadmap, engineering backlog, and Android cloud validation
- archive superseded Web dashboard UX plan
- close stale archived checklist/path references

## Validation
- git diff --check