### PR TITLE
docs: add agent readiness plans

### DIFF
--- a/docs/plans/2026-07-08_agent-readiness-entry-plan.md
+++ b/docs/plans/2026-07-08_agent-readiness-entry-plan.md
@@ -1,0 +1,43 @@
+## Goal
+
+Use a staged, low-risk agent-readiness roadmap for Kestrel so the project first fixes discovery hygiene, then adds useful agent metadata, and avoids publishing unsupported OAuth/MCP/WebMCP claims.
+
+## Context
+
+This is the entry plan for the individual agent-readiness plans under `docs/plans/agent-readiness/`. It prioritizes work by implementation cost, product value, and risk of falsely advertising unsupported capabilities.
+
+## Non-Goals
+
+- Do not implement OAuth/OIDC, MCP, WebMCP, or DNS-AID just to satisfy a scanner.
+- Do not publish metadata that implies standards-compliant auth, MCP, or browser tool support before those capabilities exist.
+- Do not index capability URLs such as `/share/[token]` unless there is an explicit product decision to make shared content discoverable.
+
+## Plan
+
+- [ ] Implement the first-wave `robots.txt` bundle by combining `docs/plans/agent-readiness/2026-07-08_robots-crawl-rules-plan.md`, `docs/plans/agent-readiness/2026-07-08_ai-crawler-robots-rules-plan.md`, and `docs/plans/agent-readiness/2026-07-08_content-signals-robots-plan.md` into one coherent `web/public/robots.txt`; verify with local and production `curl -i /robots.txt` returning `200` plain text with wildcard, AI crawler, Content Signal, and sitemap rules.
+- [ ] Implement `docs/plans/agent-readiness/2026-07-08_sitemap-discovery-plan.md` with only approved canonical public URLs; verify `/sitemap.xml` returns `200` XML and excludes `/dashboard/*`, `/api/backend/*`, and tokenized `/share/[token]` URLs unless explicitly approved.
+- [ ] Implement `docs/plans/agent-readiness/2026-07-08_api-catalog-plan.md` as a conservative catalog that advertises real docs/status/service description resources only; verify `/.well-known/api-catalog` returns `application/linkset+json` and every advertised link resolves.
+- [ ] Implement `docs/plans/agent-readiness/2026-07-08_homepage-link-headers-plan.md` after the linked resources exist; verify `curl -I "$SITE_ORIGIN/"` advertises only working resources such as the sitemap and API catalog.
+- [ ] Reassess `docs/plans/agent-readiness/2026-07-08_agent-skills-index-plan.md` after API docs/catalog stabilize; verify with user acceptance before authoring Kestrel-specific skill documents.
+- [ ] Reassess `docs/plans/agent-readiness/2026-07-08_markdown-negotiation-plan.md` only if Cloudflare or another low-maintenance edge feature is available, or if Kestrel adds public docs/content pages; verify with a documented go/no-go decision.
+- [ ] Defer `docs/plans/agent-readiness/2026-07-08_dns-aid-discovery-plan.md` until the DNS provider, DNSSEC setup, and DNS-AID draft maturity justify the operational cost; verify with an explicit accepted follow-up decision before implementation.
+- [ ] Defer `docs/plans/agent-readiness/2026-07-08_oauth-discovery-metadata-plan.md`, `docs/plans/agent-readiness/2026-07-08_oauth-protected-resource-metadata-plan.md`, and `docs/plans/agent-readiness/2026-07-08_auth-md-agent-registration-plan.md` until Kestrel has or intentionally adopts standards-compliant OAuth/OIDC and agent registration; verify no OAuth/Auth.md metadata is published as a placeholder.
+- [ ] Defer `docs/plans/agent-readiness/2026-07-08_mcp-server-card-plan.md` and `docs/plans/agent-readiness/2026-07-08_webmcp-browser-tools-plan.md` until agent operation of Kestrel becomes an explicit product feature with permissions and confirmation UX; verify no MCP/WebMCP metadata is published before working tools exist.
+
+## Risks
+
+- Publishing placeholder metadata can cause agents to trust capabilities that do not exist.
+- Making shared token URLs indexable can expose by-link content more broadly than intended.
+- Too many independent discovery files can drift unless implemented in staged bundles with shared validation.
+
+## Rollback / Recovery
+
+- If a published discovery resource is wrong, remove its homepage `Link` header and well-known/static endpoint first, then redeploy; verify with production `curl` that agents no longer discover the stale resource.
+- If crawler policy is wrong, update `robots.txt` as the single source of truth and verify production response after deploy.
+
+## Completion Checklist
+
+- [ ] First-wave discovery hygiene is complete, verified by production `curl` evidence for `/robots.txt`, `/sitemap.xml`, `/.well-known/api-catalog`, and homepage `Link` headers.
+- [ ] Second-wave candidates have explicit go/no-go decisions, verified by checked items or accepted notes in the agent skills and markdown negotiation plans.
+- [ ] Deferred capabilities are not falsely advertised, verified by production checks that OAuth/Auth.md/DNS-AID/MCP/WebMCP endpoints or records are absent unless backed by working implementations.
+- [ ] Completed child plans are archived according to `docs/plans/README.md`, verified by their checked completion checklists and files under `docs/plans/archived/`.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,6 +1,6 @@
 # Kestrel plans
 
-Top-level `*-plan.md` files are active. Closed or superseded plans live in `archived/`.
+Top-level `*-plan.md` files are active. Grouped active plan sets may live in a subdirectory with a top-level entry plan. Closed or superseded plans live in `archived/`.
 
 ## Active files
 
@@ -9,6 +9,8 @@ Top-level `*-plan.md` files are active. Closed or superseded plans live in `arch
 | `2026-05-10_product-roadmap-plan.md` | Current product state and next bets |
 | `2026-05-10_engineering-backlog-plan.md` | Curated ops/release/manual-validation backlog |
 | `2026-05-13_android-cloud-options-autofill-url-plan.md` | Manual validation only |
+| `2026-07-08_agent-readiness-entry-plan.md` | Entry plan for staged agent-readiness work |
+| `agent-readiness/` | Child plans for individual agent-readiness goals |
 
 ## Rules
 

--- a/docs/plans/agent-readiness/2026-07-08_agent-skills-index-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_agent-skills-index-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Publish an Agent Skills discovery index at `/.well-known/agent-skills/index.json` with schema metadata and SHA-256 digests for site-specific skill documents.
+
+## Context
+
+- The requested index should describe Kestrel capabilities for agents, not merely copy third-party readiness skill documents.
+- The web app already serves static well-known files from `web/public/.well-known/`.
+- References: Agent Skills Discovery RFC v0.2.0, agentskills.io, and `https://isitagentready.com/.well-known/agent-skills/agent-skills/SKILL.md`.
+
+## Unknowns
+
+- Which Kestrel skills should be advertised first, such as API usage, auth, MCP tools, or WebMCP browser actions.
+- The current exact digest format required by the RFC, for example whether values are raw hex or prefixed with `sha256:`.
+
+## Plan
+
+- [ ] Select the first set of site-specific skills and define each skill's name, type, description, and canonical URL; verify with user/product acceptance or a committed skill inventory.
+- [ ] Author skill documents under `web/public/.well-known/agent-skills/` with concise instructions and accurate links to Kestrel docs/endpoints; verify each file is fetchable locally with `curl -i`.
+- [ ] Add a generation script, such as `scripts/generate-agent-skills-index.mjs`, that calculates SHA-256 digests and writes `web/public/.well-known/agent-skills/index.json`; verify by running the script and checking `sha256sum`/`shasum -a 256` matches the index.
+- [ ] Include `$schema` and a `skills` array with `name`, `type`, `description`, `url`, and digest fields following the current RFC; verify with `jq` and schema review.
+- [ ] Add the index generation/check to the web validation or release workflow so digests stay current; verify with `just web-check` or a dedicated script in CI.
+- [ ] Deploy and verify `curl -i "$SITE_ORIGIN/.well-known/agent-skills/index.json"` returns `200` JSON and every skill URL/digest validates.
+
+## Risks
+
+- Stale digests make the index fail integrity checks.
+- Advertising skills that depend on unfinished API/MCP/auth work creates unusable agent instructions.
+
+## Rollback / Recovery
+
+- Remove the index and skill documents or prune unfinished skills; verify production no longer advertises invalid entries.
+
+## Completion Checklist
+
+- [ ] The skills index contains `$schema` and a valid `skills` array, verified by `jq` and RFC review.
+- [ ] Every advertised skill URL resolves and its SHA-256 digest matches the published document, verified by the generation/check script.
+- [ ] The index is generated or checked on publish, verified by CI/release workflow output or a documented release command.

--- a/docs/plans/agent-readiness/2026-07-08_ai-crawler-robots-rules-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_ai-crawler-robots-rules-plan.md
@@ -1,0 +1,37 @@
+## Goal
+
+Add explicit `robots.txt` rules for AI crawlers such as GPTBot, OAI-SearchBot, Claude-Web, and Google-Extended, plus a wildcard policy that matches Kestrel's content-use preferences.
+
+## Context
+
+- This plan modifies the same `web/public/robots.txt` owned by the general robots and Content Signals plans.
+- AI crawler user-agent tokens change over time, so the exact tokens should be verified against vendor documentation during implementation.
+- References: RFC 9309, Cloudflare AI Crawl Control, and `https://isitagentready.com/.well-known/agent-skills/ai-rules/SKILL.md`.
+
+## Unknowns
+
+- Kestrel's policy for AI training, AI search indexing, and agent input over public share content.
+- The current exact user-agent tokens for each vendor crawler.
+
+## Plan
+
+- [ ] Confirm the desired policy for AI crawlers, separating search/discovery bots from training crawlers; verify with explicit user acceptance or a committed policy note.
+- [ ] Verify current vendor user-agent tokens for OpenAI, Anthropic, Google, and any additional crawlers to control; verify by citing the source links in the implementation PR.
+- [ ] Update `web/public/robots.txt` with explicit AI crawler records and a wildcard record, preserving the general path rules and sitemap line; verify with `grep -nE 'GPTBot|OAI-SearchBot|Claude|Google-Extended|User-agent: \*' web/public/robots.txt`.
+- [ ] Add comments or docs that explain the policy without relying on comments for machine behavior; verify the final `robots.txt` remains RFC 9309-compatible.
+- [ ] Deploy and verify `curl -i "$SITE_ORIGIN/robots.txt"` returns the AI-specific records exactly as committed.
+
+## Risks
+
+- Nonstandard or misspelled user-agent tokens will not be honored by crawlers.
+- Overly broad disallow rules can reduce search visibility for public content.
+
+## Rollback / Recovery
+
+- Revert the AI-specific records to the prior wildcard policy and redeploy; verify production `robots.txt` matches the rollback commit.
+
+## Completion Checklist
+
+- [ ] AI crawler records and a wildcard record exist in `robots.txt`, verified by grep and production curl output.
+- [ ] The crawler policy is explicitly approved or documented, verified by a committed policy note or review comment.
+- [ ] The file remains valid robots plain text, verified by the general robots validation checks.

--- a/docs/plans/agent-readiness/2026-07-08_api-catalog-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_api-catalog-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Publish `/.well-known/api-catalog` as `application/linkset+json` with RFC 9727 linkset entries that help agents discover Kestrel APIs, service descriptions, docs, and status endpoints.
+
+## Context
+
+- Kestrel has a NestJS backend proxied by the Next.js web app at `/api/backend/*`.
+- Current API docs exist in `docs/remote-control-api.md`, but no OpenAPI service description is visible in the web root.
+- References: RFC 9727, RFC 9264, and `https://isitagentready.com/.well-known/agent-skills/api-catalog/SKILL.md`.
+
+## Unknowns
+
+- Whether the API catalog should describe only public endpoints or also authenticated endpoints.
+- Whether to generate OpenAPI from NestJS decorators or maintain a static OpenAPI file.
+
+## Plan
+
+- [ ] Inventory backend endpoints and classify public, authenticated, and admin-only API surfaces; verify with controller files under `backend/src/**/**.controller.ts` and `docs/remote-control-api.md`.
+- [ ] Choose an OpenAPI strategy: generated with NestJS Swagger or committed static `openapi.json`; verify the choice with a working `curl` or file output path for `service-desc`.
+- [ ] Add or expose a health/status endpoint suitable for `rel="status"`; verify with `curl -i http://127.0.0.1:3300/<status-path>` or the proxied `/api/backend/<status-path>`.
+- [ ] Implement `/.well-known/api-catalog` in the web app as a route handler or static file returning `Content-Type: application/linkset+json` and a top-level `linkset` array; verify with `curl -i http://127.0.0.1:3301/.well-known/api-catalog`.
+- [ ] Include link relations for `service-desc`, `service-doc`, and `status` with absolute or correctly relative URLs; verify the JSON with `jq '.linkset'` and manual review against RFC 9727 examples.
+- [ ] Reference the API catalog from homepage `Link` headers and allow it in `robots.txt`; verify with `curl -I "$SITE_ORIGIN/"` and `curl -i "$SITE_ORIGIN/.well-known/api-catalog"` after deploy.
+
+## Risks
+
+- Publishing stale or incomplete OpenAPI metadata can mislead agents into unsafe calls.
+- Exposing authenticated endpoint structure is acceptable only if it does not disclose sensitive implementation details.
+
+## Rollback / Recovery
+
+- Remove the API catalog route/header and redeploy; verify the well-known endpoint returns `404` or the prior behavior and homepage no longer advertises it.
+
+## Completion Checklist
+
+- [ ] `/.well-known/api-catalog` returns `200` with `Content-Type: application/linkset+json`, verified by production `curl -i` output.
+- [ ] The response contains a valid `linkset` array with `service-desc`, `service-doc`, and `status` relations, verified by `jq` and review against RFC 9727.
+- [ ] The advertised service description, documentation, and status URLs all resolve, verified by `curl -i` for each link.

--- a/docs/plans/agent-readiness/2026-07-08_auth-md-agent-registration-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_auth-md-agent-registration-plan.md
@@ -1,0 +1,39 @@
+## Goal
+
+Publish `/auth.md` and related OAuth metadata so agents can understand how to register, authenticate, obtain credentials, and handle claims or revocation for Kestrel APIs.
+
+## Context
+
+- Kestrel currently supports human registration/login with TOTP but does not expose an agent registration protocol.
+- This plan depends on the OAuth discovery and OAuth Protected Resource Metadata plans if agents need API tokens.
+- References: WorkOS Auth.md, `https://github.com/workos/auth.md`, and `https://isitagentready.com/.well-known/agent-skills/auth-md/SKILL.md`.
+
+## Unknowns
+
+- Whether agent registration should be self-service, manual approval, or unsupported for now.
+- Which agent identity types and credential types Kestrel will accept.
+- Whether claim and revocation URLs need new backend endpoints.
+
+## Plan
+
+- [ ] Decide the agent registration policy, identity types, credential types, and support contact; verify with a committed auth policy note or user acceptance.
+- [ ] Implement or document the registration path in `/auth.md`, including prerequisites, OAuth/OIDC discovery URLs, protected resource metadata URL, scopes, and revocation instructions; verify the markdown renders as plain text/markdown at the site root.
+- [ ] Add an `agent_auth` block to `/.well-known/oauth-authorization-server` only if Kestrel has a standards-compliant OAuth AS; verify the JSON field names against the Auth.md guidance and production `curl` output.
+- [ ] Implement any missing register, claim, or revocation endpoints before linking them; verify with backend tests and `curl -i` for each advertised endpoint.
+- [ ] Deploy and verify `curl -i "$SITE_ORIGIN/auth.md"` returns `200`, a markdown/plain text content type, and accurate registration instructions.
+- [ ] Add `auth.md` and auth discovery URLs to the API catalog or homepage `Link` headers if appropriate; verify links resolve.
+
+## Risks
+
+- Publishing registration instructions before endpoints exist can lead agents to fail or expose unsupported flows.
+- Agent registration can increase abuse risk if rate limits, approval, and revocation are not defined.
+
+## Rollback / Recovery
+
+- Remove `/auth.md`, the `agent_auth` metadata block, and related discovery links; verify production no longer advertises agent registration.
+
+## Completion Checklist
+
+- [ ] `/auth.md` returns accurate agent registration instructions, verified by production `curl -i "$SITE_ORIGIN/auth.md"` and policy review.
+- [ ] OAuth metadata includes `agent_auth` only when backed by working endpoints, verified by JSON review and backend tests.
+- [ ] All URLs referenced by `/auth.md` resolve or are explicitly marked manual/offline, verified by `curl -i` evidence.

--- a/docs/plans/agent-readiness/2026-07-08_content-signals-robots-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_content-signals-robots-plan.md
@@ -1,0 +1,37 @@
+## Goal
+
+Declare Kestrel AI content-usage preferences in `robots.txt` using `Content-Signal` directives for `ai-train`, `search`, and `ai-input`.
+
+## Context
+
+- Content Signals are draft/nonstandard preferences layered on top of `robots.txt`; they should not replace RFC 9309 crawl rules.
+- This plan modifies the same `web/public/robots.txt` as the robots and AI crawler rules plans.
+- References: contentsignals.org, draft-romm-aipref-contentsignals, and `https://isitagentready.com/.well-known/agent-skills/content-signals/SKILL.md`.
+
+## Unknowns
+
+- The desired values for `ai-train`, `search`, and `ai-input` for public Kestrel content.
+- Whether preferences should vary by path or apply site-wide.
+
+## Plan
+
+- [ ] Choose site-wide Content Signal values such as `ai-train=no`, `search=yes`, and `ai-input=no`, or document path-specific exceptions; verify with explicit user acceptance.
+- [ ] Confirm the current directive syntax from the Content Signals draft before editing; verify the implementation cites the version/source used.
+- [ ] Add `Content-Signal` directives to `web/public/robots.txt` without breaking existing `User-agent`, `Allow`, `Disallow`, or `Sitemap` records; verify with `grep -n '^Content-Signal:' web/public/robots.txt`.
+- [ ] Deploy and verify the production `robots.txt` includes the directives with `curl -i "$SITE_ORIGIN/robots.txt"`.
+- [ ] Document that Content Signals are preferences and not an access-control mechanism; verify the note appears in the implementation PR or policy docs.
+
+## Risks
+
+- Draft syntax can change and make the published directive stale.
+- Content Signals may be ignored by crawlers that only implement RFC 9309.
+
+## Rollback / Recovery
+
+- Remove or adjust the `Content-Signal` line and redeploy; verify production `robots.txt` no longer advertises the old preferences.
+
+## Completion Checklist
+
+- [ ] `robots.txt` contains approved `Content-Signal` directives, verified by grep and production curl output.
+- [ ] The directive syntax source is documented, verified by a cited reference in the implementation notes.
+- [ ] The project documents that Content Signals are advisory preferences, verified by committed docs or PR text.

--- a/docs/plans/agent-readiness/2026-07-08_dns-aid-discovery-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_dns-aid-discovery-plan.md
@@ -1,0 +1,40 @@
+## Goal
+
+Publish DNS for AI Discovery records under the production domain so agents can discover Kestrel entrypoints through DNS-AID SVCB/HTTPS records, with DNSSEC-authenticated responses.
+
+## Context
+
+- This work is primarily DNS/provider configuration, not Android app code.
+- Repository changes may still be useful for documenting zone snippets and deployment evidence.
+- References: DNS-AID draft, RFC 9460, and `https://isitagentready.com/.well-known/agent-skills/dns-aid/SKILL.md`.
+
+## Unknowns
+
+- The production domain and DNS provider.
+- Whether the DNS provider supports ServiceMode SVCB/HTTPS records and DNSSEC for the public zone.
+- The final set of agent entrypoints to advertise, such as index, API catalog, MCP, or A2A endpoints.
+
+## Plan
+
+- [ ] Identify the authoritative production domain, DNS provider, and DNSSEC status; verify with `dig NS $DOMAIN`, provider console evidence, and `dig +dnssec $DOMAIN SOA`.
+- [ ] Read the current DNS-AID draft and map Kestrel discovery resources to well-known owner names such as `_index._agents.$DOMAIN`; verify the chosen names and parameters in a committed `docs/agent-discovery-dns.md` note.
+- [ ] Prepare provider-specific SVCB/HTTPS record snippets using ServiceMode and draft-defined parameters such as `alpn` and endpoint data; verify syntax with the DNS provider's validation or a staging zone.
+- [ ] Publish records to DNS only after the referenced HTTPS endpoints exist; verify with `dig SVCB _index._agents.$DOMAIN` or `dig HTTPS _index._agents.$DOMAIN` as appropriate.
+- [ ] Enable or confirm DNSSEC signing for the public zone; verify with a validating resolver command such as `dig +dnssec +multi _index._agents.$DOMAIN SVCB` and evidence that authenticated data is returned.
+- [ ] Add rollback instructions to `docs/agent-discovery-dns.md`; verify the doc lists exact records to remove or disable.
+
+## Risks
+
+- The DNS-AID draft may change, requiring record format updates.
+- Incorrect DNS records can advertise unavailable endpoints for the TTL duration.
+- DNSSEC misconfiguration can make the domain fail validation.
+
+## Rollback / Recovery
+
+- Remove or disable the `_agents` records and wait for TTL expiry; verify with `dig` that the records no longer resolve while core site records still validate.
+
+## Completion Checklist
+
+- [ ] DNS-AID SVCB/HTTPS records resolve for the approved owner names, verified by `dig` output saved in the implementation notes.
+- [ ] Referenced HTTPS endpoints return successful responses, verified by `curl -i` for each endpoint URL advertised in DNS.
+- [ ] DNSSEC validation is active for the discovery zone, verified by validating resolver output with authenticated data.

--- a/docs/plans/agent-readiness/2026-07-08_homepage-link-headers-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_homepage-link-headers-plan.md
@@ -1,0 +1,37 @@
+## Goal
+
+Add RFC 8288 `Link` response headers to the homepage so agents can discover useful Kestrel resources such as the API catalog, API docs, service description, sitemap, and agent metadata.
+
+## Context
+
+- `web/app/page.tsx` redirects `/` to `/login`, so header behavior must be verified on the redirect response and on `/login` if agents follow redirects.
+- Candidate resources include `/.well-known/api-catalog`, `/docs/remote-control-api`, `/sitemap.xml`, `/.well-known/agent-skills/index.json`, and `/.well-known/mcp/server-card.json` once those plans land.
+- References: RFC 8288, RFC 9727 section 3, and `https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md`.
+
+## Unknowns
+
+- Which discovery resources will be implemented in the same release versus later.
+- Whether the production reverse proxy preserves multiple `Link` header values.
+
+## Plan
+
+- [ ] Select the homepage `Link` targets and relations, preferring registered relations such as `service-desc`, `service-doc`, and `status` plus documented extension relations only when needed; verify the selection in code review against IANA/RFC references.
+- [ ] Implement headers in `web/next.config.ts` via `headers()` or in Next middleware if redirect responses do not receive config headers; verify locally with `curl -I http://127.0.0.1:3301/`.
+- [ ] Include Link headers on `/login` if agents commonly follow the homepage redirect; verify with `curl -I http://127.0.0.1:3301/login`.
+- [ ] Add regression coverage with a lightweight header test or documented curl check in web validation; verify `cd web && npm run build` still passes.
+- [ ] Deploy and verify `curl -I "$SITE_ORIGIN/"` shows the expected `Link` header values without being stripped or combined incorrectly by the proxy/CDN.
+
+## Risks
+
+- Advertising resources before they exist creates broken discovery paths.
+- Incorrect relation types can make automated discovery ambiguous.
+
+## Rollback / Recovery
+
+- Remove the header configuration and redeploy; verify `curl -I "$SITE_ORIGIN/"` no longer contains the advertised links.
+
+## Completion Checklist
+
+- [ ] Homepage responses include RFC 8288-formatted `Link` headers, verified by production `curl -I "$SITE_ORIGIN/"` output.
+- [ ] Every advertised target returns the expected status and content type, verified by `curl -i` for each target.
+- [ ] Header behavior on the `/` redirect and `/login` page is documented by local or production curl evidence.

--- a/docs/plans/agent-readiness/2026-07-08_markdown-negotiation-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_markdown-negotiation-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Return Markdown representations of HTML pages when agents request `Accept: text/markdown`, while preserving HTML as the default browser response.
+
+## Context
+
+- The web front end is a Next.js app served from Docker Compose in this repository.
+- Cloudflare Markdown for Agents can satisfy this requirement if the production site is behind Cloudflare; otherwise the project needs an application or proxy implementation.
+- References: Cloudflare Markdown for Agents and `https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md`.
+
+## Unknowns
+
+- Whether the production site is proxied by Cloudflare or another programmable edge layer.
+- Which pages need Markdown negotiation first: only public pages, or authenticated dashboard pages after login.
+
+## Plan
+
+- [ ] Identify the production serving path and whether Cloudflare Markdown for Agents is available; verify with deploy documentation or CDN console evidence.
+- [ ] Choose the implementation strategy: enable Cloudflare Markdown for Agents if available, or add a repository-owned HTML-to-Markdown negotiation layer for approved public pages; verify the decision in a short docs note or PR description.
+- [ ] Implement Markdown negotiation for approved HTML routes so `Accept: text/markdown` returns `Content-Type: text/markdown` and browser requests still return HTML; verify locally with paired `curl -H 'Accept: text/markdown'` and default `curl -H 'Accept: text/html'` requests.
+- [ ] Add token-count metadata such as `x-markdown-tokens` when the selected platform supports it; verify with `curl -i` headers or mark not applicable with the platform reason.
+- [ ] Ensure generated Markdown excludes secrets and authenticated data unless the request is authorized; verify with review of public/authenticated route handling and a negative curl test.
+- [ ] Deploy and verify production negotiation with `curl -i -H 'Accept: text/markdown' "$SITE_ORIGIN/login"` and a default browser/HTML request.
+
+## Risks
+
+- HTML-to-Markdown conversion can leak hidden UI text or omit critical context.
+- A global edge feature may affect routes the app did not intend to expose as Markdown.
+
+## Rollback / Recovery
+
+- Disable the Cloudflare feature or remove the negotiation layer; verify `Accept: text/markdown` no longer changes the default HTML response.
+
+## Completion Checklist
+
+- [ ] Approved HTML routes return `Content-Type: text/markdown` for `Accept: text/markdown`, verified by production `curl -i` output.
+- [ ] Default browser requests still return HTML, verified by `curl -i -H 'Accept: text/html'` and a browser smoke check.
+- [ ] Markdown scope and auth behavior are documented, verified by a committed docs note or PR description.

--- a/docs/plans/agent-readiness/2026-07-08_mcp-server-card-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_mcp-server-card-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Publish an MCP Server Card at `/.well-known/mcp/server-card.json` that accurately advertises Kestrel's MCP server information, transport endpoint, and capabilities.
+
+## Context
+
+- The repository currently has a web app and NestJS API, but no obvious MCP server implementation.
+- Do not publish a server card that points to a nonexistent or incompatible MCP endpoint.
+- Reference: MCP Server Card SEP-1649 draft pull request and `https://isitagentready.com/.well-known/agent-skills/mcp-server-card/SKILL.md`.
+
+## Unknowns
+
+- Whether Kestrel should expose an MCP server, and which tools/resources are safe to expose.
+- Which transport to use for the server endpoint and which card schema version will be current at implementation time.
+
+## Plan
+
+- [ ] Review the current MCP server card draft/schema and decide whether Kestrel will implement MCP in this release; verify the decision in a design note or explicit user acceptance.
+- [ ] Define the MCP capabilities to expose, such as read-only library resources or remote-control tools, and mark dangerous actions that require user confirmation; verify against backend permissions and product policy.
+- [ ] Implement or configure an MCP server endpoint before publishing the card; verify with an MCP client smoke test or protocol-level curl/HTTP test for the chosen transport.
+- [ ] Add `web/app/.well-known/mcp/server-card.json/route.ts` or an equivalent static file returning `Content-Type: application/json` with `serverInfo`, transport endpoint, and capabilities; verify locally with `curl -i http://127.0.0.1:3301/.well-known/mcp/server-card.json`.
+- [ ] Reference the card from homepage `Link` headers, API catalog, or agent skills index only after the endpoint works; verify all discovery links resolve.
+- [ ] Deploy and verify production card and MCP transport with `curl -i "$SITE_ORIGIN/.well-known/mcp/server-card.json"` plus the chosen MCP smoke test.
+
+## Risks
+
+- The server-card schema is still being standardized and may change.
+- MCP tools can execute state-changing operations, so authorization and confirmation boundaries must be explicit.
+
+## Rollback / Recovery
+
+- Remove the server card and discovery links, then disable the MCP endpoint if needed; verify production no longer advertises MCP support.
+
+## Completion Checklist
+
+- [ ] A working MCP transport endpoint exists before the card is advertised, verified by an MCP smoke test or protocol-level test.
+- [ ] `/.well-known/mcp/server-card.json` returns valid JSON with `serverInfo`, transport, and capabilities, verified by production `curl` and schema review.
+- [ ] Discovery links to the card are present only when the MCP endpoint is healthy, verified by homepage/API catalog curl output.

--- a/docs/plans/agent-readiness/2026-07-08_oauth-discovery-metadata-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_oauth-discovery-metadata-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Publish OAuth 2.0 Authorization Server Metadata or OpenID Connect Discovery metadata so agents can discover how to authenticate with Kestrel APIs.
+
+## Context
+
+- Kestrel currently has custom username/password, TOTP, refresh, and HMAC-signed bearer access-token endpoints under `backend/src/auth`; access tokens are not JWTs and no JWKS endpoint exists.
+- Do not publish OAuth/OIDC metadata that implies standards-compliant behavior unless the corresponding protocol endpoints actually exist.
+- References: OpenID Connect Discovery 1.0, RFC 8414, and `https://isitagentready.com/.well-known/agent-skills/oauth-discovery/SKILL.md`.
+
+## Unknowns
+
+- Whether Kestrel should implement full OAuth/OIDC or declare the goal not applicable until a standards-compliant auth server exists.
+- The intended issuer URL, supported grant types, scopes, and client registration policy.
+
+## Plan
+
+- [ ] Decide whether this release will implement standards-compliant OAuth/OIDC discovery or explicitly mark it not applicable; verify with user/product acceptance because the current custom auth is not OAuth/OIDC.
+- [ ] If proceeding, choose OIDC (`/.well-known/openid-configuration`) or pure OAuth (`/.well-known/oauth-authorization-server`) and define issuer, authorization endpoint, token endpoint, JWKS requirements, grant types, and scopes; verify in an auth design note.
+- [ ] Implement missing protocol endpoints or adapt existing auth endpoints only where semantics match the chosen spec; verify with auth unit/e2e tests in `backend`.
+- [ ] Publish the selected well-known metadata from the web or backend origin with correct `Content-Type: application/json`; verify locally with `curl -i http://127.0.0.1:3301/.well-known/oauth-authorization-server` or the OIDC path.
+- [ ] Add discovery links to the API catalog, protected resource metadata, and homepage `Link` headers where appropriate; verify all linked URLs resolve.
+- [ ] Deploy and verify production metadata with `curl -i "$SITE_ORIGIN/.well-known/oauth-authorization-server"` or `curl -i "$SITE_ORIGIN/.well-known/openid-configuration"`.
+
+## Risks
+
+- Faking OAuth metadata over custom auth can break agents and create security misunderstandings.
+- Adding OAuth/OIDC changes auth surface area and requires threat modeling, token validation, and client registration decisions.
+
+## Rollback / Recovery
+
+- Remove the well-known metadata and discovery links if protocol support is incomplete; verify agents no longer discover unsupported auth metadata.
+
+## Completion Checklist
+
+- [ ] The project either publishes standards-compliant OAuth/OIDC metadata or records explicit not-applicable acceptance, verified by the auth design note.
+- [ ] If published, the metadata endpoint returns `200` JSON with issuer, authorization endpoint, token endpoint, JWKS URI when required, and supported grant types, verified by production `curl` and spec review.
+- [ ] Authentication behavior is covered by backend tests, verified by `cd backend && npm run test` or targeted auth test output.

--- a/docs/plans/agent-readiness/2026-07-08_oauth-protected-resource-metadata-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_oauth-protected-resource-metadata-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Publish `/.well-known/oauth-protected-resource` so agents can discover Kestrel's protected API resource identifier, authorization servers, and supported scopes.
+
+## Context
+
+- Most Kestrel backend endpoints require the existing bearer session token through `SessionAuthGuard`.
+- Protected Resource Metadata depends on a truthful OAuth/OIDC authorization-server story; coordinate with the OAuth discovery plan.
+- References: RFC 9728 and `https://isitagentready.com/.well-known/agent-skills/oauth-protected-resource/SKILL.md`.
+
+## Unknowns
+
+- The resource identifier for the Kestrel API, likely `$SITE_ORIGIN/api/backend` or the backend origin.
+- Whether Kestrel will define OAuth scopes or keep a single authenticated-user capability model.
+
+## Plan
+
+- [ ] Resolve the OAuth discovery dependency: confirm an authorization server URL exists or record not-applicable acceptance; verify by linking to the completed OAuth discovery decision.
+- [ ] Define the protected resource identifier and scope taxonomy for places, routes, sync, sharing, and remote-control APIs; verify with an auth/API design note and controller inventory.
+- [ ] Implement `/.well-known/oauth-protected-resource` with `resource`, `authorization_servers`, and `scopes_supported` values that match actual enforcement; verify locally with `curl -i http://127.0.0.1:3301/.well-known/oauth-protected-resource`.
+- [ ] If scopes are advertised, enforce or validate those scopes in backend authorization checks before publishing; verify with backend unit/e2e tests for allowed and denied scopes.
+- [ ] Reference the protected resource metadata from API docs/catalog where useful; verify linked resources resolve.
+- [ ] Deploy and verify production metadata with `curl -i "$SITE_ORIGIN/.well-known/oauth-protected-resource"` returning `200` JSON.
+
+## Risks
+
+- Advertising scopes not enforced by backend code gives agents false security semantics.
+- Publishing resource metadata without an actual authorization server leaves agents unable to obtain usable tokens.
+
+## Rollback / Recovery
+
+- Remove the protected resource metadata route and any discovery links; verify production no longer advertises unsupported PRM data.
+
+## Completion Checklist
+
+- [ ] `/.well-known/oauth-protected-resource` is published only after the authorization-server dependency is satisfied or explicitly accepted as not applicable, verified by the linked auth decision.
+- [ ] The metadata contains resource, authorization server, and scope data that matches backend behavior, verified by code review and auth tests.
+- [ ] Production returns `200` JSON for the metadata endpoint, verified by `curl -i "$SITE_ORIGIN/.well-known/oauth-protected-resource"`.

--- a/docs/plans/agent-readiness/2026-07-08_robots-crawl-rules-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_robots-crawl-rules-plan.md
@@ -1,0 +1,37 @@
+## Goal
+
+Publish `/robots.txt` at the Kestrel site root with valid RFC 9309 crawl records, explicit `User-agent` directives, path allow/disallow rules, and a `200` plain-text response.
+
+## Context
+
+- The web site is the Next.js app in `web/`; static root files can live in `web/public/`.
+- This plan should be coordinated with the sitemap, AI-crawler rules, and Content Signals plans so there is one authoritative `robots.txt`.
+- References: RFC 9309 and `https://isitagentready.com/.well-known/agent-skills/robots-txt/SKILL.md`.
+
+## Unknowns
+
+- The final production origin and whether any reverse proxy/CDN overrides `/robots.txt`.
+- The intended crawl policy for public share pages versus authenticated dashboard/API paths.
+
+## Plan
+
+- [ ] Inventory current root/static routes for conflicting robots handling; verify with `find web/app web/public -maxdepth 4 -type f | sort` and confirm no other `robots.txt` route exists.
+- [ ] Define a crawl policy matrix for `/`, `/login`, `/share/*`, `/dashboard/*`, `/api/backend/*`, and `/.well-known/*`; verify with explicit user acceptance or a committed policy note in this file before implementation.
+- [ ] Create `web/public/robots.txt` with at least `User-agent: *`, explicit `Allow`/`Disallow` lines for key paths, and no HTML; verify the file contents with `file web/public/robots.txt` and `grep -n '^User-agent:' web/public/robots.txt`.
+- [ ] Build and serve the web app locally; verify with `cd web && npm run build` and `curl -i http://127.0.0.1:3301/robots.txt` after `npm run start` returns `200` and `Content-Type: text/plain`.
+- [ ] Deploy through the production path; verify with `curl -i "$SITE_ORIGIN/robots.txt"` returning `200`, `Content-Type: text/plain`, and the committed crawl records.
+
+## Risks
+
+- A permissive default can expose private dashboard URLs to indexing even when auth blocks content.
+- Multiple plans touching `robots.txt` can overwrite one another unless implemented as one consolidated file.
+
+## Rollback / Recovery
+
+- Revert the `robots.txt` change or replace it with `User-agent: *` plus conservative `Disallow` rules; verify rollback with `curl -i "$SITE_ORIGIN/robots.txt"`.
+
+## Completion Checklist
+
+- [ ] `/robots.txt` is valid plain text with at least one `User-agent` record, verified by `curl -i "$SITE_ORIGIN/robots.txt"` and `grep -n '^User-agent:' web/public/robots.txt`.
+- [ ] Crawl rules cover public, private, API, and well-known paths, verified by the committed `web/public/robots.txt` policy matrix.
+- [ ] The production endpoint returns `200`, verified by saved `curl -i "$SITE_ORIGIN/robots.txt"` output.

--- a/docs/plans/agent-readiness/2026-07-08_sitemap-discovery-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_sitemap-discovery-plan.md
@@ -1,0 +1,38 @@
+## Goal
+
+Publish `/sitemap.xml` with canonical public URLs, keep it updated when public routes change, and reference it from `/robots.txt`.
+
+## Context
+
+- The web site is the Next.js app in `web/` with public pages such as `/login` and dynamic share pages under `/share/[token]`.
+- A sitemap should list indexable canonical URLs only; authenticated dashboard/API routes should not be listed.
+- References: Sitemap protocol and `https://isitagentready.com/.well-known/agent-skills/sitemap/SKILL.md`.
+
+## Unknowns
+
+- The canonical production origin for absolute sitemap URLs.
+- Whether public share URLs should be indexable or excluded because tokens are capability URLs.
+
+## Plan
+
+- [ ] Inventory public routes in `web/app` and classify each as indexable or non-indexable; verify with a committed route inventory in this plan or a follow-up docs note.
+- [ ] Add a canonical origin configuration such as `NEXT_PUBLIC_SITE_ORIGIN` for sitemap generation; verify the deploy workflow or runtime env sets it for production.
+- [ ] Implement `web/app/sitemap.ts` or a generated `web/public/sitemap.xml` listing canonical public URLs with `lastmod` where available; verify with `curl -i http://127.0.0.1:3301/sitemap.xml` returning XML after local serve.
+- [ ] Update `web/public/robots.txt` to include `Sitemap: $SITE_ORIGIN/sitemap.xml`; verify with `grep -n '^Sitemap:' web/public/robots.txt`.
+- [ ] Add a route-change maintenance check to the web validation path, such as a script that compares `web/app` public routes with sitemap entries; verify with `cd web && npm run build` and the chosen script output.
+- [ ] Deploy and verify `curl -i "$SITE_ORIGIN/sitemap.xml"` returns `200`, `Content-Type` XML, absolute canonical URLs, and no authenticated API/dashboard URLs.
+
+## Risks
+
+- Listing share-token URLs can make private-by-link content discoverable.
+- Missing canonical origin configuration can produce localhost URLs in production.
+
+## Rollback / Recovery
+
+- Remove the sitemap reference from `robots.txt` and revert the sitemap generator/static file; verify production no longer advertises stale sitemap data.
+
+## Completion Checklist
+
+- [ ] `/sitemap.xml` lists only approved canonical public URLs, verified by reviewing the generated XML and route inventory.
+- [ ] `/robots.txt` references the sitemap, verified by `grep -n '^Sitemap:' web/public/robots.txt` and production `curl` output.
+- [ ] The sitemap stays current on publish, verified by a documented generation/check command in the web build or release workflow.

--- a/docs/plans/agent-readiness/2026-07-08_webmcp-browser-tools-plan.md
+++ b/docs/plans/agent-readiness/2026-07-08_webmcp-browser-tools-plan.md
@@ -1,0 +1,39 @@
+## Goal
+
+Support WebMCP on Kestrel web pages by registering browser-available tools through `navigator.modelContext.provideContext()` when the API is available.
+
+## Context
+
+- Kestrel's web UI is a Next.js/React app with authenticated dashboard actions for places, routes, sharing, and remote control.
+- WebMCP is browser-experimental; implementation must feature-detect support and preserve normal behavior for browsers without it.
+- References: WebMCP draft, Chrome WebMCP article, and `https://isitagentready.com/.well-known/agent-skills/webmcp/SKILL.md`.
+
+## Unknowns
+
+- Which site actions should be exposed as tools, and which require explicit user confirmation.
+- Browser support and exact TypeScript surface for `navigator.modelContext` at implementation time.
+
+## Plan
+
+- [ ] Review current WebMCP API docs and define an ambient TypeScript type for `navigator.modelContext.provideContext`; verify `cd web && npm run typecheck` accepts the type without `any` leaks beyond the boundary.
+- [ ] Choose an initial safe tool set, such as reading current route/place context, navigating to dashboard sections, or preparing share links, and exclude destructive actions unless confirmation is built in; verify with user/product acceptance.
+- [ ] Implement a client-only `WebMcpProvider` component that feature-detects `navigator.modelContext?.provideContext()` and registers tool definitions with `name`, `description`, `inputSchema`, and `execute`; verify no server-side rendering errors in `cd web && npm run build`.
+- [ ] Reuse existing authenticated API client/session handling for tool execution and return structured success/error results; verify with unit-level tests or a manual authenticated browser smoke test.
+- [ ] Add privacy and permission guards so tools do not expose authenticated data to unsupported contexts or anonymous pages; verify by testing logged-out and logged-in page loads.
+- [ ] Validate in a WebMCP-capable browser or experimental Chrome build; verify via DevTools or browser agent tooling that tools are detected on page load.
+
+## Risks
+
+- The WebMCP API may change and break experimental implementations.
+- Tools that mutate places, routes, or devices can cause user-visible state changes if confirmation is missing.
+
+## Rollback / Recovery
+
+- Remove the provider from `web/app/layout.tsx` or gate it behind a feature flag; verify page load no longer registers WebMCP tools.
+
+## Completion Checklist
+
+- [ ] WebMCP tools are registered only in supported browsers, verified by a browser/DevTools smoke test and absence of errors in unsupported browsers.
+- [ ] Each registered tool has name, description, JSON Schema input, and execute callback, verified by code review of the provider.
+- [ ] Web build and typecheck pass, verified by `cd web && npm run typecheck && npm run build`.
+- [ ] Browser validation evidence includes the tested URL and viewport or screenshot, verified per project web UI validation rules.


### PR DESCRIPTION
## Summary
- add an entry plan for staged agent-readiness work
- group individual agent-readiness child plans under `docs/plans/agent-readiness/`
- update the plans README to document grouped active plans

## Verification
- `git diff --check origin/main...HEAD`
- `just check && just lint` could not run in this environment because the configured/default `JAVA_HOME` does not exist: `/Applications/Android Studio.app/Contents/jbr/Contents/Home`
