### PR TITLE
feat(web): edit routes directly from map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,13 @@
 - DataStore schema 變更要保持向前相容：`Json { ignoreUnknownKeys = true }` 已開；新欄位用 `T? = null` 預設。
 - pre-commit hooks（prek）：spotless、end-of-files、trailing whitespace、merge conflicts、mixed line endings。NEVER `--no-verify`。
 
+## UI/UX 原則
+
+- 優先降低單一畫面的資訊與操作密度，讓主要任務與下一步清楚可辨；避免同時呈現過多元素、CTA 或功能，以減少使用者的認知負荷。
+- 這不代表刪除或弱化功能。保留完整能力，並以漸進揭露（progressive disclosure）將次要、低頻或進階操作收納到符合情境的位置，例如次級頁面、overflow menu、dialog 或可展開區塊。
+- 被收納的功能仍須容易發現、理解與使用：入口命名清楚、位置符合使用情境、導覽結果可預期。不可為追求極簡而讓功能難找，或增加不必要的操作步驟。
+- 新增畫面元素或操作入口前，先確認現有導覽或操作是否已涵蓋相同目的；避免重複 CTA 與功能重疊。
+
 ## 領域注意事項
 
 - Mock GPS 需要 dev options 開「Select mock location app」指到本 app；UI 用 `StatusBanner` 顯示是否有權限。

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -35,5 +35,6 @@
 
 ## TASTE
 
+- Prefer progressive disclosure in UI/UX: keep each screen focused on its primary task, preserve secondary/advanced functionality in clear contextual locations, and avoid redundant CTAs or extra mode-switch clicks.
 - When reviewing or closing plan docs, do not move unfinished items into backlog/other plans just to make the current plan archivable unless the user explicitly asks for that re-scoping.
 - Keep local Docker Compose optimized for live reload, but keep deploy Compose production-only: no source bind mounts, built images, `next start`, and Nest `start:prod` after Prisma migrations.

--- a/docs/plans/archived/2026-06-28_web-map-library-navigation-plan.md
+++ b/docs/plans/archived/2026-06-28_web-map-library-navigation-plan.md
@@ -65,7 +65,7 @@ The current dashboard has top tabs for Places and Routes, and each page combines
 ## 2026-07-14 Implementation Audit
 
 - Restored the top-level `Map` / `Library` tabs above the full-width status strip after a later CSS pass had covered them; browser measurements show both tabs visible with the correct `aria-current` state at `1200×792` and `390×844`.
-- Removed the redundant Map notebook `Open Library` card. The selection preview now exposes `Edit route` / `Edit place` and carries the selected item ID into Library so the matching editor opens.
+- Removed the redundant Map notebook `Open Library` card. A later direct-editing follow-up also removed the intermediate `Edit route` action so selected routes can be changed in place.
 - Reverified `/dashboard` → `/dashboard/map`, `/dashboard/library` → `/dashboard/library/routes`, and the compatibility `/dashboard/places` and `/dashboard/routes` experiences in Chrome.
 - Reverified Place and Route create, update, and delete flows against the seeded Web test stack; temporary smoke records were deleted afterward.
 - Reverified `g m`, `g l`, `g p`, and `g r`, including that shortcuts do not navigate while a search input is focused.

--- a/docs/plans/archived/2026-07-14_map-direct-route-editing-plan.md
+++ b/docs/plans/archived/2026-07-14_map-direct-route-editing-plan.md
@@ -1,0 +1,35 @@
+## Goal
+
+Make the selected route immediately editable from the Map workspace, without an `Edit route` mode-switch button. Success means route fields and waypoints can be changed and saved in place while Map / Library remain clear top-level workspaces.
+
+## Context
+
+The restored Map / Library navigation exposed a redundant `Edit route` action in the Map selection card. Requiring that action adds a mode transition before the primary route task. The existing `RouteEditor` and `RouteMapEditor` already provide direct editing and should be reused rather than duplicated.
+
+## Non-Goals
+
+- Do not redesign direct Place editing in this change.
+- Do not remove Library CRUD or compatibility routes.
+- Do not add a second map implementation or backend API.
+
+## Plan
+
+- [x] Replace the Map route preview with the existing controlled `RouteMapEditor`, preserving selected, hovered, focus, fit, and draft waypoint state; verified map-click changed the draft from 7 to 8 waypoints and Refresh restored 7 in Chrome.
+- [x] Render the existing `RouteEditor` directly in the Map route card and save changes through the current route API followed by shared-data refresh; verified temporary route-name and waypoint edits persisted after refresh and were restored afterward without an intermediate Edit button.
+- [x] Guard route selection and browser exit when the Map route draft is dirty; verified selecting another route displayed the discard prompt and kept the current draft when rejected.
+- [x] Remove the redundant Map route action and selected-item query plumbing, while keeping Places preview-only and top-level Map / Library navigation visible; verified at `1200×792` and `390×844`.
+- [x] Run Web and repository quality gates; verified with `just check`, `just lint`, `cd web && npm run typecheck`, `cd web && npm run build`, and `git diff --check`.
+
+## Risks
+
+- Reusing the full route editor can make the Map card dense; keep existing settings and waypoint sections collapsible and avoid adding another action layer.
+- Controlled draft state can become stale when selection changes; reset it from the selected route and protect unsaved changes before switching.
+
+## Completion Checklist
+
+- [x] A selected route is immediately editable in Map with no `Edit route` button, verified at `http://localhost:3401/dashboard/map` in Chrome.
+- [x] Route settings and waypoint changes work in place; temporary name and eighth-waypoint edits persisted after save/refresh and were restored against the Web test stack.
+- [x] Unsaved route changes are not silently discarded when selecting another route, verified by rejecting the discard prompt in Chrome.
+- [x] Places preview, Library navigation, and route selection remain usable, verified by switching Places/Routes and Map/Library in Chrome.
+- [x] Desktop and mobile Map layouts are visually reviewed at `1200×792` and `390×844`; evidence is `/tmp/kestrel-map-direct-route-desktop.png` and `/tmp/kestrel-map-library-map-mobile.png`.
+- [x] Required quality gates pass with no generated cache files left in the diff, verified by command output and `git status --short`.

--- a/web/app/dashboard/map/page.tsx
+++ b/web/app/dashboard/map/page.tsx
@@ -3,25 +3,27 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { IndexCard } from '@/components/cartographer/IndexCard';
 import { KeyboardCheatsheet } from '@/components/cartographer/KeyboardCheatsheet';
 import { ScaleBar } from '@/components/cartographer/ScaleBar';
 import { Stage } from '@/components/cartographer/Stage';
 import { StatusStrip } from '@/components/cartographer/StatusStrip';
 import { UserMark } from '@/components/cartographer/UserMark';
 import { useKeyboardShortcuts } from '@/components/cartographer/useKeyboardShortcuts';
+import RouteEditor from '@/components/dashboard/RouteEditor';
 import { useDashboardLibraryData } from '@/components/dashboard/useDashboardLibraryData';
 import {
   formatCoord,
   formatMode,
   formatRouteDistanceFromWaypoints,
 } from '@/components/dashboard/utils';
-import type { Place, Route } from '@/lib/api';
+import type { Place, Route, RouteInput, RouteWaypoint } from '@/lib/api';
 
 const CartographerPlaceMap = dynamic(
   () => import('@/components/cartographer/CartographerPlaceMap'),
   { ssr: false },
 );
-const RouteMapPreview = dynamic(() => import('@/components/RouteMapPreview'), { ssr: false });
+const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), { ssr: false });
 const ZoomStack = dynamic(
   () => import('@/components/cartographer/ZoomStack').then((module) => module.ZoomStack),
   { ssr: false },
@@ -56,6 +58,12 @@ export default function DashboardMapPage() {
   const [isLibraryCollapsed, setIsLibraryCollapsed] = useState(false);
   const [isPreviewCollapsed, setIsPreviewCollapsed] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [draftWaypoints, setDraftWaypoints] = useState<RouteWaypoint[]>([]);
+  const [selectedWaypointIndex, setSelectedWaypointIndex] = useState<number | null>(null);
+  const [hoveredWaypointIndex, setHoveredWaypointIndex] = useState<number | null>(null);
+  const [focusTarget, setFocusTarget] = useState<RouteWaypoint | null>(null);
+  const [fitRequest, setFitRequest] = useState(0);
+  const [isRouteDirty, setIsRouteDirty] = useState(false);
 
   const selectedPlace = useMemo(
     () => places.find((place) => place.id === selectedPlaceId) ?? null,
@@ -91,6 +99,35 @@ export default function DashboardMapPage() {
   }, [query, routes]);
   const lastUpdatedLabel = useRelativeUpdatedLabel(lastLoadedAt);
 
+  useEffect(() => {
+    const nextWaypoints = getRouteWaypoints(selectedRoute);
+
+    setDraftWaypoints(nextWaypoints);
+    setSelectedWaypointIndex(null);
+    setHoveredWaypointIndex(null);
+    setFocusTarget(null);
+    setIsRouteDirty(false);
+
+    if (nextWaypoints.length > 0) {
+      setFitRequest((currentRequest) => currentRequest + 1);
+    }
+  }, [selectedRoute]);
+
+  useEffect(() => {
+    if (!isRouteDirty) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isRouteDirty]);
+
   useKeyboardShortcuts({
     onClose: () => setIsHelpOpen(false),
     onFocusSearch: () => searchRef.current?.focus(),
@@ -116,11 +153,56 @@ export default function DashboardMapPage() {
     });
   }
 
-  const routeWaypoints =
-    selectedRoute?.currentRevision?.waypoints.map((waypoint) => ({
-      latitude: waypoint.latitude,
-      longitude: waypoint.longitude,
-    })) ?? [];
+  async function saveRoute(input: RouteInput) {
+    if (selectedRoute == null) {
+      return;
+    }
+
+    await auth.apiRequest<Route>(`/routes/${selectedRoute.id}`, {
+      body: JSON.stringify(input),
+      method: 'PATCH',
+    });
+    setIsRouteDirty(false);
+    await refresh();
+  }
+
+  function confirmRouteDraftDiscard(): boolean {
+    return (
+      !isRouteDirty || window.confirm('Discard unsaved route changes? Save first to keep them.')
+    );
+  }
+
+  function selectMapKind(kind: MapKind) {
+    if (kind === activeKind || (activeKind === 'routes' && !confirmRouteDraftDiscard())) {
+      return;
+    }
+
+    if (activeKind === 'routes') {
+      setDraftWaypoints(getRouteWaypoints(selectedRoute));
+      setIsRouteDirty(false);
+    }
+    setActiveKind(kind);
+  }
+
+  function selectRoute(routeId: string) {
+    if (routeId === selectedRouteId || !confirmRouteDraftDiscard()) {
+      return;
+    }
+
+    setIsRouteDirty(false);
+    setSelectedRouteId(routeId);
+  }
+
+  function refreshMapData() {
+    if (activeKind === 'routes' && !confirmRouteDraftDiscard()) {
+      return;
+    }
+
+    setIsRouteDirty(false);
+    void refresh();
+  }
+
+  const routeWaypoints = draftWaypoints;
   const map =
     activeKind === 'places' ? (
       <CartographerPlaceMap
@@ -134,16 +216,19 @@ export default function DashboardMapPage() {
         }}
       />
     ) : (
-      <RouteMapPreview
+      <RouteMapEditor
         className="cartographer-map"
-        interactive
+        fitRequest={fitRequest}
+        focusTarget={focusTarget}
+        hoveredWaypointIndex={hoveredWaypointIndex}
+        selectedWaypointIndex={selectedWaypointIndex}
         waypoints={routeWaypoints}
+        onChange={setDraftWaypoints}
+        onHoverWaypoint={setHoveredWaypointIndex}
         onReady={setViewportControls}
+        onSelectWaypoint={setSelectedWaypointIndex}
       />
     );
-  const libraryPath =
-    activeKind === 'places' ? '/dashboard/library/places' : '/dashboard/library/routes';
-  const selectedItemId = activeKind === 'places' ? selectedPlaceId : selectedRouteId;
   const title =
     activeKind === 'places'
       ? (selectedPlace?.name ?? 'Places map')
@@ -163,6 +248,7 @@ export default function DashboardMapPage() {
       isRightPanelCollapsed={isPreviewCollapsed}
       map={map}
       mode={activeKind}
+      onBeforeWorkspaceChange={confirmRouteDraftDiscard}
       onToggleLeftPanel={() => setIsLibraryCollapsed((current) => !current)}
       onToggleMapFocus={() => {
         const shouldRestorePanels = isLibraryCollapsed && isPreviewCollapsed;
@@ -176,7 +262,7 @@ export default function DashboardMapPage() {
         error={error}
         isRefreshing={isLoading}
         lastUpdatedLabel={lastUpdatedLabel}
-        onRefresh={() => void refresh()}
+        onRefresh={refreshMapData}
       />
       <UserMark
         username={auth.session.user.username}
@@ -193,56 +279,72 @@ export default function DashboardMapPage() {
         selectedPlaceId={selectedPlaceId}
         selectedRouteId={selectedRouteId}
         onQueryChange={setQuery}
-        onSelectKind={setActiveKind}
+        onSelectKind={selectMapKind}
         onSelectPlace={(placeId) => {
           setActiveKind('places');
           setSelectedPlaceId(placeId);
         }}
         onSelectRoute={(routeId) => {
           setActiveKind('routes');
-          setSelectedRouteId(routeId);
+          selectRoute(routeId);
         }}
       />
-      <section className="index-card" aria-label="Map selection preview">
-        <span aria-hidden className="index-card-pin" />
-        <div className="index-card-breadcrumb breadcrumb">
-          Map / <span>{activeKind === 'places' ? 'Places' : 'Routes'}</span>
-        </div>
-        <header className="index-card-header">
-          <div>
-            <p className="index-card-stamp font-mono">Map view</p>
-            <h2 className="font-serif">{title}</h2>
-            <p>{subtitle}</p>
+      {activeKind === 'routes' ? (
+        <IndexCard
+          eyebrow={
+            <span>
+              Map / Routes / <span>{selectedRoute?.name ?? 'No route selected'}</span>
+            </span>
+          }
+          stamp={
+            selectedRoute?.currentRevision == null
+              ? 'Map editor'
+              : `Revision ${selectedRoute.currentRevision.revisionNumber}`
+          }
+          subtitle="Adjust the path and playback settings directly on the map."
+          title={title}
+          variant="route"
+        >
+          {selectedRoute == null ? (
+            <p className="muted no-margin">Select a route from the map notebook to edit it.</p>
+          ) : (
+            <RouteEditor
+              key={selectedRoute.id}
+              hoveredWaypointIndex={hoveredWaypointIndex}
+              mapMode="background"
+              places={places}
+              route={selectedRoute}
+              selectedWaypointIndex={selectedWaypointIndex}
+              waypoints={draftWaypoints}
+              onDirtyChange={setIsRouteDirty}
+              onFocusTargetChange={setFocusTarget}
+              onHoverWaypointIndexChange={setHoveredWaypointIndex}
+              onSave={saveRoute}
+              onSelectedWaypointIndexChange={setSelectedWaypointIndex}
+              onWaypointsChange={setDraftWaypoints}
+            />
+          )}
+        </IndexCard>
+      ) : (
+        <section className="index-card" aria-label="Map selection preview">
+          <span aria-hidden className="index-card-pin" />
+          <div className="index-card-breadcrumb breadcrumb">
+            Map / <span>Places</span>
           </div>
-          <div className="index-card-actions">
-            <button
-              className="secondary"
-              type="button"
-              onClick={() =>
-                router.push(
-                  selectedItemId == null
-                    ? libraryPath
-                    : `${libraryPath}?selected=${encodeURIComponent(selectedItemId)}`,
-                )
-              }
-            >
-              {activeKind === 'places'
-                ? selectedPlace == null
-                  ? 'Browse places'
-                  : 'Edit place'
-                : selectedRoute == null
-                  ? 'Browse routes'
-                  : 'Edit route'}
-            </button>
+          <header className="index-card-header">
+            <div>
+              <p className="index-card-stamp font-mono">Map view</p>
+              <h2 className="font-serif">{title}</h2>
+              <p>{subtitle}</p>
+            </div>
+          </header>
+          <div className="index-card-body stack">
+            <p className="muted no-margin">
+              Review saved coordinates here. Use Library to create, edit, share, or remove places.
+            </p>
           </div>
-        </header>
-        <div className="index-card-body stack">
-          <p className="muted no-margin">
-            Use Map for spatial review and quick device-ready context. Use Library for editing,
-            sharing, and cleanup.
-          </p>
-        </div>
-      </section>
+        </section>
+      )}
       <ZoomStack
         onFit={() => viewportControls?.fit()}
         onZoomIn={() => viewportControls?.zoomIn()}
@@ -348,6 +450,15 @@ function MapLibraryPanel({
         ) : null}
       </div>
     </aside>
+  );
+}
+
+function getRouteWaypoints(route: Route | null): RouteWaypoint[] {
+  return (
+    route?.currentRevision?.waypoints.map((waypoint) => ({
+      latitude: waypoint.latitude,
+      longitude: waypoint.longitude,
+    })) ?? []
   );
 }
 

--- a/web/app/dashboard/places/page.tsx
+++ b/web/app/dashboard/places/page.tsx
@@ -41,7 +41,6 @@ export default function PlacesDashboardPage() {
   const auth = useDashboardAuth();
   const router = useRouter();
   const searchRef = useRef<HTMLInputElement | null>(null);
-  const hasAppliedRequestedSelectionRef = useRef(false);
   const [places, setPlaces] = useState<Place[]>([]);
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
   const [draftPlaceCoords, setDraftPlaceCoords] = useState<{
@@ -93,17 +92,9 @@ export default function PlacesDashboardPage() {
 
     try {
       const nextPlaces = await auth.apiRequest<Place[]>('/places');
-      const requestedPlaceId = hasAppliedRequestedSelectionRef.current
-        ? null
-        : readRequestedSelectionId();
-      hasAppliedRequestedSelectionRef.current = true;
       setPlaces(nextPlaces);
       setSelectedPlaceId((current) =>
-        nextPlaces.some((place) => place.id === requestedPlaceId)
-          ? requestedPlaceId
-          : nextPlaces.some((place) => place.id === current)
-            ? current
-            : (nextPlaces[0]?.id ?? null),
+        nextPlaces.some((place) => place.id === current) ? current : (nextPlaces[0]?.id ?? null),
       );
       setLastLoadedAt(new Date());
     } catch (nextError) {
@@ -335,10 +326,6 @@ export default function PlacesDashboardPage() {
 
 function confirmDiscardUnsavedChanges(isDirty: boolean): boolean {
   return !isDirty || window.confirm('Discard unsaved changes? Save first to keep them.');
-}
-
-function readRequestedSelectionId(): string | null {
-  return new URLSearchParams(window.location.search).get('selected');
 }
 
 function NotebookSkeleton() {

--- a/web/app/dashboard/routes/page.tsx
+++ b/web/app/dashboard/routes/page.tsx
@@ -35,7 +35,6 @@ export default function RoutesDashboardPage() {
   const auth = useDashboardAuth();
   const router = useRouter();
   const searchRef = useRef<HTMLInputElement | null>(null);
-  const hasAppliedRequestedSelectionRef = useRef(false);
   const [places, setPlaces] = useState<Place[]>([]);
   const [routes, setRoutes] = useState<Route[]>([]);
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
@@ -85,18 +84,10 @@ export default function RoutesDashboardPage() {
         auth.apiRequest<Route[]>('/routes'),
         auth.apiRequest<Place[]>('/places'),
       ]);
-      const requestedRouteId = hasAppliedRequestedSelectionRef.current
-        ? null
-        : readRequestedSelectionId();
-      hasAppliedRequestedSelectionRef.current = true;
       setRoutes(nextRoutes);
       setPlaces(nextPlaces);
       setSelectedRouteId((current) =>
-        nextRoutes.some((route) => route.id === requestedRouteId)
-          ? requestedRouteId
-          : nextRoutes.some((route) => route.id === current)
-            ? current
-            : (nextRoutes[0]?.id ?? null),
+        nextRoutes.some((route) => route.id === current) ? current : (nextRoutes[0]?.id ?? null),
       );
       setLastLoadedAt(new Date());
     } catch (nextError) {
@@ -356,10 +347,6 @@ export default function RoutesDashboardPage() {
 
 function confirmDiscardUnsavedChanges(isDirty: boolean): boolean {
   return !isDirty || window.confirm('Discard unsaved changes? Save first to keep them.');
-}
-
-function readRequestedSelectionId(): string | null {
-  return new URLSearchParams(window.location.search).get('selected');
 }
 
 function NotebookSkeleton() {

--- a/web/components/cartographer/Stage.tsx
+++ b/web/components/cartographer/Stage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 
 type StageProps = {
   children: ReactNode;
@@ -10,6 +10,7 @@ type StageProps = {
   map: ReactNode;
   mode: 'places' | 'routes';
   workspace?: 'library' | 'map';
+  onBeforeWorkspaceChange?: () => boolean;
   onToggleLeftPanel?: () => void;
   onToggleMapFocus?: () => void;
   onToggleRightPanel?: () => void;
@@ -21,6 +22,7 @@ export function Stage({
   isRightPanelCollapsed = false,
   map,
   mode,
+  onBeforeWorkspaceChange,
   onToggleLeftPanel,
   onToggleMapFocus,
   onToggleRightPanel,
@@ -38,6 +40,12 @@ export function Stage({
   const isMapFocused = isLeftPanelCollapsed && isRightPanelCollapsed;
   const libraryHref = `/dashboard/library/${mode}`;
 
+  function handleWorkspaceChange(event: MouseEvent<HTMLAnchorElement>) {
+    if (onBeforeWorkspaceChange?.() === false) {
+      event.preventDefault();
+    }
+  }
+
   return (
     <main className={className}>
       <div className="cartographer-map-layer">{map}</div>
@@ -47,6 +55,7 @@ export function Stage({
           aria-current={workspace === 'map' ? 'page' : undefined}
           className={workspace === 'map' ? 'active' : ''}
           href="/dashboard/map"
+          onClick={handleWorkspaceChange}
         >
           Map
         </Link>
@@ -54,6 +63,7 @@ export function Stage({
           aria-current={workspace === 'library' ? 'page' : undefined}
           className={workspace === 'library' ? 'active' : ''}
           href={libraryHref}
+          onClick={handleWorkspaceChange}
         >
           Library
         </Link>


### PR DESCRIPTION
## Summary

- remove the redundant **Edit route** handoff and render the existing route editor directly in Map
- make map waypoints controlled so map clicks, marker interactions, form fields, and save state stay synchronized
- protect unsaved route drafts when switching routes, refreshing, or leaving the Map workspace
- remove now-unused selected-item query plumbing
- add repository UI/UX guidance for progressive disclosure, low cognitive load, and avoiding redundant CTAs

## Validation

- `just check`
- `just lint`
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `git diff --check`

## Browser review

Reviewed `http://localhost:3401/dashboard/map`:

- desktop Chrome at `1200×792`: route fields are immediately editable and no **Edit route** button is present
- headless Chrome at `390×844`: Map / Library, account control, map, notebook, and direct editor remain reachable without navigation overlap
- actual operation smoke: temporary route name edit saved/refreshed and was restored
- waypoint smoke: map click changed 7 → 8 waypoints, save/refresh preserved 8, then the temporary waypoint was removed and saved to restore 7
- dirty-state smoke: selecting another route displayed a discard prompt and rejecting it preserved the current draft
- Places remains a focused preview in Map; full Place management remains in Library

Screenshots: `/tmp/kestrel-map-direct-route-desktop.png` and `/tmp/kestrel-map-library-map-mobile.png`.
