### PR TITLE
fix(web): protect route editor recovery paths

### DIFF
--- a/web/app/dashboard/map/page.tsx
+++ b/web/app/dashboard/map/page.tsx
@@ -468,6 +468,7 @@ export default function DashboardMapPage() {
               route={isNewRoute ? null : selectedRoute}
               selectedWaypointIndex={selectedWaypointIndex}
               waypoints={draftWaypoints}
+              onBeforeNavigateAway={confirmDraftDiscard}
               onDirtyChange={setIsRouteDirty}
               onFocusTargetChange={setFocusTarget}
               onHoverWaypointIndexChange={setHoveredWaypointIndex}

--- a/web/components/dashboard/FavoriteWaypointPicker.tsx
+++ b/web/components/dashboard/FavoriteWaypointPicker.tsx
@@ -6,11 +6,13 @@ import type { Place } from '@/lib/api';
 
 export function FavoriteWaypointPicker({
   mode,
+  onBeforeNavigate,
   onSelect,
   places,
   showHeading = true,
 }: {
   mode: 'append' | 'start';
+  onBeforeNavigate?: () => boolean;
   onSelect: (place: Place) => void;
   places: Place[];
   showHeading?: boolean;
@@ -61,7 +63,16 @@ export function FavoriteWaypointPicker({
     return (
       <div className="favorite-picker empty-state">
         <p className="muted">No saved places yet.</p>
-        <Link href="/dashboard/library/places">Create a saved place first</Link>
+        <Link
+          href="/dashboard/library/places"
+          onClick={(event) => {
+            if (onBeforeNavigate?.() === false) {
+              event.preventDefault();
+            }
+          }}
+        >
+          Create a saved place first
+        </Link>
       </div>
     );
   }

--- a/web/components/dashboard/RouteEditor.tsx
+++ b/web/components/dashboard/RouteEditor.tsx
@@ -33,6 +33,7 @@ const RouteMapEditor = dynamic(() => import('@/components/RouteMapEditor'), {
 export default function RouteEditor({
   compactSummary = false,
   mapMode = 'embedded',
+  onBeforeNavigateAway,
   onDelete,
   onDirtyChange,
   onFocusTargetChange,
@@ -48,6 +49,7 @@ export default function RouteEditor({
 }: {
   compactSummary?: boolean;
   mapMode?: 'background' | 'embedded';
+  onBeforeNavigateAway?: () => boolean;
   onDelete?: () => void;
   onDirtyChange?: (isDirty: boolean) => void;
   onFocusTargetChange?: (waypoint: RouteWaypoint | null) => void;
@@ -352,6 +354,7 @@ export default function RouteEditor({
             inputMode="decimal"
             value={defaultSpeedKmh}
             onChange={(event) => setDefaultSpeedKmh(event.target.value)}
+            onInvalid={() => setIsRouteSettingsOpen(true)}
           />
         </label>
         <label>
@@ -413,6 +416,7 @@ export default function RouteEditor({
           mode={favoritePickerMode}
           places={places}
           showHeading={false}
+          onBeforeNavigate={onBeforeNavigateAway}
           onSelect={addFavoriteWaypoint}
         />
       </div>
@@ -579,6 +583,7 @@ export default function RouteEditor({
               <FavoriteWaypointPicker
                 mode={favoritePickerMode}
                 places={places}
+                onBeforeNavigate={onBeforeNavigateAway}
                 onSelect={addFavoriteWaypoint}
               />
             </div>

--- a/web/tests/ui/ui-regression.spec.ts
+++ b/web/tests/ui/ui-regression.spec.ts
@@ -342,6 +342,23 @@ test('new route exposes required settings and both waypoint entry paths', async 
   await expect(inspector.getByRole('button', { name: 'Save route' })).toBeEnabled();
 });
 
+test('route settings reopen when hidden speed validation fails', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-light', 'One native validation path is sufficient.');
+  await page.goto('/dashboard/map?kind=routes');
+
+  const settings = page.locator('.route-settings-disclosure');
+  await settings.locator(':scope > summary').click();
+  const speed = settings.getByLabel('Default speed (km/h)');
+  await speed.fill('');
+  await settings.locator(':scope > summary').click();
+  await expect(settings).not.toHaveAttribute('open', '');
+  await page.getByRole('button', { name: 'Save route' }).click();
+
+  await expect(settings).toHaveAttribute('open', '');
+  await expect(speed).toBeVisible();
+  await expect(speed).toBeFocused();
+});
+
 test('route inspector preserves settings, dialog, and error recovery paths', async ({
   page,
 }, testInfo) => {
@@ -454,6 +471,34 @@ test('route inspector adapts to long and dense content without nested scrolling'
     document.documentElement.style.fontSize = '200%';
   });
   await expectNoHorizontalOverflow(page);
+});
+
+test('dirty route guards the empty saved-place navigation', async ({ page }, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'desktop-light',
+    'One guarded navigation path is sufficient.',
+  );
+  await page.route('**/api/backend/places', (route) =>
+    route.fulfill({ body: '[]', contentType: 'application/json', status: 200 }),
+  );
+  await page.goto('/dashboard/map?kind=routes&new=1');
+  const name = page.getByLabel('Name');
+  await name.fill('Guarded route draft');
+  const createSavedPlace = page.getByRole('link', { name: 'Create a saved place first' });
+
+  let dismissedPrompt = '';
+  page.once('dialog', async (dialog) => {
+    dismissedPrompt = dialog.message();
+    await dialog.dismiss();
+  });
+  await createSavedPlace.click();
+  expect(dismissedPrompt).toBe('Discard unsaved changes? Save first to keep them.');
+  await expect(page).toHaveURL(/\/dashboard\/map\?kind=routes&new=1$/);
+  await expect(name).toHaveValue('Guarded route draft');
+
+  page.once('dialog', (dialog) => dialog.accept());
+  await createSavedPlace.click();
+  await expect(page).toHaveURL(/\/dashboard\/library\/places$/);
 });
 
 test('route inspector explains the empty saved places state', async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

- reopen compact Route settings when required speed validation fails
- route the empty saved-place link through the Map draft-discard guard
- add regression coverage for hidden native validation and cancel/accept navigation recovery

Follow-up to review feedback on #219.

## Validation

- `just check`
- `just lint`
- `cd web && npm run typecheck`
- `cd web && npm run build`
- `cd web && npm run test:ui` (28 passed, 29 expected project skips)
- `git diff --check`