### PR TITLE
fix(ci): split web UI regression projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,10 +172,20 @@ jobs:
           docker compose -p kestrel-webtest -f compose.dev.yaml logs
           exit 1
 
-      - name: Run Web UI regression tests
+      - name: Run desktop-light Web UI regression tests
         env:
           KESTREL_UI_BASE_URL: http://127.0.0.1:3401
-        run: timeout 170s npm run test:ui
+        run: timeout 170s npm run test:ui -- --project=desktop-light
+
+      - name: Run mobile-light Web UI regression tests
+        env:
+          KESTREL_UI_BASE_URL: http://127.0.0.1:3401
+        run: timeout 170s npm run test:ui -- --project=mobile-light
+
+      - name: Run desktop-dark Web UI regression tests
+        env:
+          KESTREL_UI_BASE_URL: http://127.0.0.1:3401
+        run: timeout 170s npm run test:ui -- --project=desktop-dark
 
       - uses: actions/upload-artifact@v7
         if: failure()


### PR DESCRIPTION
## Summary

- split the Playwright suite into one CI step per configured browser project
- retain the existing 170-second per-command guard while preventing the combined suite from timing out
- keep the same desktop-light, mobile-light, and desktop-dark coverage

Fixes the timeout in [CI job 88091241109](https://github.com/narumiruna/kestrel/actions/runs/29648704120/job/88091241109), where all tests through mobile-light passed before the combined command hit exit code 124 during desktop-dark.

## Validation

- YAML parsed successfully
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 just check`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 just lint`
- `timeout 170s npm run test:ui -- --project=desktop-light` (18 passed, 1 expected skip)
- `timeout 170s npm run test:ui -- --project=mobile-light` (5 passed, 14 expected skips)
- `timeout 170s npm run test:ui -- --project=desktop-dark` (5 passed, 14 expected skips)
- `git diff --check`