### PR TITLE
fix(web): resolve post-merge Radix review findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ replay_pid*
 *.jks
 *.keystore
 *.png
+!app/src/screenshotTestDebug/reference/**/*.png

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,4 +1,6 @@
 .next/
 out/
 node_modules/
+playwright-report/
+test-results/
 .env*.local

--- a/web/app/radix-ui.css
+++ b/web/app/radix-ui.css
@@ -474,13 +474,35 @@
 }
 
 .ui-disclosure-panel {
-  height: var(--radix-collapsible-content-height);
   overflow: hidden;
-  transition: height 160ms ease-out;
+}
+
+.ui-disclosure-panel[data-state="open"] {
+  animation: ui-disclosure-open 160ms ease-out;
 }
 
 .ui-disclosure-panel[data-state="closed"] {
-  height: 0;
+  animation: ui-disclosure-close 160ms ease-out;
+}
+
+@keyframes ui-disclosure-open {
+  from {
+    height: 0;
+  }
+
+  to {
+    height: var(--radix-collapsible-content-height);
+  }
+}
+
+@keyframes ui-disclosure-close {
+  from {
+    height: var(--radix-collapsible-content-height);
+  }
+
+  to {
+    height: 0;
+  }
 }
 
 .route-editor-collapsible.ui-disclosure,
@@ -619,5 +641,9 @@
   .ui-disclosure-panel,
   .ui-tooltip-popup {
     transition-duration: 0.01ms;
+  }
+
+  .ui-disclosure-panel {
+    animation-duration: 0.01ms;
   }
 }


### PR DESCRIPTION
## Summary

- keep PNG files ignored generally while allowing required Android screenshot-test references
- ignore removed Playwright suite output directories without hiding Android baselines
- animate disclosure transitions without pinning open panels to a stale measured height

Addresses the unresolved post-merge feedback on #227.

## Verification

- `JAVA_HOME=/home/narumi/.gradle/jdks/eclipse_adoptium-26-amd64-linux.2 just check`
- `JAVA_HOME=/home/narumi/.gradle/jdks/eclipse_adoptium-26-amd64-linux.2 just lint`
- Docker Web production build
- Chrome DevTools smoke at `http://127.0.0.1:3401/dashboard/library/routes` (1265×1333): an open disclosure grew from 40px to 120px after content was appended while its measured Radix height remained 40px
- `git check-ignore`: general PNGs remain ignored; new Android screenshot references are trackable