### PR TITLE
docs(plan): record image history cleanup evidence

### DIFF
--- a/docs/plans/2026-07-25_remove-image-binaries-from-git-history-plan.md
+++ b/docs/plans/2026-07-25_remove-image-binaries-from-git-history-plan.md
@@ -1,6 +1,6 @@
 # Remove Image Binaries from Git History Plan
 
-狀態：Draft。此計畫只定義執行與驗證方式，不授權 history rewrite、force-push、刪除 refs、變更 GitHub 規則或清除本機物件。
+狀態：In progress。所有可寫入 heads／tags 與本機歷史已重寫並驗證；GitHub read-only pull-request refs／cache purge 與全 refs 的伺服器端 push rule 仍待外部處理。
 
 ## Goal（目標）
 
@@ -47,56 +47,56 @@
 
 ### 1. 凍結與完整盤點
 
-- [ ] 宣布短期 push freeze，取得 history rewrite、所有保留 branch／tag force-push、必要 branch 刪除、GitHub ruleset 變更與最終 purge 的逐項明確同意；以執行紀錄中的核准文字作為證據。
-- [ ] 以 `git ls-remote --heads --tags origin`、`git for-each-ref`、`git reflog --all`、`gh pr list` 與 `gh release list` 建立不可變 ref manifest，記錄每個 ref 的舊 SHA、保留／刪除決策與 open PR 對應；確認 manifest 涵蓋目前 31 個 local branch、9 個 remote heads、15 個 tag、4 個 open PR 與 232 個 pull-request refs。
-- [ ] 以副檔名與 blob magic 兩種方式掃描所有 refs／reflogs，產生放在儲存庫外的精確 path/blob manifest；重現目前 40 個路徑、44 個 blobs、34 PNG／10 WebP，任何額外結果都先加入範圍再繼續。
-- [ ] 盤點 GitHub hidden PR refs、fork、Release/tag 綁定與 repository ruleset 能力；若 GitHub 無法封鎖圖片副檔名 push 或無法 purge 舊 SHA，先決定移至支援 push ruleset 的組織／主機、請 GitHub Support 協助，或刪除重建 repository，未決不得進入 cutover。
+- [x] 宣布短期 push freeze，取得 history rewrite、所有保留 branch／tag force-push、必要 branch 刪除、GitHub ruleset 變更與最終 purge 的逐項明確同意；2026-07-25 由 active goal 明確要求完整執行本計畫。
+- [x] 以 `git ls-remote --heads --tags origin`、`git for-each-ref`、`git reflog --all`、`gh pr list` 與 `gh release list` 建立 `/tmp/kestrel-image-history-rewrite/` manifest；已記錄 31 個 local branch、9 個 remote heads、15 個 tag、4 個 open PR、232 個 pull-request refs 與 15 個 Releases。
+- [x] 以副檔名與 blob magic 兩種方式掃描所有 refs／reflogs；`image-audit-before.json` 重現 40 個路徑、44 個 blobs、34 PNG／10 WebP，沒有額外圖片格式。
+- [x] 盤點 232 個 GitHub hidden PR refs、0 forks、15 Releases 與 ruleset 能力；已選擇 GitHub Support purge 以避免刪除 repository 後遺失 224 個 PR、6 stars、Actions secrets 與 Release provenance。Support 網站需要 GitHub 瀏覽器登入，CLI token 無公開 Support API。
 
 ### 2. 在隔離 mirror 重寫所有歷史
 
-- [ ] 在儲存庫外建立權限受限的新鮮 `git clone --mirror`，重新 fetch 所有已核准 heads／tags，並以 `uv tool run git-filter-repo --version`（或等價的隔離安裝）固定工具版本；不得把工具加入專案 dependency。
-- [ ] 將 path/blob manifest 轉成 `git-filter-repo` 的精確刪除輸入，對所有保留 refs 執行 invert-path rewrite；不得只用 `*.png` glob，必須同時移除 10 個歷史 WebP、已刪除 PNG、重複初始根與稽核找到的任何無副檔名圖片 binary。
-- [ ] 刪除 filter 工具留下的 backup refs，執行 `git reflog expire --expire=now --all` 與 `git gc --prune=now`；以 `git show-ref`、`git fsck --full`、全物件 MIME/magic 掃描證明隔離 mirror 中沒有任何可達或 unreachable 圖片 blob。
-- [ ] 產生舊 SHA → 新 SHA、branch 與 tag 對照表；逐一確認所有核准保留 refs 仍存在、所有核准刪除 refs 已消失，且非圖片檔的最新 tree 除預期清理外沒有內容差異。
+- [x] 在 `/tmp/kestrel-image-history-rewrite/mirror-clean.git` 建立權限受限的新鮮 mirror，fetch 所有 remote／local refs，並以 `uv tool run git-filter-repo` 版本 `a40bce548d2c` 執行，未新增專案 dependency。
+- [x] 將 40-path manifest 交給 `git-filter-repo --invert-paths --paths-from-file`，重寫 9 個 remote heads、31 個 local heads、15 個 tags 與 232 個本機鏡像 pull refs，包含 10 個 WebP、已刪除 PNG 與重複初始根。
+- [x] 刪除 backup refs，執行 reflog expire 與 aggressive immediate GC；mirror `git fsck --full --no-reflogs --unreachable` 無輸出，掃描 1,907 個 blobs 得到 0 個圖片，44 個舊 OID 全部不存在。
+- [x] 產生 882-entry commit map 與 288-entry ref map；逐一保留 31 個 local heads、9 個 remote heads、15 個 tags，並確認重寫後 `main` 只有預期的圖片與 screenshot infrastructure 清理。
 
 ### 3. 在乾淨歷史上移除產圖流程
 
-- [ ] 從重寫後的 `main` 移除 Android screenshot plugin／version／dependencies、`app/src/screenshotTest/`、`just android-ui`／`android-ui-update` 與 CI `validateDebugScreenshotTest`／報告上傳步驟；以 `rg 'screenshotTest|validateDebugScreenshotTest|updateDebugScreenshotTest'` 只剩歷史文件中的明確退役說明為證據。
-- [ ] 移除已無測試原始碼支撐的 `web/tests/ui/` snapshot 目錄，更新 `README.md` 與 `docs/design/ui-regression-testing.md`，把視覺證據改為 Chrome DevTools／暫存目錄且不得提交；以 `git ls-files web/tests/ui app/src/screenshotTestDebug/reference` 無輸出為證據。
-- [ ] 更新 `.gitignore`：刪除 Android PNG 例外，加入大小寫不敏感寫法的 PNG、JPG／JPEG、GIF、WebP、AVIF、HEIF／HEIC、BMP、TIFF、ICO 等圖片二進位副檔名；保留文字型 SVG／XML 與原始碼中的地圖 tile URL。
+- [x] 從重寫後的 `main` 移除 Android screenshot plugin／version／dependencies、`app/src/screenshotTest/`、`just android-ui`／`android-ui-update` 與 CI screenshot 步驟；`rg` 只剩本計畫與退役設計文件的文字說明。
+- [x] 移除 `web/tests/ui/` snapshots，更新 `README.md` 與 `docs/design/ui-regression-testing.md`；`git ls-files web/tests/ui app/src/screenshotTestDebug/reference` 無輸出，Chrome 驗證沒有產生 repository 圖片。
+- [x] 更新 `.gitignore`，移除 Android PNG 例外並以大小寫不敏感 pattern 忽略常見與延伸圖片格式；SVG／XML 與地圖 tile URL 保持可追蹤。
 
 ### 4. 建立可執行的防再犯機制
 
-- [ ] 新增文字腳本 `scripts/check-no-image-binaries.sh`，提供 staged、tracked-tree 與 commit-range 三種模式：同時檢查禁止副檔名與 staged／Git blob magic，忽略 deletion、允許文字 SVG，並在失敗時列出 ref、commit、path、偵測格式與修復動作。
-- [ ] 新增隔離暫存 Git repository 的腳本測試，至少證明：一般文字檔與 SVG 通過；文字內容的 `.png` 路徑失敗；無副檔名 PNG magic 失敗；add-then-delete 的 commit range 失敗；單純刪除歷史圖片不會被誤擋。
-- [ ] 在 `.pre-commit-config.yaml` 加入 pre-commit staged 檢查與 pre-push range 檢查，透過 `prek install --hook-type pre-commit --hook-type pre-push` 安裝；以測試 push 到本機 bare remote 時圖片 commit 被拒絕、純文字 commit 可 push 為證據。
-- [ ] 在 `.github/workflows/ci.yml` 加入總是執行的圖片政策 job，使用完整所需 fetch depth 掃描 PR range、push range 與結果 tree；將它設為 `main` 的 required status check，確保圖片不能 merge 到 canonical history。
-- [ ] 建立 GitHub branch/tag ruleset：禁止直接更新 `main`、要求 PR 與圖片政策檢查、限制 force-push；若方案支援 push ruleset，再封鎖所有列出的圖片副檔名於所有 refs。以 `gh api repos/narumiruna/kestrel/rulesets` 的回讀結果與一個被伺服器拒絕的測試 push 作為證據。
+- [x] 新增 `scripts/check-no-image-binaries.sh`，提供 staged、tracked、range、all-history 與 pre-push 模式；同時檢查副檔名與 MIME、忽略 deletion、允許 SVG，並列出來源、path、blob 與原因。
+- [x] 新增 `scripts/test-check-no-image-binaries.sh`；已證明文字與 SVG 通過、文字 `.png`／無副檔名 PNG 失敗、add-then-delete range 失敗、單純 deletion 通過。
+- [x] 在 `.pre-commit-config.yaml` 加入 staged 與 pre-push hooks，`just hooks` 同時安裝兩者；隔離 bare remote 整合測試證明純文字 push 通過、add-then-delete 圖片 history 被 pre-push 拒絕。
+- [x] 在 CI 加入總是執行的 `image-policy` job，掃描 tracked tree 與 PR／push range；rewritten `main` run `30140653927` 與 smoke PR #229 均通過，並已設為 `main` required status check。
+- [x] 建立 active rulesets `Protect main image policy`（ID `19719005`）與 `Protect release tags`（ID `19719008`）；直接 main push 與 tag force-update均被 GitHub 拒絕，文字 smoke PR #229 的 required `image-policy` 通過後保持 mergeable 並已關閉。GitHub 拒絕建立 push ruleset，回覆 public personal repository 不支援。
 - [ ] 若 GitHub 不支援適用於所有 refs 的 push 規則，將「遠端 topic branch 絕不短暫接收圖片」列為未滿足，改用支援自訂 pre-receive／push ruleset 的託管方式；不得只以 CI 失敗宣稱已完全避免圖片進入遠端歷史。
 
 ### 5. 驗證重寫後程式碼
 
-- [ ] 在重寫後的普通 worktree 執行 `git ls-files` 副檔名掃描、全 tracked blob magic 掃描與 `scripts/check-no-image-binaries.sh --tracked`，證明目前 tree 沒有圖片二進位檔或 Git LFS 圖片 pointer。
-- [ ] 使用 Java 26 執行 `just android-check`、`just android-lint`、`just android-test` 與 `just android-build`；確認移除 screenshot plugin 後 Android 仍可格式化、分析、測試與建置。
-- [ ] 先在 `web/` 執行 `npm ci`，再執行 `just web-check`、`npm run typecheck` 與 `npm run build`；用 Chrome DevTools 驗證主要 Web 畫面，所有截圖只存儲存庫外。
-- [ ] 執行 `git diff --check`、防圖片腳本測試與完整相關 hooks，確認準備推送的 commit 只含文字／允許的非圖片檔，且沒有 staged 圖片 deletion 以外的 binary 變更。
+- [x] 在重寫後 worktree 執行 path、tracked MIME 與 policy 掃描；追蹤圖片路徑為 0、圖片 blobs 為 0、沒有 `.gitattributes`／Git LFS 圖片 pointer。
+- [x] 使用 Temurin 26.0.1 與 Android SDK 37.0 執行 `just android-check`、`just android-lint`、`just android-test`、`just android-build`，全部通過。
+- [x] 在乾淨 worktree 執行 `npm ci`、`just web-check`、Web typecheck／build，全部通過；Chrome DevTools 驗證 login 與 Library 正常且無水平 overflow，未建立截圖。Map 的 WebGL 僅受既有 WSL Chrome `BindToCurrentSequence` 限制。
+- [x] `git diff --check`、policy tests、Prek config／hooks 均通過；rewrite 前的實作 commits 只含文字檔與 screenshot test 原始碼 deletion，未 stage 或 commit 圖片。
 
 ### 6. 遠端 cutover 與最終清除
 
-- [ ] 再次確認 push freeze 仍有效且 `origin` ref SHA 與 manifest 相符；逐一用 force-with-lease 更新核准的 branch／tag，逐一刪除核准淘汰的 refs，任何差異立即停止。
-- [ ] 重新建立或 rebase 4 個 open PR 到新歷史，確認 Dependabot 與其他自動化不會從舊基底帶回圖片 blob；關閉無法安全重建的舊 PR branch。
-- [ ] 從全新 clone 掃描所有 GitHub 可見 heads／tags 與完整物件，確認 40 個舊路徑、44 個舊 blob OID、禁止副檔名與圖片 magic 都無法由任何 canonical ref 抵達；再驗證 CI、tags、GitHub Releases 與下載流程。
+- [x] Cutover 前 `origin` 與 manifest 完全相符；以 24 個逐 ref lease 的 atomic force-push 更新 9 heads 與 15 tags，之後逐一確認遠端 tag objects 與 sanitized mirror 相符。
+- [x] Force-update 4 個 Dependabot heads 到新歷史；PR #223–#226 均為 `CLEAN`，最新 CI 與 `image-policy` 全部成功。
+- [x] 從全新 remote mirror 掃描 9 heads／15 tags，canonical refs 的 policy 全數通過；本機與 sanitized mirror 的 40 paths／44 OIDs 不可達且 magic 掃描為 0。Main CI 五個 jobs 全綠，15 tags、15 Releases 與 15 APK assets 仍存在。
 - [ ] 對 GitHub hidden refs／cache 執行已選定的 Support purge 或 repository 重建流程，並以舊 commit/blob SHA 無法透過 GitHub 取得及 Support／重建紀錄作為證據；未取得此證據前不得宣稱 GitHub 端「完全清除」。
 - [ ] 取得使用者對新歷史與功能驗證的最終接受後，刪除暫存 mirror，讓原 clone 的所有舊 refs／reflogs 到期並立即 prune，或直接刪除舊 clone 後重新 clone；再次執行 `git fsck --full --no-reflogs --unreachable` 與圖片 magic 掃描。
-- [ ] 通知所有協作者刪除舊 clone／fork 後重新 clone，禁止 merge 舊 branch；在 freeze 解除前以一個純文字測試 PR 證明 hooks、CI 與 ruleset 都生效。
+- [x] Repository 只有 `narumiruna` 一位 collaborator 且 forks 為 0；目前本機 clone 已重寫並 prune。純文字 smoke PR #229 證明 required CI／ruleset 生效後已關閉並刪除 branch。
 
 ## Completion Checklist（完成檢核）
 
-- [ ] `HEAD`、所有保留 local／remote branch、所有 tag、reflog 與可控 hidden refs 都不再含任何圖片二進位 blob。
+- [x] `HEAD`、31 個 local branches、9 個 remote heads、15 個 tags、本機 reflog 與隔離 mirror 中 232 個重寫後 pull refs 都不含圖片二進位 blob；GitHub read-only pull refs 另列於未完成 Support purge。
 - [ ] 40 個已知歷史路徑與 44 個已知 blob OID 均無法由 canonical repository 的任何 ref 取得，且完整 magic 掃描沒有新發現。
-- [ ] Android／Web 的 committed screenshot baselines 與會重新產生它們的 repository workflow 已退役，相關建置與測試仍通過。
+- [x] Android／Web 的 committed screenshot baselines 與會重新產生它們的 repository workflow 已退役，Android／Web quality gates 與 main CI 均通過。
 - [ ] `.gitignore`、pre-commit、pre-push、CI required check 與 GitHub ruleset 均已通過正反案例驗證。
-- [ ] `main` 與 release tags 已安全切換到新 SHA；PR、Release、自動化與協作者 clone 已完成重新基底或重建。
+- [x] `main` 與 15 個 release tags 已安全切換到新 SHA；4 個 open PR、15 Releases、CI 與唯一協作者的本機 clone 已完成重新基底或重寫。
 - [ ] GitHub Support purge 或 repository 重建已完成，舊 SHA 不可從 GitHub 取得；若有不可控 fork／clone，已明確列為外部限制而非宣稱已清除。
 - [ ] 暫存 mirror、舊 clone、backup refs 與 reflog 已清除，最終 fresh clone 的 `git fsck`、副檔名掃描、MIME/magic 掃描及相關 quality gates 全數通過。
 - [ ] 使用者已檢閱 SHA 對照、驗證證據、外部限制與不可逆 rollback 終止點，並明確接受完成狀態。


### PR DESCRIPTION
Records completed local/canonical history rewrite, policy controls, validation evidence, and the two remaining external constraints: GitHub read-only PR-ref purge and lack of push rulesets on a public personal repository.