### PR TITLE
chore(tooling): refine just workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,28 +65,28 @@ web/                 # Next.js cloud console
 
 ## 🛠️ Development
 
-> **Prerequisites:** Android Studio, JDK 26 with `JAVA_HOME` configured, and `adb` on `PATH`.
-> All common tasks are driven by the [`justfile`](justfile) — install [just](https://github.com/casey/just) to use them.
+> **Prerequisites:** Android Studio, JDK 26 with `JAVA_HOME` configured, and the Android SDK available through `ANDROID_HOME`, `ANDROID_SDK_ROOT`, or the default macOS location.
+> All common tasks are driven by the [`justfile`](justfile) — install [just](https://github.com/casey/just) to use them. Run bare `just` or `just help` to see the grouped, non-destructive command list.
 
 | Task | Command |
 |---|---|
-| Build debug APK | `just build` |
+| Show available recipes | `just` or `just help` |
+| Build debug APK | `just android-build` (or `just build`) |
 | Build release APK | `just release` |
-| Build → install → launch | `just` (or `just br`) |
-| Run unit tests | `just test` |
+| Build → install → launch on a selected device | `just br` |
+| Run Android unit tests | `just android-test` (or `just test`) |
 | Validate Android UI screenshots | `just android-ui` |
-| Update Android UI screenshots | `just android-ui-update` |
-| Run Web UI regression tests | `just webtest-up`, then `just web-ui` |
-| Update Web UI screenshots | `just webtest-up`, then `just web-ui-update` |
-| Auto-format (Spotless + ktlint + Biome) | `just format` |
-| Verify formatting (no writes) | `just check` |
-| Detekt static analysis | `just lint` |
-| Regenerate Detekt baseline | `just lint-baseline` |
+| Update Android UI screenshots | `just android-ui-update` (requires confirmation) |
+| Install exact Backend / Web dependencies | `just backend-install`, `just web-install` |
+| Verify Backend / Web | `just backend-check`, `just web-verify` |
+| Verify every workspace | `just verify` |
+| Auto-format Android + Web | `just format` |
+| Check Android + Web formatting/lint | `just check`, `just lint` |
+| Regenerate Detekt baseline | `just lint-baseline` (requires confirmation) |
 | Install git hooks (prek) | `just hooks` |
-| Reset app data | `just reset` |
+| Reset app data permanently | `just reset` (requires confirmation) |
 | Follow logcat | `just log` |
-| Start full dev stack (Docker Compose) | `just cloud-up` |
-| Stop Docker Compose stack | `just cloud-down` |
+| Start / stop the dev stack | `just cloud-up`, `just cloud-down` |
 
 ### 🧪 Unit tests
 
@@ -101,8 +101,8 @@ just test
 The NestJS + Prisma backend lives in `backend/`.
 
 ```bash
+just backend-install
 cd backend
-npm install
 npm run db:up
 npm run prisma:migrate:dev
 npm run start:dev
@@ -113,8 +113,8 @@ npm run start:dev
 The Next.js cloud console lives in `web/` and proxies `/api/backend/*` to the NestJS API.
 
 ```bash
+just web-install
 cd web
-npm install
 npm run dev
 ```
 
@@ -125,7 +125,7 @@ Open `http://localhost:3301`. Set `KESTREL_API_BASE_URL` if the API is not runni
 To run PostgreSQL, the NestJS backend, and the Next.js web console together:
 
 ```bash
-just cloud-up   # or: docker compose up --build
+just cloud-up   # or: docker compose -f compose.dev.yaml --profile watch up --build
 ```
 
 | Service | Address |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -6,7 +6,7 @@ Top-level `*-plan.md` files are active. Closed or superseded plans live in `arch
 
 No active implementation plans.
 
-The Web UI/UX optimization loop, Web Map workspace/route-inspector plans, and the 2026-07-15 Options, Favorites, Web Library, and cross-platform UI regression plans are complete and archived in `archived/`.
+The Justfile workflow refinement, Web UI/UX optimization loop, Web Map workspace/route-inspector plans, and the 2026-07-15 Options, Favorites, Web Library, and cross-platform UI regression plans are complete and archived in `archived/`.
 
 ## Security references
 

--- a/docs/plans/archived/2026-07-25_justfile-workflow-refinement-plan.md
+++ b/docs/plans/archived/2026-07-25_justfile-workflow-refinement-plan.md
@@ -1,0 +1,42 @@
+# Justfile Workflow Refinement Plan
+
+## Goal
+
+Make the repository `justfile` safer, deterministic, easier to discover, and complete across Android, Backend, Web, cloud, and device workflows without changing build/test semantics or running destructive/device-changing recipes.
+
+## Context
+
+- The current default recipe runs build → install → launch, so a bare `just` mutates an attached device.
+- `web-check` uses `npm exec -- biome`, which can download an unrelated package when `web/node_modules` is absent.
+- Documented recipes such as `android-ui` are missing, while Backend and full Web verification require manual command chains.
+- Repeated Java, Compose, and workspace command fragments make maintenance and review harder.
+- Existing compatibility entry points (`build`, `test`, `format`, `check`, `lint`, `br`, cloud and device recipes) must remain available.
+
+## Non-Goals
+
+- Do not change application code, dependencies, CI workflows, Gradle tasks, npm script behavior, Compose topology, deployment behavior, or database state.
+- Do not run install, launch, uninstall, reset, connected instrumentation, cloud stack mutation, release, migration, or screenshot-update recipes.
+- Do not reintroduce Web image-based or Playwright UI recipes; browser validation remains Chrome DevTools based.
+
+## Risks
+
+- Recipe renames or aggregate semantic changes could break documentation and operator habits; preserve existing names and document any safer default behavior.
+- A dependency guard could block valid workspaces if it checks the wrong executable; verify against installed local binaries and dry-run commands.
+- Aggregate verification can be expensive; retain focused workspace recipes and make the comprehensive aggregate explicit.
+
+## Plan
+
+- [x] Refactor `justfile` constants, private dependency guards, groups, and aggregate recipes while preserving all 35 existing entry points; `just --fmt --check`, `just --list`, `just --dump`, and an explicit compatibility-set assertion pass with 54 public recipes plus 4 private guards.
+- [x] Make bare `just` show discoverable help, add confirmations to destructive reset/uninstall and reference-update flows, and add deterministic local dependency checks; default output contains no Gradle/adb action, confirmation metadata is present, a temporary dependency-free Web workspace fails with `Run: just web-install`, and destructive recipes were inspected only with `--yes --dry-run`.
+- [x] Add missing Android screenshot verification plus focused Backend/Web install, format, lint, test, typecheck, build, and full verification recipes; `backend-check` passes Prisma generation, lint, 116 unit tests, 8 e2e tests, typecheck, and build, while `web-verify` passes Biome, typecheck, and a 16-route production build. Android Spotless and Detekt pass; SDK-dependent test/UI/build commands are dry-run verified and now fail early with an actionable SDK message because this host has no Android SDK.
+- [x] Update `README.md` command documentation to match the refined recipes and remove stale Web screenshot-test commands; every `just <recipe>` reference extracted from README exists in `just --summary`.
+- [x] Run final `git diff --check`, inspect the complete diff for unrelated or destructive changes, then complete and archive this plan under `docs/plans/archived/`; finalization evidence is recorded below and the plan is archived in the same change.
+
+## Completion Checklist
+
+- [x] Bare `just` performs no build, install, launch, data mutation, or other external write.
+- [x] Existing documented compatibility recipes remain available and `android-ui` resolves to `:app:validateDebugScreenshotTest`.
+- [x] Web Biome commands invoke only `web/node_modules/.bin/biome` and cannot silently install an unrelated package when dependencies are missing.
+- [x] Android, Backend, and Web each have focused and comprehensive verification entry points with actionable dependency/setup guards; Backend verification includes Prisma generation.
+- [x] Destructive device recipes require explicit interactive confirmation and no destructive/device-changing recipe was executed during validation.
+- [x] Just syntax/format, all host-available non-destructive workspace checks, documentation references, and `git diff --check` pass; Android SDK-dependent gates are explicitly unavailable on this host and verified through deterministic guard/dry-run evidence rather than claimed as executed.

--- a/justfile
+++ b/justfile
@@ -1,150 +1,329 @@
 set shell := ["bash", "-cu"]
 
 java_home := env_var_or_default("JAVA_HOME", "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home")
-adb := "$HOME/Library/Android/sdk/platform-tools/adb"
+android_sdk := env_var_or_default("ANDROID_HOME", env_var_or_default("ANDROID_SDK_ROOT", home_directory() + "/Library/Android/sdk"))
+adb := android_sdk + "/platform-tools/adb"
+gradle := 'ANDROID_HOME="' + android_sdk + '" JAVA_HOME="' + java_home + '" PATH="' + java_home + '/bin:$PATH" ./gradlew'
+dev_compose := "docker compose -f compose.dev.yaml"
+webtest_compose := "docker compose -p kestrel-webtest -f compose.dev.yaml"
 package := "dev.narumi.kestrel"
 activity := package + "/.MainActivity"
 apk := "app/build/outputs/apk/debug/app-debug.apk"
 
-# build, install, and launch
-default: br
+# show available recipes without changing local or device state
+[group('Meta')]
+default:
+    @just --list
 
-# build the debug APK
-build:
-    just android-build
+# show available recipes
+[group('Meta')]
+help:
+    @just --list
 
-# build the Android debug APK
-android-build:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew :app:assembleDebug
+# verify every workspace without writing source files
+[group('Quality')]
+verify:
+    just android-verify
+    just backend-check
+    just web-verify
 
-# build the signed release APK (requires KESTREL_RELEASE_* environment variables)
-release:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew :app:assembleRelease
-
-# clean Gradle outputs
-clean:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew clean
-
-# format Android and web code
+# format Android and Web code
+[group('Quality')]
 format:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew spotlessApply
+    just android-format
     just web-format
 
-# check Android formatting and web formatting/lint without writing changes
+# check Android and Web formatting/lint without writing changes
+[group('Quality')]
 check:
     just android-check
     just web-check
 
-# check Android formatting without writing changes
-android-check:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew spotlessCheck
-
-# run Android detekt and web lint
+# run Android detekt and Web lint
+[group('Quality')]
 lint:
     just android-lint
     just web-lint
 
-# run Android detekt only
+# build the Android debug APK
+[group('Android')]
+build: android-build
+
+# build the Android debug APK
+[group('Android')]
+android-build: _require-android-sdk
+    {{ gradle }} :app:assembleDebug
+
+# build the signed release APK (requires KESTREL_RELEASE_* environment variables)
+[group('Android')]
+release: _require-android-sdk
+    {{ gradle }} :app:assembleRelease
+
+# clean Gradle outputs
+[group('Android')]
+clean: android-clean
+
+# clean Gradle outputs
+[group('Android')]
+android-clean:
+    {{ gradle }} clean
+
+# format Android code with Spotless
+[group('Android')]
+android-format:
+    {{ gradle }} spotlessApply
+
+# check Android formatting without writing changes
+[group('Android')]
+android-check:
+    {{ gradle }} spotlessCheck
+
+# run Android detekt
+[group('Android')]
 android-lint:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew detekt
-
-# format web code with Biome (safe fixes and import sorting)
-web-format:
-    cd web && npm exec -- biome check --write .
-
-# check web formatting/lint/import sorting without writing changes
-web-check:
-    cd web && npm exec -- biome ci .
-
-# run web lint only
-web-lint:
-    cd web && npm exec -- biome lint .
-
-# run debug-variant JVM unit tests
-test:
-    just android-test
+    {{ gradle }} detekt
 
 # run Android debug-variant JVM unit tests
-android-test:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew :app:testDebugUnitTest
+[group('Android')]
+test: android-test
 
-# update Android Compose screenshot references (review image diffs before committing)
-android-ui-update:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew :app:updateDebugScreenshotTest
+# run Android debug-variant JVM unit tests
+[group('Android')]
+android-test: _require-android-sdk
+    {{ gradle }} :app:testDebugUnitTest
 
-# start the web/backend/Postgres dev stack with hot reload
-cloud-up:
-    docker compose -f compose.dev.yaml --profile watch up --build
+# validate Android Compose screenshots without updating references
+[group('Android')]
+android-ui: _require-android-sdk
+    {{ gradle }} :app:validateDebugScreenshotTest
 
-# stop the dev stack without removing its database volume
-cloud-down:
-    docker compose -f compose.dev.yaml --profile watch --profile image down
+# update Android Compose screenshot references (review images; never commit binaries)
+[confirm('Update Android screenshot reference images?')]
+[group('Android')]
+android-ui-update: _require-android-sdk
+    {{ gradle }} :app:updateDebugScreenshotTest
 
-# follow hot-reload dev stack logs
-cloud-log:
-    docker compose -f compose.dev.yaml logs -f web-watch backend-watch postgres
-
-# start the isolated browser-review dev stack with hot reload on localhost:3401
-webtest-up:
-    KESTREL_DEV_WEB_PORT=3401 KESTREL_DEV_BACKEND_PORT=3400 KESTREL_DEV_POSTGRES_PORT=15433 docker compose -p kestrel-webtest -f compose.dev.yaml --profile watch up --build
-
-# stop the isolated browser-review stack without removing its database volume
-webtest-down:
-    docker compose -p kestrel-webtest -f compose.dev.yaml --profile watch --profile image down
-
-# follow isolated browser-review stack logs
-webtest-log:
-    docker compose -p kestrel-webtest -f compose.dev.yaml logs -f web-watch backend-watch postgres
+# run all non-destructive Android quality gates
+[group('Android')]
+android-verify:
+    just android-check
+    just android-lint
+    just android-test
+    just android-ui
+    just android-build
 
 # regenerate the detekt baseline (accept current warnings)
+[confirm('Regenerate the Detekt baseline and accept current warnings?')]
+[group('Android')]
 lint-baseline:
-    JAVA_HOME="{{ java_home }}" PATH="{{ java_home }}/bin:$PATH" ./gradlew detektBaseline
+    {{ gradle }} detektBaseline
+
+# install exact Web dependencies from the lockfile
+[group('Setup')]
+[working-directory('web')]
+web-install:
+    npm ci
+
+# format Web code with the repository Biome binary
+[group('Web')]
+[working-directory('web')]
+web-format: _require-web-deps
+    ./node_modules/.bin/biome check --write .
+
+# check Web formatting, lint, and imports without writing changes
+[group('Web')]
+[working-directory('web')]
+web-check: _require-web-deps
+    ./node_modules/.bin/biome ci .
+
+# run Web lint only
+[group('Web')]
+[working-directory('web')]
+web-lint: _require-web-deps
+    ./node_modules/.bin/biome lint .
+
+# generate Next.js route types and run TypeScript
+[group('Web')]
+[working-directory('web')]
+web-typecheck: _require-web-deps
+    npm run typecheck
+
+# build the production Web application
+[group('Web')]
+[working-directory('web')]
+web-build: _require-web-deps
+    npm run build
+
+# run all Web quality gates
+[group('Web')]
+web-verify:
+    just web-check
+    just web-typecheck
+    just web-build
+
+# install exact Backend dependencies from the lockfile
+[group('Setup')]
+[working-directory('backend')]
+backend-install:
+    npm ci
+
+# generate the Backend Prisma client
+[group('Backend')]
+[working-directory('backend')]
+backend-prisma-generate: _require-backend-deps
+    npm run prisma:generate
+
+# format Backend source and tests with Prettier
+[group('Backend')]
+[working-directory('backend')]
+backend-format: _require-backend-deps
+    npm run format
+
+# lint Backend source and tests
+[group('Backend')]
+[working-directory('backend')]
+backend-lint: _require-backend-deps
+    npm run lint
+
+# run Backend unit tests
+[group('Backend')]
+[working-directory('backend')]
+backend-test: _require-backend-deps
+    npm run test
+
+# run Backend end-to-end tests
+[group('Backend')]
+[working-directory('backend')]
+backend-test-e2e: _require-backend-deps
+    npm run test:e2e
+
+# type-check Backend production sources
+[group('Backend')]
+[working-directory('backend')]
+backend-typecheck: _require-backend-deps
+    npm run typecheck
+
+# build the Backend application
+[group('Backend')]
+[working-directory('backend')]
+backend-build: _require-backend-deps
+    npm run build
+
+# run the complete Backend quality gate
+[group('Backend')]
+backend-check:
+    just backend-prisma-generate
+    just backend-lint
+    just backend-test
+    just backend-test-e2e
+    just backend-typecheck
+    just backend-build
+
+# start the Web/Backend/Postgres dev stack with hot reload
+[group('Cloud')]
+cloud-up:
+    {{ dev_compose }} --profile watch up --build
+
+# stop the dev stack without removing its database volume
+[group('Cloud')]
+cloud-down:
+    {{ dev_compose }} --profile watch --profile image down
+
+# follow hot-reload dev stack logs
+[group('Cloud')]
+cloud-log:
+    {{ dev_compose }} logs -f web-watch backend-watch postgres
+
+# start the isolated browser-review stack on localhost:3401
+[group('Cloud')]
+webtest-up:
+    KESTREL_DEV_WEB_PORT=3401 KESTREL_DEV_BACKEND_PORT=3400 KESTREL_DEV_POSTGRES_PORT=15433 {{ webtest_compose }} --profile watch up --build
+
+# stop the isolated browser-review stack without removing its database volume
+[group('Cloud')]
+webtest-down:
+    {{ webtest_compose }} --profile watch --profile image down
+
+# follow isolated browser-review stack logs
+[group('Cloud')]
+webtest-log:
+    {{ webtest_compose }} logs -f web-watch backend-watch postgres
 
 # install git hooks with prek
+[group('Setup')]
 hooks:
     prek install
 
 # run all hooks on every tracked file
+[group('Quality')]
 hooks-all:
     prek run --all-files
 
 # install or replace the debug APK on the connected device
-install:
-    {{ adb }} install -r {{ apk }}
+[group('Device')]
+install: _require-adb
+    "{{ adb }}" install -r {{ apk }}
 
 # force-stop and relaunch the app
-run:
-    {{ adb }} shell am force-stop {{ package }}
-    {{ adb }} shell am start -n {{ activity }}
+[group('Device')]
+run: _require-adb
+    "{{ adb }}" shell am force-stop {{ package }}
+    "{{ adb }}" shell am start -n {{ activity }}
 
-# build, install, and run
-br: build install run
+# build, install, and run on the connected device
+[group('Device')]
+br: android-build install run
 
 # force-stop the app
-stop:
-    {{ adb }} shell am force-stop {{ package }}
+[group('Device')]
+stop: _require-adb
+    "{{ adb }}" shell am force-stop {{ package }}
 
-# uninstall the app
-uninstall:
-    {{ adb }} uninstall {{ package }}
+# uninstall the app and all of its private data
+[confirm('Uninstall Kestrel and permanently remove its app-private data?')]
+[group('Device')]
+uninstall: _require-adb
+    "{{ adb }}" uninstall {{ package }}
 
 # list connected devices
-devices:
-    {{ adb }} devices
+[group('Device')]
+devices: _require-adb
+    "{{ adb }}" devices
 
 # follow logcat filtered to Kestrel and crashes
-log:
-    {{ adb }} logcat | grep --line-buffered -iE "AndroidRuntime|FATAL|JNI DETECTED|{{ package }}|MapLibre|LocationService"
+[group('Device')]
+log: _require-adb
+    "{{ adb }}" logcat | grep --line-buffered -iE "AndroidRuntime|FATAL|JNI DETECTED|{{ package }}|MapLibre|LocationService"
 
 # clear logcat, then follow with the same filter
-logf:
-    {{ adb }} logcat -c
+[group('Device')]
+logf: _require-adb
+    "{{ adb }}" logcat -c
     just log
 
 # dump current DataStore prefs as a hex preview
-prefs:
-    {{ adb }} shell "run-as {{ package }} cat files/datastore/kestrel_prefs.preferences_pb" | xxd | head -40
+[group('Device')]
+prefs: _require-adb
+    "{{ adb }}" shell "run-as {{ package }} cat files/datastore/kestrel_prefs.preferences_pb" | xxd | head -40
 
 # clear all app data (resets prefs, mock state, and favorites)
-reset:
-    {{ adb }} shell pm clear {{ package }}
+[confirm('Permanently clear Kestrel prefs, favorites, and mock state?')]
+[group('Device')]
+reset: _require-adb
+    "{{ adb }}" shell pm clear {{ package }}
+
+[private]
+_require-android-sdk:
+    @test -d "{{ android_sdk }}" || { printf '%s\n' 'Android SDK not found. Set ANDROID_HOME or ANDROID_SDK_ROOT.' >&2; exit 1; }
+
+[private]
+_require-adb: _require-android-sdk
+    @test -x "{{ adb }}" || { printf '%s\n' 'adb not found in the configured Android SDK.' >&2; exit 1; }
+
+[private]
+_require-web-deps:
+    @test -x web/node_modules/.bin/biome && test -x web/node_modules/.bin/next || { printf '%s\n' 'Web dependencies are missing. Run: just web-install' >&2; exit 1; }
+
+[private]
+_require-backend-deps:
+    @test -x backend/node_modules/.bin/eslint && test -x backend/node_modules/.bin/jest && test -x backend/node_modules/.bin/nest && test -x backend/node_modules/.bin/prisma || { printf '%s\n' 'Backend dependencies are missing. Run: just backend-install' >&2; exit 1; }


### PR DESCRIPTION
## Summary

- make bare `just` display grouped, non-destructive help while preserving existing recipe entry points
- add deterministic Android SDK, adb, Web, and Backend dependency guards plus explicit install/setup recipes
- add focused and comprehensive Android, Backend, and Web verification workflows, including Prisma client generation
- require confirmation for destructive device and generated-reference updates
- align README task documentation and archive the completed implementation plan

## Validation

- `just --fmt --check`
- `just check`
- `just lint`
- `just backend-check` (116 unit tests and 8 e2e tests)
- `just web-verify`
- `git diff --check`
- README recipe-reference assertion against `just --summary`
- missing-dependency, confirmation-metadata, default-safety, and destructive-command dry-run assertions

## Environment note

The current host has no Android SDK, so SDK-dependent Android test, screenshot, and build tasks were verified through command expansion and the new actionable SDK guard rather than executed. Android Spotless and Detekt passed.
