### PR TITLE
fix(web): align route playback select options

### DIFF
--- a/web/app/radix-ui.css
+++ b/web/app/radix-ui.css
@@ -327,7 +327,7 @@
 
 .ui-select-popup {
   border-radius: 12px;
-  min-width: var(--anchor-width);
+  min-width: var(--radix-select-trigger-width);
   overflow: hidden;
 }
 
@@ -341,13 +341,11 @@
   align-items: center;
   border-radius: 8px;
   cursor: default;
-  display: grid;
+  display: flex;
   font-size: 0.9rem;
-  gap: 8px;
-  grid-template-columns: 16px minmax(0, 1fr);
   min-height: 38px;
   outline: none;
-  padding: 7px 10px;
+  padding-block: 7px;
   user-select: none;
 }
 


### PR DESCRIPTION
## Summary
- size the playback mode popup with the Radix Select trigger-width variable
- preserve Radix Select’s flex item layout and indicator spacing so option labels remain horizontal

## Verification
- verified the route editor playback menu in Chrome DevTools
- `just web-check`
- `just web-typecheck`
- `just web-build`