### PR TITLE
perf(android): reduce runtime CPU and allocations

### DIFF
--- a/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/data/Preferences.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
@@ -158,18 +159,46 @@ class KestrelPrefs(
     private val json = Json { ignoreUnknownKeys = true }
     private val store = context.applicationContext.prefStore
 
-    val lastCamera: Flow<CameraSnapshot?> = store.data.map { it.toCamera() }
+    val lastCamera: Flow<CameraSnapshot?> =
+        store.data
+            .map { it.toCamera() }
+            .distinctUntilChanged()
 
-    val favoritesSortMode: Flow<FavoritesSortMode> = store.data.map { it.toFavoritesSortMode(json) }
-    val mockState: Flow<MockState?> = store.data.map { it.toMockState(json) }
-    val startupPreference: Flow<StartupPreference> = store.data.map { it.toStartupPref(json) }
+    val favoritesSortMode: Flow<FavoritesSortMode> =
+        store.data
+            .map { it[Keys.FAVORITES_SORT_MODE] }
+            .distinctUntilChanged()
+            .map { decodeFavoritesSortMode(it, json) }
+    val mockState: Flow<MockState?> =
+        store.data
+            .map { it[Keys.MOCK_STATE] }
+            .distinctUntilChanged()
+            .map { decodeMockState(it, json) }
+    val startupPreference: Flow<StartupPreference> =
+        store.data
+            .map { it[Keys.STARTUP_PREF] }
+            .distinctUntilChanged()
+            .map { decodeStartupPreference(it, json) }
     val randomRoutePreference: Flow<RandomRoutePreference> =
-        store.data.map { it.toRandomRoutePref(json) }
+        store.data
+            .map { it[Keys.RANDOM_ROUTE_PREF] }
+            .distinctUntilChanged()
+            .map { decodeRandomRoutePreference(it, json) }
     val mockPlaybackSettings: Flow<MockPlaybackSettings> =
-        store.data.map { it.toMockPlaybackSettings(json) }
-    val cloudSettings: Flow<CloudSettings> = store.data.map { it.toCloudSettings(json) }
+        store.data
+            .map { it[Keys.MOCK_PLAYBACK_SETTINGS] }
+            .distinctUntilChanged()
+            .map { decodeMockPlaybackSettings(it, json) }
+    val cloudSettings: Flow<CloudSettings> =
+        store.data
+            .map { it[Keys.CLOUD_SETTINGS] }
+            .distinctUntilChanged()
+            .map { decodeCloudSettings(it, json) }
     val remoteControlSettings: Flow<RemoteControlSettings> =
-        store.data.map { it.toRemoteControlSettings(json) }
+        store.data
+            .map { it[Keys.REMOTE_CONTROL_SETTINGS] }
+            .distinctUntilChanged()
+            .map { decodeRemoteControlSettings(it, json) }
 
     suspend fun setLastCamera(snap: CameraSnapshot) {
         store.edit {
@@ -312,52 +341,67 @@ class KestrelPrefs(
         return CameraSnapshot(lat, lng, zoom)
     }
 
-    private fun Preferences.toFavoritesSortMode(json: Json): FavoritesSortMode {
-        val raw = this[Keys.FAVORITES_SORT_MODE] ?: return FavoritesSortMode()
-        return runCatching {
-            json.decodeFromString(FavoritesSortMode.serializer(), raw)
-        }.getOrDefault(FavoritesSortMode())
+    private fun Preferences.toRandomRoutePref(json: Json): RandomRoutePreference = decodeRandomRoutePreference(this[Keys.RANDOM_ROUTE_PREF], json)
+
+    private fun Preferences.toMockPlaybackSettings(json: Json): MockPlaybackSettings = decodeMockPlaybackSettings(this[Keys.MOCK_PLAYBACK_SETTINGS], json)
+
+    private fun Preferences.toCloudSettings(json: Json): CloudSettings = decodeCloudSettings(this[Keys.CLOUD_SETTINGS], json)
+}
+
+private fun decodeFavoritesSortMode(
+    raw: String?,
+    json: Json,
+): FavoritesSortMode =
+    raw?.let {
+        runCatching { json.decodeFromString(FavoritesSortMode.serializer(), it) }.getOrNull()
+    } ?: FavoritesSortMode()
+
+private fun decodeMockState(
+    raw: String?,
+    json: Json,
+): MockState? =
+    raw?.let {
+        runCatching { json.decodeFromString(MockState.serializer(), it) }.getOrNull()
     }
 
-    private fun Preferences.toMockState(json: Json): MockState? {
-        val raw = this[Keys.MOCK_STATE] ?: return null
-        return runCatching {
-            json.decodeFromString(MockState.serializer(), raw)
+private fun decodeStartupPreference(
+    raw: String?,
+    json: Json,
+): StartupPreference =
+    raw?.let {
+        runCatching { json.decodeFromString(StartupPreference.serializer(), it) }.getOrNull()
+    } ?: StartupPreference()
+
+private fun decodeRandomRoutePreference(
+    raw: String?,
+    json: Json,
+): RandomRoutePreference =
+    raw?.let {
+        runCatching { json.decodeFromString(RandomRoutePreference.serializer(), it) }.getOrNull()
+    } ?: RandomRoutePreference()
+
+private fun decodeMockPlaybackSettings(
+    raw: String?,
+    json: Json,
+): MockPlaybackSettings =
+    raw?.let {
+        runCatching {
+            json.decodeFromString(MockPlaybackSettings.serializer(), it).normalized()
         }.getOrNull()
-    }
+    } ?: MockPlaybackSettings()
 
-    private fun Preferences.toStartupPref(json: Json): StartupPreference {
-        val raw = this[Keys.STARTUP_PREF] ?: return StartupPreference()
-        return runCatching {
-            json.decodeFromString(StartupPreference.serializer(), raw)
-        }.getOrDefault(StartupPreference())
-    }
+private fun decodeCloudSettings(
+    raw: String?,
+    json: Json,
+): CloudSettings =
+    raw?.let {
+        runCatching { json.decodeFromString(CloudSettings.serializer(), it) }.getOrNull()
+    } ?: CloudSettings()
 
-    private fun Preferences.toRandomRoutePref(json: Json): RandomRoutePreference {
-        val raw = this[Keys.RANDOM_ROUTE_PREF] ?: return RandomRoutePreference()
-        return runCatching {
-            json.decodeFromString(RandomRoutePreference.serializer(), raw)
-        }.getOrDefault(RandomRoutePreference())
-    }
-
-    private fun Preferences.toMockPlaybackSettings(json: Json): MockPlaybackSettings {
-        val raw = this[Keys.MOCK_PLAYBACK_SETTINGS] ?: return MockPlaybackSettings()
-        return runCatching {
-            json.decodeFromString(MockPlaybackSettings.serializer(), raw).normalized()
-        }.getOrDefault(MockPlaybackSettings())
-    }
-
-    private fun Preferences.toCloudSettings(json: Json): CloudSettings {
-        val raw = this[Keys.CLOUD_SETTINGS] ?: return CloudSettings()
-        return runCatching {
-            json.decodeFromString(CloudSettings.serializer(), raw)
-        }.getOrDefault(CloudSettings())
-    }
-}
-
-private fun Preferences.toRemoteControlSettings(json: Json): RemoteControlSettings {
-    val raw = this[Keys.REMOTE_CONTROL_SETTINGS] ?: return RemoteControlSettings()
-    return runCatching {
-        json.decodeFromString(RemoteControlSettings.serializer(), raw)
-    }.getOrDefault(RemoteControlSettings())
-}
+private fun decodeRemoteControlSettings(
+    raw: String?,
+    json: Json,
+): RemoteControlSettings =
+    raw?.let {
+        runCatching { json.decodeFromString(RemoteControlSettings.serializer(), it) }.getOrNull()
+    } ?: RemoteControlSettings()

--- a/app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
@@ -38,6 +38,43 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
 
+internal class ActiveRouteSnapshot private constructor(
+    val engine: MovementEngine,
+    private val latitudes: DoubleArray,
+    private val longitudes: DoubleArray,
+    private val speedKmh: Double,
+    private val mode: MovementEngine.Mode,
+) {
+    fun toRouteState(
+        progressMeters: Double,
+        forward: Boolean,
+    ): RouteState =
+        RouteState(
+            lats = latitudes,
+            lngs = longitudes,
+            speedKmh = speedKmh,
+            mode = mode.name,
+            progressMeters = progressMeters,
+            forward = forward,
+        )
+
+    companion object {
+        fun create(
+            engine: MovementEngine,
+            waypoints: List<LatLng>,
+            speedKmh: Double,
+            mode: MovementEngine.Mode,
+        ): ActiveRouteSnapshot =
+            ActiveRouteSnapshot(
+                engine = engine,
+                latitudes = DoubleArray(waypoints.size) { waypoints[it].lat },
+                longitudes = DoubleArray(waypoints.size) { waypoints[it].lng },
+                speedKmh = speedKmh,
+                mode = mode,
+            )
+    }
+}
+
 class LocationService : Service() {
     private lateinit var mockProvider: MockProviderManager
     private lateinit var prefs: KestrelPrefs
@@ -53,13 +90,9 @@ class LocationService : Service() {
     @Volatile private var paused = false
     private var currentMode: MockState.Mode = MockState.Mode.Idle
 
-    // Snapshot the serialized coordinates once per route instead of allocating new arrays on every
-    // periodic progress write.
-    private var activeEngine: MovementEngine? = null
-    private var activeRouteLatitudes: DoubleArray? = null
-    private var activeRouteLongitudes: DoubleArray? = null
-    private var activeRouteSpeedKmh: Double = 0.0
-    private var activeRouteMode: MovementEngine.Mode = MovementEngine.Mode.Once
+    // Publish the active engine and serialized route fields together so progress writers cannot
+    // combine state from two routes during replacement.
+    @Volatile private var activeRoute: ActiveRouteSnapshot? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -220,7 +253,7 @@ class LocationService : Service() {
         }
         setRemoteControlServiceLease(true)
         refreshNotification()
-        scope.launch { persistRouteState(progressMeters = 0.0, forward = true) }
+        scope.launch { persistRouteState(engine) }
         completeOperation(intent, succeeded = true, message = "Route playback started.")
         return START_STICKY
     }
@@ -231,8 +264,8 @@ class LocationService : Service() {
         updateRouteRuntimePaused(paused = true)
         refreshNotification()
         scope.launch {
-            val engine = activeEngine ?: return@launch
-            persistRouteState(engine.progressMeters(), engine.isForward())
+            val engine = activeRoute?.engine ?: return@launch
+            persistRouteState(engine)
         }
         completeOperation(intent, succeeded = true, message = "Route paused.")
         return START_STICKY
@@ -244,8 +277,8 @@ class LocationService : Service() {
         updateRouteRuntimePaused(paused = false)
         refreshNotification()
         scope.launch {
-            val engine = activeEngine ?: return@launch
-            persistRouteState(engine.progressMeters(), engine.isForward())
+            val engine = activeRoute?.engine ?: return@launch
+            persistRouteState(engine)
         }
         completeOperation(intent, succeeded = true, message = "Route resumed.")
         return START_STICKY
@@ -256,10 +289,10 @@ class LocationService : Service() {
     override fun onDestroy() {
         // Best-effort progress flush before the scope is cancelled. onDestroy is not guaranteed to
         // run under sudden kills; the periodic tick writer is what makes overnight kills survivable.
-        val engine = activeEngine
+        val engine = activeRoute?.engine
         if (engine != null && currentMode == MockState.Mode.Route) {
             runCatching {
-                runBlocking { persistRouteState(engine.progressMeters(), engine.isForward()) }
+                runBlocking { persistRouteState(engine) }
             }
         }
         stopRoute()
@@ -363,11 +396,7 @@ class LocationService : Service() {
         stopRoute()
         stopSingleKeepAlive()
         paused = false
-        activeEngine = engine
-        activeRouteLatitudes = DoubleArray(waypoints.size) { waypoints[it].lat }
-        activeRouteLongitudes = DoubleArray(waypoints.size) { waypoints[it].lng }
-        activeRouteSpeedKmh = speedKmh
-        activeRouteMode = mode
+        activeRoute = ActiveRouteSnapshot.create(engine, waypoints, speedKmh, mode)
         routeJob =
             scope.launch {
                 // Read once per route job so Settings changes apply to the next route start or
@@ -387,14 +416,16 @@ class LocationService : Service() {
                         tickCounter = 0
                         // Snapshot progress + direction in the same write so they can't disagree
                         // across a process restart.
-                        persistRouteState(engine.progressMeters(), engine.isForward())
+                        persistRouteState(engine)
                     }
                 }
-                if (mode == MovementEngine.Mode.Once && engine.isFinished()) {
+                if (
+                    mode == MovementEngine.Mode.Once &&
+                    engine.isFinished() &&
+                    activeRoute?.engine === engine
+                ) {
                     val last = waypoints.last()
-                    activeEngine = null
-                    activeRouteLatitudes = null
-                    activeRouteLongitudes = null
+                    activeRoute = null
                     currentMode = MockState.Mode.Single
                     startSingleKeepAlive(last)
                     _runtimeState.value = RuntimeState.Single(last)
@@ -414,29 +445,15 @@ class LocationService : Service() {
         routeJob?.cancel()
         routeJob = null
         paused = false
-        activeEngine = null
-        activeRouteLatitudes = null
-        activeRouteLongitudes = null
+        activeRoute = null
     }
 
-    private suspend fun persistRouteState(
-        progressMeters: Double,
-        forward: Boolean,
-    ) {
-        val lats = activeRouteLatitudes ?: return
-        val lngs = activeRouteLongitudes ?: return
+    private suspend fun persistRouteState(engine: MovementEngine) {
+        val route = activeRoute?.takeIf { it.engine === engine } ?: return
         prefs.setMockState(
             MockState(
                 mode = MockState.Mode.Route,
-                route =
-                    RouteState(
-                        lats = lats,
-                        lngs = lngs,
-                        speedKmh = activeRouteSpeedKmh,
-                        mode = activeRouteMode.name,
-                        progressMeters = progressMeters,
-                        forward = forward,
-                    ),
+                route = route.toRouteState(engine.progressMeters(), engine.isForward()),
             ),
         )
     }
@@ -472,7 +489,7 @@ class LocationService : Service() {
         engine: MovementEngine,
     ) {
         synchronized(providerWriteLock) {
-            if (activeEngine !== engine || !providerStarted) return
+            if (activeRoute?.engine !== engine || !providerStarted) return
             runCatching {
                 mockProvider.setLocation(
                     point = sample.point,

--- a/app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/location/LocationService.kt
@@ -53,10 +53,11 @@ class LocationService : Service() {
     @Volatile private var paused = false
     private var currentMode: MockState.Mode = MockState.Mode.Idle
 
-    // Snapshot of the in-flight route so periodic + transition writes can rebuild the matching
-    // `RouteState` (with current progress + forward) without re-reading waypoints from DataStore.
+    // Snapshot the serialized coordinates once per route instead of allocating new arrays on every
+    // periodic progress write.
     private var activeEngine: MovementEngine? = null
-    private var activeRouteWaypoints: List<LatLng> = emptyList()
+    private var activeRouteLatitudes: DoubleArray? = null
+    private var activeRouteLongitudes: DoubleArray? = null
     private var activeRouteSpeedKmh: Double = 0.0
     private var activeRouteMode: MovementEngine.Mode = MovementEngine.Mode.Once
 
@@ -363,7 +364,8 @@ class LocationService : Service() {
         stopSingleKeepAlive()
         paused = false
         activeEngine = engine
-        activeRouteWaypoints = waypoints
+        activeRouteLatitudes = DoubleArray(waypoints.size) { waypoints[it].lat }
+        activeRouteLongitudes = DoubleArray(waypoints.size) { waypoints[it].lng }
         activeRouteSpeedKmh = speedKmh
         activeRouteMode = mode
         routeJob =
@@ -391,7 +393,8 @@ class LocationService : Service() {
                 if (mode == MovementEngine.Mode.Once && engine.isFinished()) {
                     val last = waypoints.last()
                     activeEngine = null
-                    activeRouteWaypoints = emptyList()
+                    activeRouteLatitudes = null
+                    activeRouteLongitudes = null
                     currentMode = MockState.Mode.Single
                     startSingleKeepAlive(last)
                     _runtimeState.value = RuntimeState.Single(last)
@@ -412,17 +415,16 @@ class LocationService : Service() {
         routeJob = null
         paused = false
         activeEngine = null
-        activeRouteWaypoints = emptyList()
+        activeRouteLatitudes = null
+        activeRouteLongitudes = null
     }
 
     private suspend fun persistRouteState(
         progressMeters: Double,
         forward: Boolean,
     ) {
-        val waypoints = activeRouteWaypoints
-        if (waypoints.isEmpty()) return
-        val lats = DoubleArray(waypoints.size) { waypoints[it].lat }
-        val lngs = DoubleArray(waypoints.size) { waypoints[it].lng }
+        val lats = activeRouteLatitudes ?: return
+        val lngs = activeRouteLongitudes ?: return
         prefs.setMockState(
             MockState(
                 mode = MockState.Mode.Route,

--- a/app/src/main/java/dev/narumi/kestrel/core/location/MockProviderManager.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/location/MockProviderManager.kt
@@ -15,6 +15,7 @@ class MockProviderManager(
         requireNotNull(context.getSystemService<LocationManager>()) {
             "LocationManager unavailable"
         }
+    private val mockLocations = MOCK_PROVIDERS.map(::Location)
     private var enabled = false
 
     fun start() {
@@ -51,23 +52,26 @@ class MockProviderManager(
         accuracy: Float = 1f,
     ) {
         if (!enabled) return
-        for (provider in MOCK_PROVIDERS) {
-            val location =
-                Location(provider).apply {
-                    latitude = point.lat
-                    longitude = point.lng
-                    this.accuracy = accuracy
-                    this.speed = speed
-                    this.bearing = bearing
-                    time = System.currentTimeMillis()
-                    elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        speedAccuracyMetersPerSecond = 0.1f
-                        bearingAccuracyDegrees = 0.1f
-                        verticalAccuracyMeters = 1f
-                    }
+        val wallClockMillis = System.currentTimeMillis()
+        val elapsedRealtimeNanos = SystemClock.elapsedRealtimeNanos()
+        for (location in mockLocations) {
+            location.apply {
+                latitude = point.lat
+                longitude = point.lng
+                this.accuracy = accuracy
+                this.speed = speed
+                this.bearing = bearing
+                time = wallClockMillis
+                this.elapsedRealtimeNanos = elapsedRealtimeNanos
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    speedAccuracyMetersPerSecond = 0.1f
+                    bearingAccuracyDegrees = 0.1f
+                    verticalAccuracyMeters = 1f
                 }
-            runCatching { locationManager.setTestProviderLocation(provider, location) }
+            }
+            runCatching {
+                locationManager.setTestProviderLocation(requireNotNull(location.provider), location)
+            }
         }
     }
 

--- a/app/src/main/java/dev/narumi/kestrel/core/location/MovementEngine.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/location/MovementEngine.kt
@@ -29,7 +29,15 @@ class MovementEngine(
                 if (len > 0.0) add(Segment(a, b, len, bearingDegrees(a, b)))
             }
         }
-    private val totalDistance: Double = segments.sumOf { it.length }
+    private val segmentEnds: DoubleArray =
+        DoubleArray(segments.size).also { ends ->
+            var distance = 0.0
+            segments.forEachIndexed { index, segment ->
+                distance += segment.length
+                ends[index] = distance
+            }
+        }
+    private val totalDistance: Double = segmentEnds.lastOrNull() ?: 0.0
 
     // Seeded from persisted state so that a service restart resumes near where the previous run
     // stopped, instead of from the first waypoint. Clamped into [0, totalDistance] to keep corrupt
@@ -77,20 +85,29 @@ class MovementEngine(
         if (segments.isEmpty()) {
             return MockSample(point = LatLng(0.0, 0.0), speedMps = 0.0, bearingDeg = 0.0)
         }
-        var remaining = meters
-        for (segment in segments) {
-            if (remaining <= segment.length) {
-                val t = if (segment.length == 0.0) 0.0 else remaining / segment.length
-                return MockSample(
-                    point = lerpLatLng(segment.from, segment.to, t),
-                    speedMps = if (isFinished()) 0.0 else speedMps,
-                    bearingDeg = segment.bearing,
-                )
+        val segmentIndex = segmentIndexAt(meters)
+        val segment = segments[segmentIndex]
+        val segmentStart = if (segmentIndex == 0) 0.0 else segmentEnds[segmentIndex - 1]
+        val offset = (meters - segmentStart).coerceIn(0.0, segment.length)
+        return MockSample(
+            point = lerpLatLng(segment.from, segment.to, offset / segment.length),
+            speedMps = if (isFinished()) 0.0 else speedMps,
+            bearingDeg = segment.bearing,
+        )
+    }
+
+    private fun segmentIndexAt(meters: Double): Int {
+        var low = 0
+        var high = segmentEnds.lastIndex
+        while (low < high) {
+            val middle = (low + high) ushr 1
+            if (segmentEnds[middle] < meters) {
+                low = middle + 1
+            } else {
+                high = middle
             }
-            remaining -= segment.length
         }
-        val last = segments.last()
-        return MockSample(point = last.to, speedMps = 0.0, bearingDeg = last.bearing)
+        return low
     }
 
     private data class Segment(

--- a/app/src/main/java/dev/narumi/kestrel/core/map/KestrelMap.kt
+++ b/app/src/main/java/dev/narumi/kestrel/core/map/KestrelMap.kt
@@ -86,13 +86,16 @@ fun KestrelMap(
     val currentMapClick by rememberUpdatedState(onMapClick)
     val currentMapLongClick by rememberUpdatedState(onMapLongClick)
     val currentCameraIdle by rememberUpdatedState(onCameraIdle)
+    val colorScheme = MaterialTheme.colorScheme
     val colors =
-        MapColors(
-            primary = MaterialTheme.colorScheme.primary.toArgb(),
-            preview = MaterialTheme.colorScheme.tertiary.toArgb(),
-            mock = MaterialTheme.colorScheme.error.toArgb(),
-            onPrimary = MaterialTheme.colorScheme.onPrimary.toArgb(),
-        )
+        remember(colorScheme) {
+            MapColors(
+                primary = colorScheme.primary.toArgb(),
+                preview = colorScheme.tertiary.toArgb(),
+                mock = colorScheme.error.toArgb(),
+                onPrimary = colorScheme.onPrimary.toArgb(),
+            )
+        }
     val mapView =
         remember {
             MapLibre.getInstance(context, null, WellKnownTileServer.MapLibre)

--- a/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/map/MapScreen.kt
@@ -361,7 +361,9 @@ fun MapScreen(
 
     val setupStep = mapSetupStep(permissionState.allPermissionsGranted, mockAllowed)
     val ready = setupStep == MapSetupStep.Ready
-    val mockNow by LocationService.currentMock.collectAsStateWithLifecycle()
+    // Defer the per-tick value read to the map and sheet lambdas so route playback does not
+    // recompose this entire screen every second.
+    val currentMockState = LocationService.currentMock.collectAsStateWithLifecycle()
     val runtimeState by LocationService.runtimeState.collectAsStateWithLifecycle()
     val latestOperationResult by
         LocationService.operationResults.collectAsStateWithLifecycle(initialValue = null)
@@ -616,7 +618,7 @@ fun MapScreen(
             runState = runState,
             waypointCount = renderedWaypoints.size,
             draftWaypointCount = waypoints.size,
-            mockNow = mockNow,
+            mockNow = currentMockState.value,
             ready = ready,
             speedKmh = renderedSpeedKmh,
             routeMode = renderedRouteMode,
@@ -650,7 +652,7 @@ fun MapScreen(
     val mapCanvas: @Composable (Modifier) -> Unit = { canvasModifier ->
         MapCanvas(
             modifier = canvasModifier,
-            mockLocation = mockNow,
+            mockLocation = currentMockState.value,
             currentRoute = activeRoute,
             previewRoute = previewRoute,
             previewPoint = previewPoint,

--- a/app/src/test/java/dev/narumi/kestrel/core/location/ActiveRouteSnapshotTest.kt
+++ b/app/src/test/java/dev/narumi/kestrel/core/location/ActiveRouteSnapshotTest.kt
@@ -1,0 +1,42 @@
+package dev.narumi.kestrel.core.location
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class ActiveRouteSnapshotTest {
+    @Test
+    fun buildsConsistentRouteStateFromCapturedRoute() {
+        val originalStart = LatLng(25.0, 121.0)
+        val originalEnd = LatLng(25.1, 121.1)
+        val waypoints = mutableListOf(originalStart, originalEnd)
+        val engine =
+            MovementEngine(
+                waypoints = waypoints,
+                speedMps = 5.0,
+                mode = MovementEngine.Mode.Loop,
+            )
+        val snapshot =
+            ActiveRouteSnapshot.create(
+                engine = engine,
+                waypoints = waypoints,
+                speedKmh = 18.0,
+                mode = MovementEngine.Mode.Loop,
+            )
+
+        waypoints[0] = LatLng(0.0, 0.0)
+        val first = snapshot.toRouteState(progressMeters = 12.5, forward = false)
+        val second = snapshot.toRouteState(progressMeters = 25.0, forward = true)
+
+        assertSame(engine, snapshot.engine)
+        assertArrayEquals(doubleArrayOf(originalStart.lat, originalEnd.lat), first.lats, 0.0)
+        assertArrayEquals(doubleArrayOf(originalStart.lng, originalEnd.lng), first.lngs, 0.0)
+        assertEquals(18.0, first.speedKmh, 0.0)
+        assertEquals(MovementEngine.Mode.Loop.name, first.mode)
+        assertEquals(12.5, first.progressMeters, 0.0)
+        assertEquals(false, first.forward)
+        assertSame(first.lats, second.lats)
+        assertSame(first.lngs, second.lngs)
+    }
+}

--- a/app/src/test/java/dev/narumi/kestrel/core/location/MovementEngineTest.kt
+++ b/app/src/test/java/dev/narumi/kestrel/core/location/MovementEngineTest.kt
@@ -46,6 +46,41 @@ class MovementEngineTest {
     }
 
     @Test
+    fun exactWaypointUsesTheIncomingSegment() {
+        val c = LatLng(0.001, 0.001)
+        val engine =
+            MovementEngine(
+                waypoints = listOf(a, b, c),
+                speedMps = segmentMeters,
+                mode = MovementEngine.Mode.Once,
+            )
+
+        val sample = engine.advance(deltaSeconds = 1.0)
+
+        assertEquals(b.lat, sample.point.lat, 1e-9)
+        assertEquals(b.lng, sample.point.lng, 1e-9)
+        assertEquals(bearingDegrees(a, b), sample.bearingDeg, 1e-9)
+    }
+
+    @Test
+    fun findsPositionNearEndOfLongRoute() {
+        val waypoints = List(1001) { index -> LatLng(0.0, index * 0.001) }
+        val engine =
+            MovementEngine(
+                waypoints = waypoints,
+                speedMps = segmentMeters,
+                mode = MovementEngine.Mode.Once,
+                initialProgressMeters = segmentMeters * 998.5,
+            )
+
+        val sample = engine.advance(deltaSeconds = 0.25)
+
+        assertEquals(segmentMeters * 998.75, engine.progressMeters(), 1e-4)
+        assertEquals(0.99875, sample.point.lng, 1e-8)
+        assertTrue(sample.speedMps > 0.0)
+    }
+
+    @Test
     fun pingPongModeReflectsAfterPassingEnd() {
         val engine =
             MovementEngine(


### PR DESCRIPTION
## Summary

- replace linear route segment scans with binary search for long-route playback
- reuse route persistence arrays and mock `Location` objects to reduce allocation and GC pressure
- skip unrelated DataStore JSON decoding and limit per-tick Compose recomposition work
- add coverage for long routes and exact waypoint boundaries

## Validation

- `just android-check`
- `just android-lint`
- `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools just android-test`
- `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools just android-build`
- `git diff --check`

## Notes

No connected-device or instrumentation checks were run, so this does not modify app or device state.
