### PR TITLE
fix(android): reclaim favorites list space

### DIFF
--- a/app/src/androidTest/java/dev/narumi/kestrel/feature/FavoritesLayoutInteractionTest.kt
+++ b/app/src/androidTest/java/dev/narumi/kestrel/feature/FavoritesLayoutInteractionTest.kt
@@ -1,0 +1,189 @@
+package dev.narumi.kestrel.feature
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsAtLeast
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.unit.dp
+import dev.narumi.kestrel.core.data.FavoritesSortMode
+import dev.narumi.kestrel.core.library.LibraryItem
+import dev.narumi.kestrel.core.library.LibraryItemKind
+import dev.narumi.kestrel.core.library.LibraryItemWithContent
+import dev.narumi.kestrel.core.location.LatLng
+import dev.narumi.kestrel.core.location.MovementEngine
+import dev.narumi.kestrel.core.location.RuntimeState
+import dev.narumi.kestrel.feature.favorites.FavoritesContent
+import dev.narumi.kestrel.feature.favorites.FavoritesFilter
+import dev.narumi.kestrel.feature.favorites.FavoritesToolbar
+import dev.narumi.kestrel.ui.components.PlaybackStatusBar
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class FavoritesLayoutInteractionTest {
+    @get:Rule val composeRule = createComposeRule()
+
+    @Test
+    fun menusShowCurrentSelectionsAndDisableSortingWhileSaving() {
+        composeRule.setContent {
+            var filter by remember { mutableStateOf(FavoritesFilter.All) }
+            var sort by remember { mutableStateOf(FavoritesSortMode.Mode.Manual) }
+            var busy by remember { mutableStateOf(false) }
+            MaterialTheme {
+                FavoritesToolbar(
+                    selectedFilter = filter,
+                    sortMode = sort,
+                    operationBusy = busy,
+                    onFilterChange = { filter = it },
+                    onSortModeChange = {
+                        sort = it
+                        busy = true
+                    },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Show: All").assertHeightIsAtLeast(48.dp).performClick()
+        composeRule.onNodeWithText("All").assertIsSelected()
+        composeRule.onNodeWithText("Points").performClick()
+        composeRule.onNodeWithText("Show: Points").assertIsDisplayed()
+        composeRule.onNodeWithText("Sort by: Manual").assertHeightIsAtLeast(48.dp).performClick()
+        composeRule.onNodeWithText("Manual").assertIsSelected()
+        composeRule.onNodeWithText("Alphabetical").performClick()
+        composeRule.onNodeWithText("Sort by: Alphabetical").assertIsNotEnabled()
+    }
+
+    @Test
+    fun compactPlaybackKeepsDirectAccessibleActionsAndBusyGuard() {
+        var mapViews = 0
+        var pauses = 0
+        var resumes = 0
+        var stops = 0
+        composeRule.setContent {
+            var runtime by remember { mutableStateOf(playingRoute) }
+            var busy by remember { mutableStateOf(false) }
+            MaterialTheme {
+                PlaybackStatusBar(
+                    runtime = runtime,
+                    busy = busy,
+                    error = null,
+                    onViewMap = { mapViews++ },
+                    onPause = {
+                        pauses++
+                        runtime = runtime.copy(paused = true)
+                    },
+                    onResume = {
+                        resumes++
+                        runtime = runtime.copy(paused = false)
+                    },
+                    onStop = {
+                        stops++
+                        busy = true
+                    },
+                    modifier = Modifier.width(320.dp).testTag("playback"),
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag("playback").assertHeightIsEqualTo(56.dp)
+        composeRule.onNodeWithText("View map").assertHeightIsAtLeast(48.dp).performClick()
+        composeRule.onNodeWithContentDescription("Pause").assertHeightIsAtLeast(48.dp).performClick()
+        composeRule.onNodeWithText("Route paused").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Resume").assertHeightIsAtLeast(48.dp).performClick()
+        composeRule.onNodeWithText("Route playing").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Stop").assertHeightIsAtLeast(48.dp).performClick()
+        composeRule.onNodeWithContentDescription("Pause").assertIsNotEnabled()
+        composeRule.onNodeWithContentDescription("Stop").assertIsNotEnabled()
+        composeRule.runOnIdle {
+            assertEquals(listOf(1, 1, 1, 1), listOf(mapViews, pauses, resumes, stops))
+        }
+    }
+
+    @Test
+    fun shortViewportScrollsFromControlsToLastFavoriteWithoutLosingPlayback() {
+        val items =
+            List(20) { index ->
+                LibraryItemWithContent(
+                    item =
+                        LibraryItem(
+                            id = "item-$index",
+                            kind = LibraryItemKind.Place,
+                            sortOrder = index,
+                            createdAt = 0,
+                            updatedAt = 0,
+                        ),
+                    name = "Favorite $index",
+                    kind = LibraryItemKind.Place,
+                )
+            }
+        composeRule.setContent {
+            MaterialTheme {
+                Column(Modifier.size(width = 320.dp, height = 360.dp)) {
+                    PlaybackStatusBar(
+                        runtime = playingRoute,
+                        busy = false,
+                        error = null,
+                        onViewMap = {},
+                        onPause = {},
+                        onResume = {},
+                        onStop = {},
+                    )
+                    FavoritesContent(
+                        modifier = Modifier.weight(1f),
+                        items = items,
+                        visibleItems = items,
+                        loading = false,
+                        selectedFilter = FavoritesFilter.All,
+                        sortMode = FavoritesSortMode.Mode.Manual,
+                        operationMessage = null,
+                        operationError = null,
+                        operationBusy = false,
+                        onFilterChange = {},
+                        onSortModeChange = {},
+                        onChooseOnMap = {},
+                        onApply = {},
+                        onRename = {},
+                        onEdit = {},
+                        onMove = { _, _ -> },
+                        onDelete = {},
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Favorite 0").assertIsDisplayed()
+        composeRule.onNode(hasScrollAction()).performScrollToNode(hasText("Favorite 19"))
+        composeRule.onNodeWithText("Favorite 19").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Pause").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Stop").assertIsDisplayed()
+        composeRule.onNode(hasScrollAction()).performScrollToNode(hasText("Show: All", substring = true))
+        composeRule.onNodeWithText("Show: All").assertIsDisplayed()
+    }
+}
+
+private val playingRoute =
+    RuntimeState.Route(
+        waypoints = listOf(LatLng(25.0, 121.0), LatLng(25.1, 121.1)),
+        speedKmh = 12.0,
+        mode = MovementEngine.Mode.Loop,
+        paused = false,
+    )

--- a/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesScreen.kt
@@ -3,20 +3,19 @@ package dev.narumi.kestrel.feature.favorites
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -57,7 +56,6 @@ import dev.narumi.kestrel.core.location.parseCoordInput
 import dev.narumi.kestrel.ui.components.KestrelActionRow
 import dev.narumi.kestrel.ui.components.KestrelCard
 import dev.narumi.kestrel.ui.components.KestrelEmptyState
-import dev.narumi.kestrel.ui.components.KestrelScreenHeader
 import dev.narumi.kestrel.ui.components.PersistedActionResult
 import dev.narumi.kestrel.ui.components.runPersistedAction
 import kotlinx.coroutines.launch
@@ -332,7 +330,7 @@ private fun FavoriteEditDialogs(
 
 @Suppress("LongParameterList")
 @Composable
-private fun FavoritesContent(
+internal fun FavoritesContent(
     modifier: Modifier,
     items: List<LibraryItemWithContent>,
     visibleItems: List<LibraryItemWithContent>,
@@ -351,58 +349,71 @@ private fun FavoritesContent(
     onMove: (LibraryItemWithContent, Int) -> Unit,
     onDelete: (LibraryItemWithContent) -> Unit,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        KestrelScreenHeader(
-            title = "Favorites",
-            subtitle = "Saved points and routes ready to preview on the map.",
-        )
-        (operationError ?: operationMessage)?.let {
-            KestrelCard(
-                modifier =
-                    Modifier.semantics {
-                        liveRegion =
-                            if (operationError != null) LiveRegionMode.Assertive else LiveRegionMode.Polite
-                    },
-            ) {
+        item(key = "header") {
+            Text("Favorites", style = MaterialTheme.typography.titleLarge)
+        }
+        if (!loading && items.isNotEmpty()) {
+            item(key = "controls") {
+                FavoritesToolbar(
+                    selectedFilter = selectedFilter,
+                    sortMode = sortMode,
+                    operationBusy = operationBusy,
+                    onFilterChange = onFilterChange,
+                    onSortModeChange = onSortModeChange,
+                )
+            }
+        }
+        (operationError ?: operationMessage)?.let { message ->
+            item(key = "feedback") {
                 Text(
-                    text = it,
+                    text = message,
+                    modifier =
+                        Modifier.semantics {
+                            liveRegion =
+                                if (operationError != null) LiveRegionMode.Assertive else LiveRegionMode.Polite
+                        },
+                    style = MaterialTheme.typography.bodySmall,
                     color = if (operationError != null) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
                 )
             }
         }
         if (loading) {
-            Column(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                CircularProgressIndicator()
-                Text("Loading Favorites…")
+            item(key = "loading") {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    CircularProgressIndicator()
+                    Text("Loading Favorites…")
+                }
             }
-        } else if (items.isEmpty()) {
-            EmptyFavorites(
-                title = "No favorites yet",
-                message = "Choose a point or route on the map, then save its preview.",
-            )
-            Button(onClick = onChooseOnMap, modifier = Modifier.align(Alignment.CenterHorizontally)) {
-                Text("Choose on map")
+        } else if (visibleItems.isEmpty()) {
+            item(key = "empty") {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    EmptyFavorites(
+                        title = if (items.isEmpty()) "No favorites yet" else "No ${selectedFilter.label().lowercase()} favorites",
+                        message =
+                            if (items.isEmpty()) {
+                                "Choose a point or route on the map, then save its preview."
+                            } else {
+                                "Choose another filter or create a preview on the map."
+                            },
+                    )
+                    Button(onClick = onChooseOnMap) { Text("Choose on map") }
+                }
             }
         } else {
-            FavoritesListContent(
+            favoriteItems(
                 items = items,
                 visibleItems = visibleItems,
-                selectedFilter = selectedFilter,
                 sortMode = sortMode,
                 operationBusy = operationBusy,
-                onFilterChange = onFilterChange,
-                onSortModeChange = onSortModeChange,
-                onChooseOnMap = onChooseOnMap,
                 onApply = onApply,
                 onRename = onRename,
                 onEdit = onEdit,
@@ -413,71 +424,34 @@ private fun FavoritesContent(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Suppress("LongParameterList")
-@Composable
-private fun FavoritesListContent(
+private fun LazyListScope.favoriteItems(
     items: List<LibraryItemWithContent>,
     visibleItems: List<LibraryItemWithContent>,
-    selectedFilter: FavoritesFilter,
     sortMode: FavoritesSortMode.Mode,
     operationBusy: Boolean,
-    onFilterChange: (FavoritesFilter) -> Unit,
-    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
-    onChooseOnMap: () -> Unit,
     onApply: (LibraryItemWithContent) -> Unit,
     onRename: (LibraryItemWithContent) -> Unit,
     onEdit: (LibraryItemWithContent) -> Unit,
     onMove: (LibraryItemWithContent, Int) -> Unit,
     onDelete: (LibraryItemWithContent) -> Unit,
 ) {
-    KestrelCard {
-        Text("Show", style = MaterialTheme.typography.labelLarge)
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            FavoritesFilter.entries.forEach { filter ->
-                AssistChip(
-                    onClick = { onFilterChange(filter) },
-                    label = { Text(if (filter == selectedFilter) "✓ ${filter.label()}" else filter.label()) },
-                )
-            }
-        }
-        Text("Sort by", style = MaterialTheme.typography.labelLarge)
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            FavoritesSortMode.Mode.entries.forEach { mode ->
-                AssistChip(
-                    onClick = { onSortModeChange(mode) },
-                    enabled = !operationBusy,
-                    label = { Text(if (mode == sortMode) "✓ ${mode.label()}" else mode.label()) },
-                )
-            }
-        }
-    }
-    if (visibleItems.isEmpty()) {
-        EmptyFavorites(
-            title = "No ${selectedFilter.label().lowercase()} favorites",
-            message = "Choose another filter or create a preview on the map.",
+    itemsIndexed(visibleItems, key = { _, item -> "favorite:${item.item.id}" }) { index, item ->
+        val previousIndex = visibleItems.getOrNull(index - 1)?.globalIndexIn(items)
+        val nextIndex = visibleItems.getOrNull(index + 1)?.globalIndexIn(items)
+        FavoriteRow(
+            item = item,
+            enabled = !operationBusy,
+            canReorder = sortMode == FavoritesSortMode.Mode.Manual,
+            canMoveUp = previousIndex != null,
+            canMoveDown = nextIndex != null,
+            onApply = { onApply(item) },
+            onRename = { onRename(item) },
+            onEdit = { onEdit(item) },
+            onMoveUp = { previousIndex?.let { onMove(item, it) } },
+            onMoveDown = { nextIndex?.let { onMove(item, it) } },
+            onDelete = { onDelete(item) },
         )
-        Button(onClick = onChooseOnMap) { Text("Choose on map") }
-    } else {
-        LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            itemsIndexed(visibleItems, key = { _, item -> item.item.id }) { index, item ->
-                val previousIndex = visibleItems.getOrNull(index - 1)?.globalIndexIn(items)
-                val nextIndex = visibleItems.getOrNull(index + 1)?.globalIndexIn(items)
-                FavoriteRow(
-                    item = item,
-                    enabled = !operationBusy,
-                    canReorder = sortMode == FavoritesSortMode.Mode.Manual,
-                    canMoveUp = previousIndex != null,
-                    canMoveDown = nextIndex != null,
-                    onApply = { onApply(item) },
-                    onRename = { onRename(item) },
-                    onEdit = { onEdit(item) },
-                    onMoveUp = { previousIndex?.let { onMove(item, it) } },
-                    onMoveDown = { nextIndex?.let { onMove(item, it) } },
-                    onDelete = { onDelete(item) },
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesToolbar.kt
+++ b/app/src/main/java/dev/narumi/kestrel/feature/favorites/FavoritesToolbar.kt
@@ -1,0 +1,92 @@
+package dev.narumi.kestrel.feature.favorites
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dev.narumi.kestrel.core.data.FavoritesSortMode
+import dev.narumi.kestrel.core.library.label
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun FavoritesToolbar(
+    selectedFilter: FavoritesFilter,
+    sortMode: FavoritesSortMode.Mode,
+    operationBusy: Boolean,
+    onFilterChange: (FavoritesFilter) -> Unit,
+    onSortModeChange: (FavoritesSortMode.Mode) -> Unit,
+) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        FavoritesMenu(
+            label = "Show: ${selectedFilter.label()}",
+            options = FavoritesFilter.entries,
+            selected = selectedFilter,
+            optionLabel = { it.label() },
+            onSelect = onFilterChange,
+        )
+        FavoritesMenu(
+            label = "Sort by: ${sortMode.label()}",
+            options = FavoritesSortMode.Mode.entries,
+            selected = sortMode,
+            optionLabel = { it.label() },
+            enabled = !operationBusy,
+            onSelect = onSortModeChange,
+        )
+    }
+}
+
+@Composable
+private fun <T> FavoritesMenu(
+    label: String,
+    options: List<T>,
+    selected: T,
+    optionLabel: (T) -> String,
+    enabled: Boolean = true,
+    onSelect: (T) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        TextButton(
+            onClick = { expanded = true },
+            enabled = enabled,
+            modifier = Modifier.heightIn(min = 48.dp),
+        ) {
+            Text(label)
+            Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(optionLabel(option)) },
+                    modifier = Modifier.semantics { this.selected = option == selected },
+                    enabled = enabled,
+                    trailingIcon = {
+                        if (option == selected) Icon(Icons.Filled.Check, contentDescription = null)
+                    },
+                    onClick = {
+                        expanded = false
+                        if (option != selected) onSelect(option)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/narumi/kestrel/ui/components/PlaybackStatusBar.kt
+++ b/app/src/main/java/dev/narumi/kestrel/ui/components/PlaybackStatusBar.kt
@@ -1,19 +1,30 @@
 package dev.narumi.kestrel.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import dev.narumi.kestrel.core.location.MovementEngine
 import dev.narumi.kestrel.core.location.RuntimeState
@@ -57,48 +68,73 @@ fun PlaybackStatusBar(
     modifier: Modifier = Modifier,
 ) {
     val presentation = playbackBarPresentation(runtime) ?: return
-    KestrelCard(
-        modifier = modifier.semantics { liveRegion = LiveRegionMode.Polite },
+    Surface(
+        modifier = modifier.fillMaxWidth().semantics { liveRegion = LiveRegionMode.Polite },
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceContainer,
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(presentation.title, style = MaterialTheme.typography.titleSmall)
+        Column(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .clickable(role = Role.Button, onClickLabel = "View map", onClick = onViewMap)
+                            .heightIn(min = 48.dp)
+                            .padding(horizontal = 8.dp)
+                            .semantics { stateDescription = presentation.details },
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        presentation.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        if (busy) "Applying playback change…" else "View map",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                PlaybackActions(presentation.primaryAction, busy, onPause, onResume, onStop)
+            }
+            error?.let {
                 Text(
-                    presentation.details,
+                    text = it,
+                    modifier = Modifier.padding(8.dp).semantics { liveRegion = LiveRegionMode.Assertive },
+                    color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            OutlinedButton(onClick = onViewMap) { Text("View map") }
         }
-        if (busy) {
-            Text(
-                text = "Applying playback change…",
-                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
-                color = MaterialTheme.colorScheme.primary,
-                style = MaterialTheme.typography.bodySmall,
+    }
+}
+
+@Composable
+private fun PlaybackActions(
+    primaryAction: PlaybackBarAction?,
+    busy: Boolean,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onStop: () -> Unit,
+) {
+    if (primaryAction != null) {
+        val paused = primaryAction == PlaybackBarAction.Resume
+        IconButton(onClick = if (paused) onResume else onPause, enabled = !busy) {
+            Icon(
+                imageVector = if (paused) Icons.Filled.PlayArrow else Icons.Filled.Pause,
+                contentDescription = if (paused) "Resume" else "Pause",
             )
         }
-        error?.let {
-            Text(
-                text = it,
-                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Assertive },
-                color = MaterialTheme.colorScheme.error,
-                style = MaterialTheme.typography.bodySmall,
-            )
-        }
-        KestrelActionRow {
-            when (presentation.primaryAction) {
-                PlaybackBarAction.Pause -> Button(onClick = onPause, enabled = !busy) { Text("Pause") }
-                PlaybackBarAction.Resume -> Button(onClick = onResume, enabled = !busy) { Text("Resume") }
-                null -> Unit
-            }
-            OutlinedButton(onClick = onStop, enabled = !busy) { Text("Stop") }
-        }
+    }
+    IconButton(onClick = onStop, enabled = !busy) {
+        Icon(Icons.Filled.Stop, contentDescription = "Stop")
     }
 }
 

--- a/app/src/screenshotTest/java/dev/narumi/kestrel/ui/FavoritesLayoutScreenshots.kt
+++ b/app/src/screenshotTest/java/dev/narumi/kestrel/ui/FavoritesLayoutScreenshots.kt
@@ -1,0 +1,98 @@
+package dev.narumi.kestrel.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.android.tools.screenshot.PreviewTest
+import dev.narumi.kestrel.core.data.FavoritesSortMode
+import dev.narumi.kestrel.core.library.LibraryItem
+import dev.narumi.kestrel.core.library.LibraryItemKind
+import dev.narumi.kestrel.core.library.LibraryItemWithContent
+import dev.narumi.kestrel.core.library.Place
+import dev.narumi.kestrel.core.location.LatLng
+import dev.narumi.kestrel.core.location.MovementEngine
+import dev.narumi.kestrel.core.location.RuntimeState
+import dev.narumi.kestrel.feature.favorites.FavoritesContent
+import dev.narumi.kestrel.feature.favorites.FavoritesFilter
+import dev.narumi.kestrel.ui.components.PlaybackStatusBar
+import dev.narumi.kestrel.ui.theme.KestrelTheme
+
+@PreviewTest
+@Preview(name = "Favorites playing", widthDp = 360, heightDp = 560, showBackground = true)
+@Preview(name = "Favorites playing narrow large text", widthDp = 320, heightDp = 480, fontScale = 1.5f)
+@Preview(name = "Favorites playing short landscape", widthDp = 600, heightDp = 240)
+@Composable
+fun FavoritesPlayingScreenshot() {
+    KestrelTheme {
+        Surface {
+            Column(Modifier.fillMaxSize()) {
+                PlaybackStatusBar(
+                    runtime =
+                        RuntimeState.Route(
+                            waypoints = listOf(LatLng(25.0, 121.0), LatLng(25.1, 121.1)),
+                            speedKmh = 12.0,
+                            mode = MovementEngine.Mode.Loop,
+                            paused = false,
+                        ),
+                    busy = false,
+                    error = null,
+                    onViewMap = {},
+                    onPause = {},
+                    onResume = {},
+                    onStop = {},
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+                FavoritesContent(
+                    modifier = Modifier.weight(1f),
+                    items = layoutPreviewItems,
+                    visibleItems = layoutPreviewItems,
+                    loading = false,
+                    selectedFilter = FavoritesFilter.All,
+                    sortMode = FavoritesSortMode.Mode.Manual,
+                    operationMessage = null,
+                    operationError = null,
+                    operationBusy = false,
+                    onFilterChange = {},
+                    onSortModeChange = {},
+                    onChooseOnMap = {},
+                    onApply = {},
+                    onRename = {},
+                    onEdit = {},
+                    onMove = { _, _ -> },
+                    onDelete = {},
+                )
+            }
+        }
+    }
+}
+
+private val layoutPreviewItems =
+    List(10) { index ->
+        LibraryItemWithContent(
+            item =
+                LibraryItem(
+                    id = "item-$index",
+                    kind = LibraryItemKind.Place,
+                    placeId = "place-$index",
+                    sortOrder = index,
+                    createdAt = 0,
+                    updatedAt = 0,
+                ),
+            name = "Saved point ${index + 1}",
+            kind = LibraryItemKind.Place,
+            place =
+                Place(
+                    id = "place-$index",
+                    name = "Saved point ${index + 1}",
+                    lat = 25.03398,
+                    lng = 121.56454,
+                    createdAt = 0,
+                    updatedAt = 0,
+                ),
+        )
+    }


### PR DESCRIPTION
## Summary

Reclaim usable scrolling space in Android Favorites while keeping playback controls directly accessible.

- Replace the tall shared playback card with a compact status bar (56dp at standard font size), direct pause/resume and stop buttons, and a tappable View map area. Preserve runtime-driven state, busy guards, error feedback, and accessibility labels.
- Replace the expanded Show and Sort by chip groups with dropdown menus that display the current selections and wrap on narrow screens or larger text.
- Put the Favorites title, toolbar, feedback, empty/loading states, and saved items in one scrollable list instead of reserving fixed header space.
- Add Compose interaction test coverage and full-layout screenshot previews for portrait, narrow large-text, and short-landscape layouts. The shared playback improvement also applies to Options.

## Validation

Passed locally using Java 26 and `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools`:

- `just android-check`
- `just android-lint`
- `just android-test`
- `just android-build`
- `./gradlew :app:compileDebugAndroidTestKotlin`
- `git diff --check`

Rendered and visually reviewed the three new Favorites previews. `:app:validateDebugScreenshotTest` does **not** pass: all 15 previews report `ScreenshotImageNotFoundException` because reference images are absent. Screenshot outputs were redirected outside the repository; no image binaries are included.

The new interaction tests are compiled but have not been executed on a device. No installation, connected instrumentation, or device-state changes were performed.
